### PR TITLE
Fix column delimiters and line endings

### DIFF
--- a/2008/20080920__hi__primary__precinct.csv
+++ b/2008/20080920__hi__primary__precinct.csv
@@ -1,5366 +1,5366 @@
-county	precinct	office	district	party	candidate	absentee	early_votes	election_day	votes
-County of Hawaii	01-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427
-County of Hawaii	01-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Hawaii	01-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	01-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	01-01	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
-County of Hawaii	01-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	01-01	US Representative	2	D	"HIRONO, Mazie"	0	0	321	321
-County of Hawaii	01-01	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
-County of Hawaii	01-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	01-01	State Senate	3	D	"ISBELL, Virginia"	0	0	60	60
-County of Hawaii	01-01	State Senate	3	D	"GREEN, Josh"	0	0	344	344
-County of Hawaii	01-01	State Representative	1	D	"FUJIYAMA, Ken"	0	0	53	53
-County of Hawaii	01-01	State Representative	1	D	"KIM, Jo"	0	0	91	91
-County of Hawaii	01-01	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	219	219
-County of Hawaii	01-01	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	17	17
-County of Hawaii	01-01	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	22	22
-County of Hawaii	01-01	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	17	17
-County of Hawaii	01-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	241	241
-County of Hawaii	01-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	01-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	01-02	Straight Party			REPUBLICAN PARTY (R)	0	0	29	29
-County of Hawaii	01-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	01-02	US Representative	2	D	"HIRONO, Mazie"	0	0	171	171
-County of Hawaii	01-02	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
-County of Hawaii	01-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-02	State Senate	3	D	"ISBELL, Virginia"	0	0	36	36
-County of Hawaii	01-02	State Senate	3	D	"GREEN, Josh"	0	0	195	195
-County of Hawaii	01-02	State Representative	1	D	"FUJIYAMA, Ken"	0	0	35	35
-County of Hawaii	01-02	State Representative	1	D	"KIM, Jo"	0	0	72	72
-County of Hawaii	01-02	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	86	86
-County of Hawaii	01-02	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	14	14
-County of Hawaii	01-02	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	13	13
-County of Hawaii	01-02	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	10	10
-County of Hawaii	01-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	82	82
-County of Hawaii	01-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Hawaii	01-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	01-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	01-03	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
-County of Hawaii	01-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	01-03	US Representative	2	D	"HIRONO, Mazie"	0	0	55	55
-County of Hawaii	01-03	US Representative	2	R	"EVANS, Roger B."	0	0	6	6
-County of Hawaii	01-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	01-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	61	61
-County of Hawaii	01-03	State Senate	1	R	"HONG, Ted H.S."	0	0	9	9
-County of Hawaii	01-03	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7
-County of Hawaii	01-03	State Representative	1	D	"KIM, Jo"	0	0	32	32
-County of Hawaii	01-03	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	24	24
-County of Hawaii	01-03	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6
-County of Hawaii	01-03	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	7	7
-County of Hawaii	01-03	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	0	0
-County of Hawaii	01-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	582	582
-County of Hawaii	01-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	01-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	01-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	01-04	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
-County of Hawaii	01-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	01-04	US Representative	2	D	"HIRONO, Mazie"	0	0	401	401
-County of Hawaii	01-04	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
-County of Hawaii	01-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	01-04	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	472	472
-County of Hawaii	01-04	State Senate	1	R	"HONG, Ted H.S."	0	0	50	50
-County of Hawaii	01-04	State Representative	1	D	"FUJIYAMA, Ken"	0	0	30	30
-County of Hawaii	01-04	State Representative	1	D	"KIM, Jo"	0	0	252	252
-County of Hawaii	01-04	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	250	250
-County of Hawaii	01-04	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	13	13
-County of Hawaii	01-04	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	39	39
-County of Hawaii	01-04	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	10	10
-County of Hawaii	01-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	246	246
-County of Hawaii	01-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	01-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Hawaii	01-05	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
-County of Hawaii	01-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	01-05	US Representative	2	D	"HIRONO, Mazie"	0	0	162	162
-County of Hawaii	01-05	US Representative	2	R	"EVANS, Roger B."	0	0	13	13
-County of Hawaii	01-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	01-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	191	191
-County of Hawaii	01-05	State Senate	1	R	"HONG, Ted H.S."	0	0	22	22
-County of Hawaii	01-05	State Representative	1	D	"FUJIYAMA, Ken"	0	0	22	22
-County of Hawaii	01-05	State Representative	1	D	"KIM, Jo"	0	0	121	121
-County of Hawaii	01-05	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	79	79
-County of Hawaii	01-05	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6
-County of Hawaii	01-05	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	12	12
-County of Hawaii	01-05	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	4	4
-County of Hawaii	01-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	56	56
-County of Hawaii	01-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Hawaii	01-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	01-06	Straight Party			REPUBLICAN PARTY (R)	0	0	10	10
-County of Hawaii	01-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	01-06	US Representative	2	D	"HIRONO, Mazie"	0	0	42	42
-County of Hawaii	01-06	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
-County of Hawaii	01-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	42	42
-County of Hawaii	01-06	State Senate	1	R	"HONG, Ted H.S."	0	0	8	8
-County of Hawaii	01-06	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7
-County of Hawaii	01-06	State Representative	1	D	"KIM, Jo"	0	0	12	12
-County of Hawaii	01-06	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	33	33
-County of Hawaii	01-06	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	1	1
-County of Hawaii	01-06	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	8	8
-County of Hawaii	01-06	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	1	1
-County of Hawaii	01-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	185	185
-County of Hawaii	01-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Hawaii	01-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	01-07	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
-County of Hawaii	01-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	01-07	US Representative	2	D	"HIRONO, Mazie"	0	0	132	132
-County of Hawaii	01-07	US Representative	2	R	"EVANS, Roger B."	0	0	20	20
-County of Hawaii	01-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	161	161
-County of Hawaii	01-07	State Senate	1	R	"HONG, Ted H.S."	0	0	25	25
-County of Hawaii	01-07	State Representative	1	D	"FUJIYAMA, Ken"	0	0	29	29
-County of Hawaii	01-07	State Representative	1	D	"KIM, Jo"	0	0	61	61
-County of Hawaii	01-07	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	58	58
-County of Hawaii	01-07	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	8	8
-County of Hawaii	01-07	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	19	19
-County of Hawaii	01-07	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	4	4
-County of Hawaii	01-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	73	73
-County of Hawaii	01-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	01-08	Straight Party			REPUBLICAN PARTY (R)	0	0	21	21
-County of Hawaii	01-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	01-08	US Representative	2	D	"HIRONO, Mazie"	0	0	51	51
-County of Hawaii	01-08	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Hawaii	01-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-08	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	55	55
-County of Hawaii	01-08	State Senate	1	R	"HONG, Ted H.S."	0	0	19	19
-County of Hawaii	01-08	State Representative	1	D	"FUJIYAMA, Ken"	0	0	8	8
-County of Hawaii	01-08	State Representative	1	D	"KIM, Jo"	0	0	20	20
-County of Hawaii	01-08	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	28	28
-County of Hawaii	01-08	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6
-County of Hawaii	01-08	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	15	15
-County of Hawaii	01-08	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	2	2
-County of Hawaii	01-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	74	74
-County of Hawaii	01-09	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	01-09	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
-County of Hawaii	01-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	01-09	US Representative	2	D	"HIRONO, Mazie"	0	0	56	56
-County of Hawaii	01-09	US Representative	2	R	"EVANS, Roger B."	0	0	5	5
-County of Hawaii	01-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-09	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	63	63
-County of Hawaii	01-09	State Senate	1	R	"HONG, Ted H.S."	0	0	6	6
-County of Hawaii	01-09	State Representative	1	D	"FUJIYAMA, Ken"	0	0	24	24
-County of Hawaii	01-09	State Representative	1	D	"KIM, Jo"	0	0	18	18
-County of Hawaii	01-09	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	25	25
-County of Hawaii	01-09	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	2	2
-County of Hawaii	01-09	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	5	5
-County of Hawaii	01-09	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	3	3
-County of Hawaii	01-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	116	116
-County of Hawaii	01-10	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	01-10	Straight Party			REPUBLICAN PARTY (R)	0	0	18	18
-County of Hawaii	01-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	01-10	US Representative	2	D	"HIRONO, Mazie"	0	0	77	77
-County of Hawaii	01-10	US Representative	2	R	"EVANS, Roger B."	0	0	9	9
-County of Hawaii	01-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-10	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	99	99
-County of Hawaii	01-10	State Senate	1	R	"HONG, Ted H.S."	0	0	17	17
-County of Hawaii	01-10	State Representative	1	D	"FUJIYAMA, Ken"	0	0	22	22
-County of Hawaii	01-10	State Representative	1	D	"KIM, Jo"	0	0	22	22
-County of Hawaii	01-10	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	43	43
-County of Hawaii	01-10	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	4	4
-County of Hawaii	01-10	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	8	8
-County of Hawaii	01-10	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	3	3
-County of Hawaii	01-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313
-County of Hawaii	01-11	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-County of Hawaii	01-11	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
-County of Hawaii	01-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	01-11	US Representative	2	D	"HIRONO, Mazie"	0	0	247	247
-County of Hawaii	01-11	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Hawaii	01-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-11	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	283	283
-County of Hawaii	01-11	State Senate	1	R	"HONG, Ted H.S."	0	0	15	15
-County of Hawaii	01-11	State Representative	1	D	"FUJIYAMA, Ken"	0	0	52	52
-County of Hawaii	01-11	State Representative	1	D	"KIM, Jo"	0	0	51	51
-County of Hawaii	01-11	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	170	170
-County of Hawaii	01-11	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	12	12
-County of Hawaii	01-11	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	11	11
-County of Hawaii	01-11	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	2	2
-County of Hawaii	01-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	228	228
-County of Hawaii	01-12	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	01-12	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56
-County of Hawaii	01-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	01-12	US Representative	2	D	"HIRONO, Mazie"	0	0	170	170
-County of Hawaii	01-12	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
-County of Hawaii	01-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-12	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	176	176
-County of Hawaii	01-12	State Senate	1	R	"HONG, Ted H.S."	0	0	43	43
-County of Hawaii	01-12	State Representative	1	D	"FUJIYAMA, Ken"	0	0	64	64
-County of Hawaii	01-12	State Representative	1	D	"KIM, Jo"	0	0	39	39
-County of Hawaii	01-12	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	91	91
-County of Hawaii	01-12	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	8	8
-County of Hawaii	01-12	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	20	20
-County of Hawaii	01-12	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	19	19
-County of Hawaii	01-13	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317
-County of Hawaii	01-13	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-13	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	01-13	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	01-13	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47
-County of Hawaii	01-13	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	01-13	US Representative	2	D	"HIRONO, Mazie"	0	0	213	213
-County of Hawaii	01-13	US Representative	2	R	"EVANS, Roger B."	0	0	26	26
-County of Hawaii	01-13	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	01-13	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	231	231
-County of Hawaii	01-13	State Senate	1	R	"HONG, Ted H.S."	0	0	42	42
-County of Hawaii	01-13	State Representative	1	D	"FUJIYAMA, Ken"	0	0	81	81
-County of Hawaii	01-13	State Representative	1	D	"KIM, Jo"	0	0	63	63
-County of Hawaii	01-13	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	114	114
-County of Hawaii	01-13	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	17	17
-County of Hawaii	01-13	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	10	10
-County of Hawaii	01-13	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	14	14
-County of Hawaii	01-14	Straight Party			DEMOCRATIC PARTY (D)	0	0	97	97
-County of Hawaii	01-14	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	01-14	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	01-14	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	01-14	Straight Party			REPUBLICAN PARTY (R)	0	0	16	16
-County of Hawaii	01-14	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	01-14	US Representative	2	D	"HIRONO, Mazie"	0	0	81	81
-County of Hawaii	01-14	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Hawaii	01-14	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	01-14	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	72	72
-County of Hawaii	01-14	State Senate	1	R	"HONG, Ted H.S."	0	0	14	14
-County of Hawaii	01-14	State Representative	1	D	"FUJIYAMA, Ken"	0	0	29	29
-County of Hawaii	01-14	State Representative	1	D	"KIM, Jo"	0	0	23	23
-County of Hawaii	01-14	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	16	16
-County of Hawaii	01-14	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	11	11
-County of Hawaii	01-14	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	9	9
-County of Hawaii	01-14	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	6	6
-County of Hawaii	01-15	Straight Party			DEMOCRATIC PARTY (D)	0	0	95	95
-County of Hawaii	01-15	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Hawaii	01-15	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	01-15	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	01-15	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
-County of Hawaii	01-15	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	01-15	US Representative	2	D	"HIRONO, Mazie"	0	0	82	82
-County of Hawaii	01-15	US Representative	2	R	"EVANS, Roger B."	0	0	23	23
-County of Hawaii	01-15	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Hawaii	01-15	State Senate	3	D	"ISBELL, Virginia"	0	0	14	14
-County of Hawaii	01-15	State Senate	3	D	"GREEN, Josh"	0	0	73	73
-County of Hawaii	01-15	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7
-County of Hawaii	01-15	State Representative	1	D	"KIM, Jo"	0	0	30	30
-County of Hawaii	01-15	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	30	30
-County of Hawaii	01-15	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	12	12
-County of Hawaii	01-15	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	7	7
-County of Hawaii	01-15	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	12	12
-County of Hawaii	02-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	683	683
-County of Hawaii	02-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-County of Hawaii	02-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	02-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	02-01	Straight Party			REPUBLICAN PARTY (R)	0	0	135	135
-County of Hawaii	02-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	02-01	US Representative	2	D	"HIRONO, Mazie"	0	0	480	480
-County of Hawaii	02-01	US Representative	2	R	"EVANS, Roger B."	0	0	44	44
-County of Hawaii	02-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	02-01	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	476	476
-County of Hawaii	02-01	State Senate	1	R	"HONG, Ted H.S."	0	0	124	124
-County of Hawaii	02-01	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	420	420
-County of Hawaii	02-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	367	367
-County of Hawaii	02-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	02-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	02-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Hawaii	02-02	Straight Party			REPUBLICAN PARTY (R)	0	0	77	77
-County of Hawaii	02-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	02-02	US Representative	2	D	"HIRONO, Mazie"	0	0	264	264
-County of Hawaii	02-02	US Representative	2	R	"EVANS, Roger B."	0	0	29	29
-County of Hawaii	02-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	02-02	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	252	252
-County of Hawaii	02-02	State Senate	1	R	"HONG, Ted H.S."	0	0	72	72
-County of Hawaii	02-02	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	253	253
-County of Hawaii	02-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	520	520
-County of Hawaii	02-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Hawaii	02-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	02-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Hawaii	02-03	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
-County of Hawaii	02-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Hawaii	02-03	US Representative	2	D	"HIRONO, Mazie"	0	0	390	390
-County of Hawaii	02-03	US Representative	2	R	"EVANS, Roger B."	0	0	49	49
-County of Hawaii	02-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	02-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	367	367
-County of Hawaii	02-03	State Senate	1	R	"HONG, Ted H.S."	0	0	96	96
-County of Hawaii	02-03	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	352	352
-County of Hawaii	02-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129
-County of Hawaii	02-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	02-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	02-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	02-04	Straight Party			REPUBLICAN PARTY (R)	0	0	30	30
-County of Hawaii	02-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	02-04	US Representative	2	D	"HIRONO, Mazie"	0	0	92	92
-County of Hawaii	02-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17
-County of Hawaii	02-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	02-04	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	85	85
-County of Hawaii	02-04	State Senate	1	R	"HONG, Ted H.S."	0	0	25	25
-County of Hawaii	02-04	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	73	73
-County of Hawaii	02-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	224	224
-County of Hawaii	02-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	02-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-County of Hawaii	02-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	02-05	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32
-County of Hawaii	02-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	02-05	US Representative	2	D	"HIRONO, Mazie"	0	0	169	169
-County of Hawaii	02-05	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Hawaii	02-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-County of Hawaii	02-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	136	136
-County of Hawaii	02-05	State Senate	1	R	"HONG, Ted H.S."	0	0	26	26
-County of Hawaii	02-05	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	125	125
-County of Hawaii	02-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	335	335
-County of Hawaii	02-06	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-County of Hawaii	02-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	02-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	02-06	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
-County of Hawaii	02-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Hawaii	02-06	US Representative	2	D	"HIRONO, Mazie"	0	0	227	227
-County of Hawaii	02-06	US Representative	2	R	"EVANS, Roger B."	0	0	19	19
-County of Hawaii	02-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	02-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	223	223
-County of Hawaii	02-06	State Senate	1	R	"HONG, Ted H.S."	0	0	41	41
-County of Hawaii	02-06	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	214	214
-County of Hawaii	02-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	148	148
-County of Hawaii	02-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	02-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	02-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	02-07	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
-County of Hawaii	02-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	02-07	US Representative	2	D	"HIRONO, Mazie"	0	0	104	104
-County of Hawaii	02-07	US Representative	2	R	"EVANS, Roger B."	0	0	6	6
-County of Hawaii	02-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	02-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	112	112
-County of Hawaii	02-07	State Senate	1	R	"HONG, Ted H.S."	0	0	16	16
-County of Hawaii	02-07	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	106	106
-County of Hawaii	02-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	259	259
-County of Hawaii	02-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Hawaii	02-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	02-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	02-08	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
-County of Hawaii	02-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	02-08	US Representative	2	D	"HIRONO, Mazie"	0	0	183	183
-County of Hawaii	02-08	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
-County of Hawaii	02-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	02-08	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	185	185
-County of Hawaii	02-08	State Senate	1	R	"HONG, Ted H.S."	0	0	33	33
-County of Hawaii	02-08	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	167	167
-County of Hawaii	03-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	493	493
-County of Hawaii	03-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Hawaii	03-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	03-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Hawaii	03-01	Straight Party			REPUBLICAN PARTY (R)	0	0	41	41
-County of Hawaii	03-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	03-01	US Representative	2	D	"HIRONO, Mazie"	0	0	351	351
-County of Hawaii	03-01	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
-County of Hawaii	03-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	03-01	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	362	362
-County of Hawaii	03-01	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	23	23
-County of Hawaii	03-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	127	127
-County of Hawaii	03-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	03-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	03-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-County of Hawaii	03-02	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
-County of Hawaii	03-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	03-02	US Representative	2	D	"HIRONO, Mazie"	0	0	91	91
-County of Hawaii	03-02	US Representative	2	R	"EVANS, Roger B."	0	0	9	9
-County of Hawaii	03-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	03-02	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	111	111
-County of Hawaii	03-02	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	8	8
-County of Hawaii	03-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129
-County of Hawaii	03-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Hawaii	03-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	03-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	03-03	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
-County of Hawaii	03-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	03-03	US Representative	2	D	"HIRONO, Mazie"	0	0	97	97
-County of Hawaii	03-03	US Representative	2	R	"EVANS, Roger B."	0	0	4	4
-County of Hawaii	03-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	03-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	101	101
-County of Hawaii	03-03	State Senate	1	R	"HONG, Ted H.S."	0	0	19	19
-County of Hawaii	03-03	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	101	101
-County of Hawaii	03-03	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	4	4
-County of Hawaii	03-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	499	499
-County of Hawaii	03-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	03-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	03-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Hawaii	03-04	Straight Party			REPUBLICAN PARTY (R)	0	0	46	46
-County of Hawaii	03-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	03-04	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380
-County of Hawaii	03-04	US Representative	2	R	"EVANS, Roger B."	0	0	32	32
-County of Hawaii	03-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	03-04	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	392	392
-County of Hawaii	03-04	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	23	23
-County of Hawaii	03-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	490	490
-County of Hawaii	03-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Hawaii	03-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	03-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	03-05	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
-County of Hawaii	03-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-County of Hawaii	03-05	US Representative	2	D	"HIRONO, Mazie"	0	0	400	400
-County of Hawaii	03-05	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
-County of Hawaii	03-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	03-05	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	362	362
-County of Hawaii	03-05	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	44	44
-County of Hawaii	03-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	709	709
-County of Hawaii	03-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Hawaii	03-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	03-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	15	15
-County of Hawaii	03-06	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
-County of Hawaii	03-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Hawaii	03-06	US Representative	2	D	"HIRONO, Mazie"	0	0	499	499
-County of Hawaii	03-06	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
-County of Hawaii	03-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	03-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	509	509
-County of Hawaii	03-06	State Senate	1	R	"HONG, Ted H.S."	0	0	65	65
-County of Hawaii	03-06	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	499	499
-County of Hawaii	03-06	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	28	28
-County of Hawaii	03-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	401	401
-County of Hawaii	03-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Hawaii	03-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	03-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Hawaii	03-07	Straight Party			REPUBLICAN PARTY (R)	0	0	37	37
-County of Hawaii	03-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	03-07	US Representative	2	D	"HIRONO, Mazie"	0	0	316	316
-County of Hawaii	03-07	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
-County of Hawaii	03-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Hawaii	03-07	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	310	310
-County of Hawaii	03-07	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	16	16
-County of Hawaii	03-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	601	601
-County of Hawaii	03-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Hawaii	03-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	03-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Hawaii	03-08	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54
-County of Hawaii	03-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Hawaii	03-08	US Representative	2	D	"HIRONO, Mazie"	0	0	469	469
-County of Hawaii	03-08	US Representative	2	R	"EVANS, Roger B."	0	0	35	35
-County of Hawaii	03-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Hawaii	03-08	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	447	447
-County of Hawaii	03-08	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	38	38
-County of Hawaii	04-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	406	406
-County of Hawaii	04-01	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-County of Hawaii	04-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-County of Hawaii	04-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-County of Hawaii	04-01	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
-County of Hawaii	04-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-County of Hawaii	04-01	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305
-County of Hawaii	04-01	US Representative	2	R	"EVANS, Roger B."	0	0	49	49
-County of Hawaii	04-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-County of Hawaii	04-01	State Representative	4	D	"HANOHANO, Faye P."	0	0	184	184
-County of Hawaii	04-01	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	76	76
-County of Hawaii	04-01	State Representative	4	D	"SPARKS, Steven B."	0	0	92	92
-County of Hawaii	04-01	State Representative	4	R	"BLAS, Fred"	0	0	56	56
-County of Hawaii	04-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	306	306
-County of Hawaii	04-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-County of Hawaii	04-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	04-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
-County of Hawaii	04-02	Straight Party			REPUBLICAN PARTY (R)	0	0	52	52
-County of Hawaii	04-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Hawaii	04-02	US Representative	2	D	"HIRONO, Mazie"	0	0	234	234
-County of Hawaii	04-02	US Representative	2	R	"EVANS, Roger B."	0	0	38	38
-County of Hawaii	04-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	04-02	State Representative	4	D	"HANOHANO, Faye P."	0	0	144	144
-County of Hawaii	04-02	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	66	66
-County of Hawaii	04-02	State Representative	4	D	"SPARKS, Steven B."	0	0	58	58
-County of Hawaii	04-02	State Representative	4	R	"BLAS, Fred"	0	0	38	38
-County of Hawaii	04-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	517	517
-County of Hawaii	04-03	Straight Party			INDEPENDENT PARTY (I)	0	0	12	12
-County of Hawaii	04-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
-County of Hawaii	04-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Hawaii	04-03	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108
-County of Hawaii	04-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
-County of Hawaii	04-03	US Representative	2	D	"HIRONO, Mazie"	0	0	354	354
-County of Hawaii	04-03	US Representative	2	R	"EVANS, Roger B."	0	0	67	67
-County of Hawaii	04-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	10	10
-County of Hawaii	04-03	State Representative	4	D	"HANOHANO, Faye P."	0	0	186	186
-County of Hawaii	04-03	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	159	159
-County of Hawaii	04-03	State Representative	4	D	"SPARKS, Steven B."	0	0	109	109
-County of Hawaii	04-03	State Representative	4	R	"BLAS, Fred"	0	0	74	74
-County of Hawaii	04-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	396	396
-County of Hawaii	04-04	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-County of Hawaii	04-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	04-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	04-04	Straight Party			REPUBLICAN PARTY (R)	0	0	126	126
-County of Hawaii	04-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Hawaii	04-04	US Representative	2	D	"HIRONO, Mazie"	0	0	284	284
-County of Hawaii	04-04	US Representative	2	R	"EVANS, Roger B."	0	0	50	50
-County of Hawaii	04-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Hawaii	04-04	State Representative	4	D	"HANOHANO, Faye P."	0	0	213	213
-County of Hawaii	04-04	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	90	90
-County of Hawaii	04-04	State Representative	4	D	"SPARKS, Steven B."	0	0	45	45
-County of Hawaii	04-04	State Representative	4	R	"BLAS, Fred"	0	0	116	116
-County of Hawaii	04-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	677	677
-County of Hawaii	04-05	Straight Party			INDEPENDENT PARTY (I)	0	0	18	18
-County of Hawaii	04-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-County of Hawaii	04-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
-County of Hawaii	04-05	Straight Party			REPUBLICAN PARTY (R)	0	0	94	94
-County of Hawaii	04-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	14	14
-County of Hawaii	04-05	US Representative	2	D	"HIRONO, Mazie"	0	0	410	410
-County of Hawaii	04-05	US Representative	2	R	"EVANS, Roger B."	0	0	52	52
-County of Hawaii	04-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6
-County of Hawaii	04-05	State Representative	4	D	"HANOHANO, Faye P."	0	0	199	199
-County of Hawaii	04-05	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	264	264
-County of Hawaii	04-05	State Representative	4	D	"SPARKS, Steven B."	0	0	161	161
-County of Hawaii	04-05	State Representative	4	R	"BLAS, Fred"	0	0	67	67
-County of Hawaii	04-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421
-County of Hawaii	04-06	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
-County of Hawaii	04-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-County of Hawaii	04-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
-County of Hawaii	04-06	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
-County of Hawaii	04-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-County of Hawaii	04-06	US Representative	2	D	"HIRONO, Mazie"	0	0	317	317
-County of Hawaii	04-06	US Representative	2	R	"EVANS, Roger B."	0	0	75	75
-County of Hawaii	04-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-County of Hawaii	04-06	State Representative	4	D	"HANOHANO, Faye P."	0	0	208	208
-County of Hawaii	04-06	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	105	105
-County of Hawaii	04-06	State Representative	4	D	"SPARKS, Steven B."	0	0	61	61
-County of Hawaii	04-06	State Representative	4	R	"BLAS, Fred"	0	0	69	69
-County of Hawaii	04-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	166	166
-County of Hawaii	04-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	04-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	04-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	04-07	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19
-County of Hawaii	04-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	04-07	US Representative	2	D	"HIRONO, Mazie"	0	0	85	85
-County of Hawaii	04-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
-County of Hawaii	04-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	04-07	State Representative	4	D	"HANOHANO, Faye P."	0	0	44	44
-County of Hawaii	04-07	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	46	46
-County of Hawaii	04-07	State Representative	4	D	"SPARKS, Steven B."	0	0	58	58
-County of Hawaii	04-07	State Representative	4	R	"BLAS, Fred"	0	0	16	16
-County of Hawaii	04-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236
-County of Hawaii	04-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	04-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	04-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	04-08	Straight Party			REPUBLICAN PARTY (R)	0	0	62	62
-County of Hawaii	04-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	04-08	US Representative	2	D	"HIRONO, Mazie"	0	0	175	175
-County of Hawaii	04-08	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
-County of Hawaii	04-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	04-08	State Representative	4	D	"HANOHANO, Faye P."	0	0	116	116
-County of Hawaii	04-08	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	69	69
-County of Hawaii	04-08	State Representative	4	D	"SPARKS, Steven B."	0	0	25	25
-County of Hawaii	04-08	State Representative	4	R	"BLAS, Fred"	0	0	47	47
-County of Hawaii	05-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	142	142
-County of Hawaii	05-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Hawaii	05-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	05-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Hawaii	05-01	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24
-County of Hawaii	05-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-County of Hawaii	05-01	US Representative	2	D	"HIRONO, Mazie"	0	0	112	112
-County of Hawaii	05-01	US Representative	2	R	"EVANS, Roger B."	0	0	23	23
-County of Hawaii	05-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Hawaii	05-01	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	83	83
-County of Hawaii	05-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	298	298
-County of Hawaii	05-02	Straight Party			INDEPENDENT PARTY (I)	0	0	16	16
-County of Hawaii	05-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	05-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
-County of Hawaii	05-02	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
-County of Hawaii	05-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	16	16
-County of Hawaii	05-02	US Representative	2	D	"HIRONO, Mazie"	0	0	244	244
-County of Hawaii	05-02	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
-County of Hawaii	05-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Hawaii	05-02	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	152	152
-County of Hawaii	05-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	469	469
-County of Hawaii	05-03	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15
-County of Hawaii	05-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	19	19
-County of Hawaii	05-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
-County of Hawaii	05-03	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101
-County of Hawaii	05-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	13	13
-County of Hawaii	05-03	US Representative	2	D	"HIRONO, Mazie"	0	0	370	370
-County of Hawaii	05-03	US Representative	2	R	"EVANS, Roger B."	0	0	96	96
-County of Hawaii	05-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	19	19
-County of Hawaii	05-03	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	280	280
-County of Hawaii	05-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	205	205
-County of Hawaii	05-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	05-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	05-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Hawaii	05-04	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
-County of Hawaii	05-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	05-04	US Representative	2	D	"HIRONO, Mazie"	0	0	169	169
-County of Hawaii	05-04	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
-County of Hawaii	05-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	05-04	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	122	122
-County of Hawaii	05-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267
-County of Hawaii	05-05	Straight Party			INDEPENDENT PARTY (I)	0	0	21	21
-County of Hawaii	05-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	05-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
-County of Hawaii	05-05	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53
-County of Hawaii	05-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	19	19
-County of Hawaii	05-05	US Representative	2	D	"HIRONO, Mazie"	0	0	203	203
-County of Hawaii	05-05	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
-County of Hawaii	05-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Hawaii	05-05	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	171	171
-County of Hawaii	05-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	343	343
-County of Hawaii	05-06	Straight Party			INDEPENDENT PARTY (I)	0	0	12	12
-County of Hawaii	05-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	12	12
-County of Hawaii	05-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
-County of Hawaii	05-06	Straight Party			REPUBLICAN PARTY (R)	0	0	97	97
-County of Hawaii	05-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10
-County of Hawaii	05-06	US Representative	2	D	"HIRONO, Mazie"	0	0	268	268
-County of Hawaii	05-06	US Representative	2	R	"EVANS, Roger B."	0	0	94	94
-County of Hawaii	05-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	11	11
-County of Hawaii	05-06	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	190	190
-County of Hawaii	05-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	115	115
-County of Hawaii	05-07	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	05-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	05-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	05-07	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
-County of Hawaii	05-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	05-07	US Representative	2	D	"HIRONO, Mazie"	0	0	67	67
-County of Hawaii	05-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
-County of Hawaii	05-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	05-07	State Senate	3	D	"ISBELL, Virginia"	0	0	30	30
-County of Hawaii	05-07	State Senate	3	D	"GREEN, Josh"	0	0	77	77
-County of Hawaii	05-07	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	66	66
-County of Hawaii	05-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	130	130
-County of Hawaii	05-08	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	05-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	05-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	05-08	Straight Party			REPUBLICAN PARTY (R)	0	0	9	9
-County of Hawaii	05-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	05-08	US Representative	2	D	"HIRONO, Mazie"	0	0	80	80
-County of Hawaii	05-08	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
-County of Hawaii	05-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	05-08	State Senate	3	D	"ISBELL, Virginia"	0	0	43	43
-County of Hawaii	05-08	State Senate	3	D	"GREEN, Josh"	0	0	81	81
-County of Hawaii	05-08	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	68	68
-County of Hawaii	05-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	280	280
-County of Hawaii	05-09	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	05-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Hawaii	05-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	05-09	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15
-County of Hawaii	05-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	05-09	US Representative	2	D	"HIRONO, Mazie"	0	0	177	177
-County of Hawaii	05-09	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Hawaii	05-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	05-09	State Senate	3	D	"ISBELL, Virginia"	0	0	94	94
-County of Hawaii	05-09	State Senate	3	D	"GREEN, Josh"	0	0	174	174
-County of Hawaii	05-09	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	160	160
-County of Hawaii	05-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	119	119
-County of Hawaii	05-10	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	05-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	05-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	05-10	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
-County of Hawaii	05-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	05-10	US Representative	2	D	"HIRONO, Mazie"	0	0	86	86
-County of Hawaii	05-10	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
-County of Hawaii	05-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	05-10	State Senate	3	D	"ISBELL, Virginia"	0	0	36	36
-County of Hawaii	05-10	State Senate	3	D	"GREEN, Josh"	0	0	77	77
-County of Hawaii	05-10	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	76	76
-County of Hawaii	05-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	481	481
-County of Hawaii	05-11	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	05-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	05-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-County of Hawaii	05-11	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43
-County of Hawaii	05-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	05-11	US Representative	2	D	"HIRONO, Mazie"	0	0	331	331
-County of Hawaii	05-11	US Representative	2	R	"EVANS, Roger B."	0	0	39	39
-County of Hawaii	05-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	05-11	State Senate	3	D	"ISBELL, Virginia"	0	0	144	144
-County of Hawaii	05-11	State Senate	3	D	"GREEN, Josh"	0	0	312	312
-County of Hawaii	05-11	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	267	267
-County of Hawaii	05-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	412	412
-County of Hawaii	05-12	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Hawaii	05-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	05-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	05-12	Straight Party			REPUBLICAN PARTY (R)	0	0	60	60
-County of Hawaii	05-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Hawaii	05-12	US Representative	2	D	"HIRONO, Mazie"	0	0	278	278
-County of Hawaii	05-12	US Representative	2	R	"EVANS, Roger B."	0	0	56	56
-County of Hawaii	05-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	05-12	State Senate	3	D	"ISBELL, Virginia"	0	0	122	122
-County of Hawaii	05-12	State Senate	3	D	"GREEN, Josh"	0	0	277	277
-County of Hawaii	05-12	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	255	255
-County of Hawaii	06-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	301	301
-County of Hawaii	06-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-County of Hawaii	06-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	06-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-County of Hawaii	06-01	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
-County of Hawaii	06-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	06-01	US Representative	2	D	"HIRONO, Mazie"	0	0	205	205
-County of Hawaii	06-01	US Representative	2	R	"EVANS, Roger B."	0	0	33	33
-County of Hawaii	06-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	06-01	State Senate	3	D	"ISBELL, Virginia"	0	0	69	69
-County of Hawaii	06-01	State Senate	3	D	"GREEN, Josh"	0	0	224	224
-County of Hawaii	06-01	State Representative	6	D	"COFFMAN, Denny"	0	0	101	101
-County of Hawaii	06-01	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	88	88
-County of Hawaii	06-01	State Representative	6	D	"MACGREGOR, Maegan"	0	0	47	47
-County of Hawaii	06-01	State Representative	6	R	"SMITH, Andy"	0	0	49	49
-County of Hawaii	06-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	554	554
-County of Hawaii	06-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-County of Hawaii	06-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	06-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	06-02	Straight Party			REPUBLICAN PARTY (R)	0	0	152	152
-County of Hawaii	06-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-County of Hawaii	06-02	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380
-County of Hawaii	06-02	US Representative	2	R	"EVANS, Roger B."	0	0	84	84
-County of Hawaii	06-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	06-02	State Senate	3	D	"ISBELL, Virginia"	0	0	86	86
-County of Hawaii	06-02	State Senate	3	D	"GREEN, Josh"	0	0	458	458
-County of Hawaii	06-02	State Representative	6	D	"COFFMAN, Denny"	0	0	287	287
-County of Hawaii	06-02	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	106	106
-County of Hawaii	06-02	State Representative	6	D	"MACGREGOR, Maegan"	0	0	74	74
-County of Hawaii	06-02	State Representative	6	R	"SMITH, Andy"	0	0	129	129
-County of Hawaii	06-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	214	214
-County of Hawaii	06-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	06-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	06-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Hawaii	06-03	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
-County of Hawaii	06-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	06-03	US Representative	2	D	"HIRONO, Mazie"	0	0	145	145
-County of Hawaii	06-03	US Representative	2	R	"EVANS, Roger B."	0	0	43	43
-County of Hawaii	06-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	06-03	State Senate	3	D	"ISBELL, Virginia"	0	0	32	32
-County of Hawaii	06-03	State Senate	3	D	"GREEN, Josh"	0	0	179	179
-County of Hawaii	06-03	State Representative	6	D	"COFFMAN, Denny"	0	0	98	98
-County of Hawaii	06-03	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	30	30
-County of Hawaii	06-03	State Representative	6	D	"MACGREGOR, Maegan"	0	0	32	32
-County of Hawaii	06-03	State Representative	6	R	"SMITH, Andy"	0	0	73	73
-County of Hawaii	06-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	282	282
-County of Hawaii	06-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Hawaii	06-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	06-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	06-04	Straight Party			REPUBLICAN PARTY (R)	0	0	95	95
-County of Hawaii	06-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Hawaii	06-04	US Representative	2	D	"HIRONO, Mazie"	0	0	180	180
-County of Hawaii	06-04	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
-County of Hawaii	06-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	06-04	State Senate	3	D	"ISBELL, Virginia"	0	0	49	49
-County of Hawaii	06-04	State Senate	3	D	"GREEN, Josh"	0	0	223	223
-County of Hawaii	06-04	State Representative	6	D	"COFFMAN, Denny"	0	0	74	74
-County of Hawaii	06-04	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	119	119
-County of Hawaii	06-04	State Representative	6	D	"MACGREGOR, Maegan"	0	0	34	34
-County of Hawaii	06-04	State Representative	6	R	"SMITH, Andy"	0	0	76	76
-County of Hawaii	06-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	286	286
-County of Hawaii	06-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Hawaii	06-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	06-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Hawaii	06-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
-County of Hawaii	06-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Hawaii	06-05	US Representative	2	D	"HIRONO, Mazie"	0	0	187	187
-County of Hawaii	06-05	US Representative	2	R	"EVANS, Roger B."	0	0	43	43
-County of Hawaii	06-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	06-05	State Senate	3	D	"ISBELL, Virginia"	0	0	65	65
-County of Hawaii	06-05	State Senate	3	D	"GREEN, Josh"	0	0	210	210
-County of Hawaii	06-05	State Representative	6	D	"COFFMAN, Denny"	0	0	81	81
-County of Hawaii	06-05	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	88	88
-County of Hawaii	06-05	State Representative	6	D	"MACGREGOR, Maegan"	0	0	45	45
-County of Hawaii	06-05	State Representative	6	R	"SMITH, Andy"	0	0	69	69
-County of Hawaii	06-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	216	216
-County of Hawaii	06-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	06-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	06-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Hawaii	06-06	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
-County of Hawaii	06-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	06-06	US Representative	2	D	"HIRONO, Mazie"	0	0	162	162
-County of Hawaii	06-06	US Representative	2	R	"EVANS, Roger B."	0	0	34	34
-County of Hawaii	06-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	06-06	State Senate	3	D	"ISBELL, Virginia"	0	0	51	51
-County of Hawaii	06-06	State Senate	3	D	"GREEN, Josh"	0	0	153	153
-County of Hawaii	06-06	State Representative	6	D	"COFFMAN, Denny"	0	0	73	73
-County of Hawaii	06-06	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	68	68
-County of Hawaii	06-06	State Representative	6	D	"MACGREGOR, Maegan"	0	0	38	38
-County of Hawaii	06-06	State Representative	6	R	"SMITH, Andy"	0	0	60	60
-County of Hawaii	06-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	183	183
-County of Hawaii	06-07	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-County of Hawaii	06-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	06-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
-County of Hawaii	06-07	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54
-County of Hawaii	06-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	06-07	US Representative	2	D	"HIRONO, Mazie"	0	0	129	129
-County of Hawaii	06-07	US Representative	2	R	"EVANS, Roger B."	0	0	33	33
-County of Hawaii	06-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	06-07	State Senate	3	D	"ISBELL, Virginia"	0	0	24	24
-County of Hawaii	06-07	State Senate	3	D	"GREEN, Josh"	0	0	155	155
-County of Hawaii	06-07	State Representative	6	D	"COFFMAN, Denny"	0	0	79	79
-County of Hawaii	06-07	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	42	42
-County of Hawaii	06-07	State Representative	6	D	"MACGREGOR, Maegan"	0	0	25	25
-County of Hawaii	06-07	State Representative	6	R	"SMITH, Andy"	0	0	49	49
-County of Hawaii	06-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	291	291
-County of Hawaii	06-08	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Hawaii	06-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	06-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-County of Hawaii	06-08	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
-County of Hawaii	06-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	06-08	US Representative	2	D	"HIRONO, Mazie"	0	0	206	206
-County of Hawaii	06-08	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
-County of Hawaii	06-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	06-08	State Senate	3	D	"ISBELL, Virginia"	0	0	75	75
-County of Hawaii	06-08	State Senate	3	D	"GREEN, Josh"	0	0	200	200
-County of Hawaii	06-08	State Representative	6	D	"COFFMAN, Denny"	0	0	77	77
-County of Hawaii	06-08	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	93	93
-County of Hawaii	06-08	State Representative	6	D	"MACGREGOR, Maegan"	0	0	56	56
-County of Hawaii	06-08	State Representative	6	R	"SMITH, Andy"	0	0	39	39
-County of Hawaii	07-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	240	240
-County of Hawaii	07-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	07-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Hawaii	07-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-County of Hawaii	07-01	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
-County of Hawaii	07-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Hawaii	07-01	US Representative	2	D	"HIRONO, Mazie"	0	0	158	158
-County of Hawaii	07-01	US Representative	2	R	"EVANS, Roger B."	0	0	45	45
-County of Hawaii	07-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Hawaii	07-01	State Senate	3	D	"ISBELL, Virginia"	0	0	40	40
-County of Hawaii	07-01	State Senate	3	D	"GREEN, Josh"	0	0	182	182
-County of Hawaii	07-01	State Representative	7	D	"EVANS, Cindy"	0	0	162	162
-County of Hawaii	07-01	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	32	32
-County of Hawaii	07-01	State Representative	7	R	"KAILIMAI, B.J."	0	0	17	17
-County of Hawaii	07-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	593	593
-County of Hawaii	07-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Hawaii	07-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	07-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
-County of Hawaii	07-02	Straight Party			REPUBLICAN PARTY (R)	0	0	139	139
-County of Hawaii	07-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Hawaii	07-02	US Representative	2	D	"HIRONO, Mazie"	0	0	368	368
-County of Hawaii	07-02	US Representative	2	R	"EVANS, Roger B."	0	0	107	107
-County of Hawaii	07-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	07-02	State Senate	3	D	"ISBELL, Virginia"	0	0	142	142
-County of Hawaii	07-02	State Senate	3	D	"GREEN, Josh"	0	0	410	410
-County of Hawaii	07-02	State Representative	7	D	"EVANS, Cindy"	0	0	379	379
-County of Hawaii	07-02	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	62	62
-County of Hawaii	07-02	State Representative	7	R	"KAILIMAI, B.J."	0	0	36	36
-County of Hawaii	07-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	498	498
-County of Hawaii	07-03	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
-County of Hawaii	07-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-County of Hawaii	07-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
-County of Hawaii	07-03	Straight Party			REPUBLICAN PARTY (R)	0	0	166	166
-County of Hawaii	07-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10
-County of Hawaii	07-03	US Representative	2	D	"HIRONO, Mazie"	0	0	346	346
-County of Hawaii	07-03	US Representative	2	R	"EVANS, Roger B."	0	0	121	121
-County of Hawaii	07-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	7	7
-County of Hawaii	07-03	State Senate	3	D	"ISBELL, Virginia"	0	0	81	81
-County of Hawaii	07-03	State Senate	3	D	"GREEN, Josh"	0	0	348	348
-County of Hawaii	07-03	State Representative	7	D	"EVANS, Cindy"	0	0	401	401
-County of Hawaii	07-03	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	86	86
-County of Hawaii	07-03	State Representative	7	R	"KAILIMAI, B.J."	0	0	61	61
-County of Hawaii	07-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	70	70
-County of Hawaii	07-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	07-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	07-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	07-04	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
-County of Hawaii	07-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	07-04	US Representative	2	D	"HIRONO, Mazie"	0	0	53	53
-County of Hawaii	07-04	US Representative	2	R	"EVANS, Roger B."	0	0	18	18
-County of Hawaii	07-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	07-04	State Senate	3	D	"ISBELL, Virginia"	0	0	9	9
-County of Hawaii	07-04	State Senate	3	D	"GREEN, Josh"	0	0	51	51
-County of Hawaii	07-04	State Representative	7	D	"EVANS, Cindy"	0	0	52	52
-County of Hawaii	07-04	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	13	13
-County of Hawaii	07-04	State Representative	7	R	"KAILIMAI, B.J."	0	0	6	6
-County of Hawaii	07-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	329	329
-County of Hawaii	07-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	07-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-County of Hawaii	07-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-County of Hawaii	07-05	Straight Party			REPUBLICAN PARTY (R)	0	0	131	131
-County of Hawaii	07-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	07-05	US Representative	2	D	"HIRONO, Mazie"	0	0	216	216
-County of Hawaii	07-05	US Representative	2	R	"EVANS, Roger B."	0	0	84	84
-County of Hawaii	07-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-County of Hawaii	07-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	223	223
-County of Hawaii	07-05	State Senate	1	R	"HONG, Ted H.S."	0	0	94	94
-County of Hawaii	07-05	State Representative	7	D	"EVANS, Cindy"	0	0	210	210
-County of Hawaii	07-05	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	48	48
-County of Hawaii	07-05	State Representative	7	R	"KAILIMAI, B.J."	0	0	64	64
-County of Hawaii	07-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
-County of Hawaii	07-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	07-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	07-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-County of Hawaii	07-06	Straight Party			REPUBLICAN PARTY (R)	0	0	104	104
-County of Hawaii	07-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	07-06	US Representative	2	D	"HIRONO, Mazie"	0	0	204	204
-County of Hawaii	07-06	US Representative	2	R	"EVANS, Roger B."	0	0	55	55
-County of Hawaii	07-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	07-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	214	214
-County of Hawaii	07-06	State Senate	1	R	"HONG, Ted H.S."	0	0	65	65
-County of Hawaii	07-06	State Representative	7	D	"EVANS, Cindy"	0	0	207	207
-County of Hawaii	07-06	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	32	32
-County of Hawaii	07-06	State Representative	7	R	"KAILIMAI, B.J."	0	0	56	56
-County of Hawaii	07-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	161	161
-County of Hawaii	07-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Hawaii	07-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Hawaii	07-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Hawaii	07-07	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
-County of Hawaii	07-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Hawaii	07-07	US Representative	2	D	"HIRONO, Mazie"	0	0	99	99
-County of Hawaii	07-07	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
-County of Hawaii	07-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Hawaii	07-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	109	109
-County of Hawaii	07-07	State Senate	1	R	"HONG, Ted H.S."	0	0	43	43
-County of Hawaii	07-07	State Representative	7	D	"EVANS, Cindy"	0	0	92	92
-County of Hawaii	07-07	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	19	19
-County of Hawaii	07-07	State Representative	7	R	"KAILIMAI, B.J."	0	0	38	38
-County of Hawaii	07-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	33	33
-County of Hawaii	07-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Hawaii	07-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Hawaii	07-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Hawaii	07-08	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
-County of Hawaii	07-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Hawaii	07-08	US Representative	2	D	"HIRONO, Mazie"	0	0	20	20
-County of Hawaii	07-08	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
-County of Hawaii	07-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Hawaii	07-08	State Senate	3	D	"ISBELL, Virginia"	0	0	2	2
-County of Hawaii	07-08	State Senate	3	D	"GREEN, Josh"	0	0	26	26
-County of Hawaii	07-08	State Representative	7	D	"EVANS, Cindy"	0	0	25	25
-County of Hawaii	07-08	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	3	3
-County of Hawaii	07-08	State Representative	7	R	"KAILIMAI, B.J."	0	0	6	6
-County of Maui	08-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	264	264
-County of Maui	08-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	08-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	08-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	08-01	Straight Party			REPUBLICAN PARTY (R)	0	0	27	27
-County of Maui	08-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Maui	08-01	US Representative	2	D	"HIRONO, Mazie"	0	0	193	193
-County of Maui	08-01	US Representative	2	R	"EVANS, Roger B."	0	0	24	24
-County of Maui	08-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	08-01	State Representative	8	D	"KAMA, Tasha"	0	0	160	160
-County of Maui	08-01	State Representative	8	D	"SOUKI, Joe"	0	0	93	93
-County of Maui	08-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	452	452
-County of Maui	08-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	08-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	08-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-County of Maui	08-02	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
-County of Maui	08-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Maui	08-02	US Representative	2	D	"HIRONO, Mazie"	0	0	338	338
-County of Maui	08-02	US Representative	2	R	"EVANS, Roger B."	0	0	38	38
-County of Maui	08-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	08-02	State Representative	8	D	"KAMA, Tasha"	0	0	234	234
-County of Maui	08-02	State Representative	8	D	"SOUKI, Joe"	0	0	192	192
-County of Maui	08-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	213	213
-County of Maui	08-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Maui	08-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	08-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	08-03	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
-County of Maui	08-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	08-03	US Representative	2	D	"HIRONO, Mazie"	0	0	168	168
-County of Maui	08-03	US Representative	2	R	"EVANS, Roger B."	0	0	24	24
-County of Maui	08-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	08-03	State Representative	8	D	"KAMA, Tasha"	0	0	69	69
-County of Maui	08-03	State Representative	8	D	"SOUKI, Joe"	0	0	127	127
-County of Maui	08-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	209	209
-County of Maui	08-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Maui	08-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	08-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-County of Maui	08-04	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14
-County of Maui	08-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	08-04	US Representative	2	D	"HIRONO, Mazie"	0	0	158	158
-County of Maui	08-04	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Maui	08-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	08-04	State Representative	8	D	"KAMA, Tasha"	0	0	92	92
-County of Maui	08-04	State Representative	8	D	"SOUKI, Joe"	0	0	95	95
-County of Maui	08-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	426	426
-County of Maui	08-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	08-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	08-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-County of Maui	08-05	Straight Party			REPUBLICAN PARTY (R)	0	0	70	70
-County of Maui	08-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	08-05	US Representative	2	D	"HIRONO, Mazie"	0	0	333	333
-County of Maui	08-05	US Representative	2	R	"EVANS, Roger B."	0	0	61	61
-County of Maui	08-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	08-05	State Representative	8	D	"KAMA, Tasha"	0	0	178	178
-County of Maui	08-05	State Representative	8	D	"SOUKI, Joe"	0	0	216	216
-County of Maui	08-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223
-County of Maui	08-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	08-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	08-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	08-06	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15
-County of Maui	08-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	08-06	US Representative	2	D	"HIRONO, Mazie"	0	0	181	181
-County of Maui	08-06	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Maui	08-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Maui	08-06	State Representative	8	D	"KAMA, Tasha"	0	0	85	85
-County of Maui	08-06	State Representative	8	D	"SOUKI, Joe"	0	0	118	118
-County of Maui	08-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	141	141
-County of Maui	08-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	08-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	08-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	08-07	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
-County of Maui	08-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	08-07	US Representative	2	D	"HIRONO, Mazie"	0	0	115	115
-County of Maui	08-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
-County of Maui	08-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	08-07	State Representative	8	D	"KAMA, Tasha"	0	0	61	61
-County of Maui	08-07	State Representative	8	D	"SOUKI, Joe"	0	0	71	71
-County of Maui	09-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	192	192
-County of Maui	09-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	09-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	09-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Maui	09-01	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
-County of Maui	09-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	09-01	US Representative	2	D	"HIRONO, Mazie"	0	0	148	148
-County of Maui	09-01	US Representative	2	R	"EVANS, Roger B."	0	0	20	20
-County of Maui	09-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	09-01	State Representative	9	D	"NAKASONE, Bob"	0	0	123	123
-County of Maui	09-01	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	21	21
-County of Maui	09-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392
-County of Maui	09-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	09-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	09-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	09-02	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56
-County of Maui	09-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	09-02	US Representative	2	D	"HIRONO, Mazie"	0	0	337	337
-County of Maui	09-02	US Representative	2	R	"EVANS, Roger B."	0	0	31	31
-County of Maui	09-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Maui	09-02	State Representative	9	D	"NAKASONE, Bob"	0	0	268	268
-County of Maui	09-02	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	34	34
-County of Maui	09-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	338	338
-County of Maui	09-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	09-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	09-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Maui	09-03	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
-County of Maui	09-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	09-03	US Representative	2	D	"HIRONO, Mazie"	0	0	287	287
-County of Maui	09-03	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
-County of Maui	09-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	09-03	State Representative	9	D	"NAKASONE, Bob"	0	0	246	246
-County of Maui	09-03	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	24	24
-County of Maui	09-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	299	299
-County of Maui	09-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Maui	09-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	09-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	09-04	Straight Party			REPUBLICAN PARTY (R)	0	0	33	33
-County of Maui	09-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	09-04	US Representative	2	D	"HIRONO, Mazie"	0	0	249	249
-County of Maui	09-04	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
-County of Maui	09-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	09-04	State Representative	9	D	"NAKASONE, Bob"	0	0	183	183
-County of Maui	09-04	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	24	24
-County of Maui	09-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	381	381
-County of Maui	09-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Maui	09-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	09-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	09-05	Straight Party			REPUBLICAN PARTY (R)	0	0	30	30
-County of Maui	09-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Maui	09-05	US Representative	2	D	"HIRONO, Mazie"	0	0	312	312
-County of Maui	09-05	US Representative	2	R	"EVANS, Roger B."	0	0	24	24
-County of Maui	09-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	09-05	State Representative	9	D	"NAKASONE, Bob"	0	0	256	256
-County of Maui	09-05	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	18	18
-County of Maui	09-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	22	22
-County of Maui	09-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	09-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	09-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	09-06	Straight Party			REPUBLICAN PARTY (R)	0	0	2	2
-County of Maui	09-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	09-06	US Representative	2	D	"HIRONO, Mazie"	0	0	17	17
-County of Maui	09-06	US Representative	2	R	"EVANS, Roger B."	0	0	1	1
-County of Maui	09-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	09-06	State Representative	9	D	"NAKASONE, Bob"	0	0	11	11
-County of Maui	09-06	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	1	1
-County of Maui	09-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	120	120
-County of Maui	09-07	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Maui	09-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Maui	09-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Maui	09-07	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
-County of Maui	09-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Maui	09-07	US Representative	2	D	"HIRONO, Mazie"	0	0	98	98
-County of Maui	09-07	US Representative	2	R	"EVANS, Roger B."	0	0	12	12
-County of Maui	09-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Maui	09-07	State Representative	9	D	"NAKASONE, Bob"	0	0	60	60
-County of Maui	09-07	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	19	19
-County of Maui	10-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	114	114
-County of Maui	10-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Maui	10-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	10-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	10-01	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24
-County of Maui	10-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-County of Maui	10-01	US Representative	2	D	"HIRONO, Mazie"	0	0	90	90
-County of Maui	10-01	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
-County of Maui	10-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	10-01	State Senate	5	D	"BAKER, Roz"	0	0	89	89
-County of Maui	10-01	State Senate	5	D	"MULVIHILL, Bart"	0	0	13	13
-County of Maui	10-01	State Senate	5	R	"SHIELDS, Jan"	0	0	17	17
-County of Maui	10-01	State Representative	10	D	"MCKELVEY, Angus"	0	0	76	76
-County of Maui	10-01	State Representative	10	R	"MADDEN, Ramon K."	0	0	14	14
-County of Maui	10-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
-County of Maui	10-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	10-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	10-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	10-02	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
-County of Maui	10-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	10-02	US Representative	2	D	"HIRONO, Mazie"	0	0	125	125
-County of Maui	10-02	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
-County of Maui	10-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	10-02	State Senate	5	D	"BAKER, Roz"	0	0	112	112
-County of Maui	10-02	State Senate	5	D	"MULVIHILL, Bart"	0	0	42	42
-County of Maui	10-02	State Senate	5	R	"SHIELDS, Jan"	0	0	52	52
-County of Maui	10-02	State Representative	10	D	"MCKELVEY, Angus"	0	0	136	136
-County of Maui	10-02	State Representative	10	R	"MADDEN, Ramon K."	0	0	26	26
-County of Maui	10-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	246	246
-County of Maui	10-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Maui	10-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	10-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	10-03	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
-County of Maui	10-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Maui	10-03	US Representative	2	D	"HIRONO, Mazie"	0	0	206	206
-County of Maui	10-03	US Representative	2	R	"EVANS, Roger B."	0	0	12	12
-County of Maui	10-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	10-03	State Senate	5	D	"BAKER, Roz"	0	0	194	194
-County of Maui	10-03	State Senate	5	D	"MULVIHILL, Bart"	0	0	37	37
-County of Maui	10-03	State Senate	5	R	"SHIELDS, Jan"	0	0	22	22
-County of Maui	10-03	State Representative	10	D	"MCKELVEY, Angus"	0	0	191	191
-County of Maui	10-03	State Representative	10	R	"MADDEN, Ramon K."	0	0	15	15
-County of Maui	10-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
-County of Maui	10-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	10-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	10-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Maui	10-04	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
-County of Maui	10-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	10-04	US Representative	2	D	"HIRONO, Mazie"	0	0	145	145
-County of Maui	10-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17
-County of Maui	10-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Maui	10-04	State Senate	5	D	"BAKER, Roz"	0	0	132	132
-County of Maui	10-04	State Senate	5	D	"MULVIHILL, Bart"	0	0	31	31
-County of Maui	10-04	State Senate	5	R	"SHIELDS, Jan"	0	0	37	37
-County of Maui	10-04	State Representative	10	D	"MCKELVEY, Angus"	0	0	151	151
-County of Maui	10-04	State Representative	10	R	"MADDEN, Ramon K."	0	0	22	22
-County of Maui	10-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	162	162
-County of Maui	10-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	10-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	10-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	10-05	Straight Party			REPUBLICAN PARTY (R)	0	0	87	87
-County of Maui	10-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	10-05	US Representative	2	D	"HIRONO, Mazie"	0	0	111	111
-County of Maui	10-05	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
-County of Maui	10-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	10-05	State Senate	5	D	"BAKER, Roz"	0	0	105	105
-County of Maui	10-05	State Senate	5	D	"MULVIHILL, Bart"	0	0	46	46
-County of Maui	10-05	State Senate	5	R	"SHIELDS, Jan"	0	0	74	74
-County of Maui	10-05	State Representative	10	D	"MCKELVEY, Angus"	0	0	125	125
-County of Maui	10-05	State Representative	10	R	"MADDEN, Ramon K."	0	0	39	39
-County of Maui	10-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200
-County of Maui	10-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Maui	10-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	10-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Maui	10-06	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
-County of Maui	10-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	10-06	US Representative	2	D	"HIRONO, Mazie"	0	0	142	142
-County of Maui	10-06	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
-County of Maui	10-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	10-06	State Senate	5	D	"BAKER, Roz"	0	0	129	129
-County of Maui	10-06	State Senate	5	D	"MULVIHILL, Bart"	0	0	52	52
-County of Maui	10-06	State Senate	5	R	"SHIELDS, Jan"	0	0	74	74
-County of Maui	10-06	State Representative	10	D	"MCKELVEY, Angus"	0	0	153	153
-County of Maui	10-06	State Representative	10	R	"MADDEN, Ramon K."	0	0	35	35
-County of Maui	11-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	299	299
-County of Maui	11-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Maui	11-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	11-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	11-01	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
-County of Maui	11-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-County of Maui	11-01	US Representative	2	D	"HIRONO, Mazie"	0	0	239	239
-County of Maui	11-01	US Representative	2	R	"EVANS, Roger B."	0	0	26	26
-County of Maui	11-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	11-01	State Senate	5	D	"BAKER, Roz"	0	0	217	217
-County of Maui	11-01	State Senate	5	D	"MULVIHILL, Bart"	0	0	55	55
-County of Maui	11-01	State Senate	5	R	"SHIELDS, Jan"	0	0	47	47
-County of Maui	11-01	State Representative	11	D	"GINGERICH, Michael"	0	0	86	86
-County of Maui	11-01	State Representative	11	D	"BERTRAM, Joe, III"	0	0	175	175
-County of Maui	11-01	State Representative	11	R	"FONTAINE, George R."	0	0	35	35
-County of Maui	11-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	462	462
-County of Maui	11-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-County of Maui	11-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	11-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Maui	11-02	Straight Party			REPUBLICAN PARTY (R)	0	0	159	159
-County of Maui	11-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Maui	11-02	US Representative	2	D	"HIRONO, Mazie"	0	0	342	342
-County of Maui	11-02	US Representative	2	R	"EVANS, Roger B."	0	0	77	77
-County of Maui	11-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Maui	11-02	State Senate	5	D	"BAKER, Roz"	0	0	270	270
-County of Maui	11-02	State Senate	5	D	"MULVIHILL, Bart"	0	0	153	153
-County of Maui	11-02	State Senate	5	R	"SHIELDS, Jan"	0	0	135	135
-County of Maui	11-02	State Representative	11	D	"GINGERICH, Michael"	0	0	131	131
-County of Maui	11-02	State Representative	11	D	"BERTRAM, Joe, III"	0	0	296	296
-County of Maui	11-02	State Representative	11	R	"FONTAINE, George R."	0	0	108	108
-County of Maui	11-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	272	272
-County of Maui	11-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-County of Maui	11-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	11-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Maui	11-03	Straight Party			REPUBLICAN PARTY (R)	0	0	116	116
-County of Maui	11-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Maui	11-03	US Representative	2	D	"HIRONO, Mazie"	0	0	196	196
-County of Maui	11-03	US Representative	2	R	"EVANS, Roger B."	0	0	45	45
-County of Maui	11-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	11-03	State Senate	5	D	"BAKER, Roz"	0	0	175	175
-County of Maui	11-03	State Senate	5	D	"MULVIHILL, Bart"	0	0	84	84
-County of Maui	11-03	State Senate	5	R	"SHIELDS, Jan"	0	0	97	97
-County of Maui	11-03	State Representative	11	D	"GINGERICH, Michael"	0	0	61	61
-County of Maui	11-03	State Representative	11	D	"BERTRAM, Joe, III"	0	0	183	183
-County of Maui	11-03	State Representative	11	R	"FONTAINE, George R."	0	0	67	67
-County of Maui	11-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293
-County of Maui	11-04	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-County of Maui	11-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	11-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-County of Maui	11-04	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112
-County of Maui	11-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Maui	11-04	US Representative	2	D	"HIRONO, Mazie"	0	0	218	218
-County of Maui	11-04	US Representative	2	R	"EVANS, Roger B."	0	0	62	62
-County of Maui	11-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	11-04	State Senate	5	D	"BAKER, Roz"	0	0	202	202
-County of Maui	11-04	State Senate	5	D	"MULVIHILL, Bart"	0	0	73	73
-County of Maui	11-04	State Senate	5	R	"SHIELDS, Jan"	0	0	85	85
-County of Maui	11-04	State Representative	11	D	"GINGERICH, Michael"	0	0	81	81
-County of Maui	11-04	State Representative	11	D	"BERTRAM, Joe, III"	0	0	180	180
-County of Maui	11-04	State Representative	11	R	"FONTAINE, George R."	0	0	75	75
-County of Maui	12-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	516	516
-County of Maui	12-01	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-County of Maui	12-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	12-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	12-01	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
-County of Maui	12-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-County of Maui	12-01	US Representative	2	D	"HIRONO, Mazie"	0	0	367	367
-County of Maui	12-01	US Representative	2	R	"EVANS, Roger B."	0	0	29	29
-County of Maui	12-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Maui	12-01	State Senate	6	I	"BLUMER-BUELL, John"	0	0	6	6
-County of Maui	12-01	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	344	344
-County of Maui	12-01	State Representative	12	D	"YAMASHITA, Kyle"	0	0	300	300
-County of Maui	12-01	State Representative	12	D	"STARR, Summer"	0	0	195	195
-County of Maui	12-01	State Representative	12	R	"VIERRA, Mickey"	0	0	49	49
-County of Maui	12-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	403	403
-County of Maui	12-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	12-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	12-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	12-02	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36
-County of Maui	12-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	12-02	US Representative	2	D	"HIRONO, Mazie"	0	0	247	247
-County of Maui	12-02	US Representative	2	R	"EVANS, Roger B."	0	0	15	15
-County of Maui	12-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Maui	12-02	State Senate	6	I	"BLUMER-BUELL, John"	0	0	3	3
-County of Maui	12-02	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	249	249
-County of Maui	12-02	State Representative	12	D	"YAMASHITA, Kyle"	0	0	191	191
-County of Maui	12-02	State Representative	12	D	"STARR, Summer"	0	0	203	203
-County of Maui	12-02	State Representative	12	R	"VIERRA, Mickey"	0	0	27	27
-County of Maui	12-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	532	532
-County of Maui	12-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Maui	12-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	12-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Maui	12-03	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
-County of Maui	12-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	12-03	US Representative	2	D	"HIRONO, Mazie"	0	0	344	344
-County of Maui	12-03	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
-County of Maui	12-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	12-03	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2
-County of Maui	12-03	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	319	319
-County of Maui	12-03	State Representative	12	D	"YAMASHITA, Kyle"	0	0	275	275
-County of Maui	12-03	State Representative	12	D	"STARR, Summer"	0	0	239	239
-County of Maui	12-03	State Representative	12	R	"VIERRA, Mickey"	0	0	51	51
-County of Maui	12-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	679	679
-County of Maui	12-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Maui	12-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	12-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	12-04	Straight Party			REPUBLICAN PARTY (R)	0	0	90	90
-County of Maui	12-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	12-04	US Representative	2	D	"HIRONO, Mazie"	0	0	492	492
-County of Maui	12-04	US Representative	2	R	"EVANS, Roger B."	0	0	32	32
-County of Maui	12-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	12-04	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2
-County of Maui	12-04	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	448	448
-County of Maui	12-04	State Representative	12	D	"YAMASHITA, Kyle"	0	0	444	444
-County of Maui	12-04	State Representative	12	D	"STARR, Summer"	0	0	211	211
-County of Maui	12-04	State Representative	12	R	"VIERRA, Mickey"	0	0	72	72
-County of Maui	12-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	306	306
-County of Maui	12-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Maui	12-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	12-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Maui	12-05	Straight Party			REPUBLICAN PARTY (R)	0	0	46	46
-County of Maui	12-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	12-05	US Representative	2	D	"HIRONO, Mazie"	0	0	208	208
-County of Maui	12-05	US Representative	2	R	"EVANS, Roger B."	0	0	16	16
-County of Maui	12-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	12-05	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
-County of Maui	12-05	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	204	204
-County of Maui	12-05	State Representative	12	D	"YAMASHITA, Kyle"	0	0	149	149
-County of Maui	12-05	State Representative	12	D	"STARR, Summer"	0	0	141	141
-County of Maui	12-05	State Representative	12	R	"VIERRA, Mickey"	0	0	34	34
-County of Maui	12-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	524	524
-County of Maui	12-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-County of Maui	12-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Maui	12-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	12-06	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
-County of Maui	12-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	12-06	US Representative	2	D	"HIRONO, Mazie"	0	0	324	324
-County of Maui	12-06	US Representative	2	R	"EVANS, Roger B."	0	0	34	34
-County of Maui	12-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Maui	12-06	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2
-County of Maui	12-06	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	331	331
-County of Maui	12-06	State Representative	12	D	"YAMASHITA, Kyle"	0	0	220	220
-County of Maui	12-06	State Representative	12	D	"STARR, Summer"	0	0	288	288
-County of Maui	12-06	State Representative	12	R	"VIERRA, Mickey"	0	0	49	49
-County of Maui	12-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	33	33
-County of Maui	12-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	12-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	12-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	12-07	Straight Party			REPUBLICAN PARTY (R)	0	0	5	5
-County of Maui	12-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	12-07	US Representative	2	D	"HIRONO, Mazie"	0	0	17	17
-County of Maui	12-07	US Representative	2	R	"EVANS, Roger B."	0	0	3	3
-County of Maui	12-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	12-07	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
-County of Maui	12-07	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	25	25
-County of Maui	12-07	State Representative	12	D	"YAMASHITA, Kyle"	0	0	6	6
-County of Maui	12-07	State Representative	12	D	"STARR, Summer"	0	0	27	27
-County of Maui	12-07	State Representative	12	R	"VIERRA, Mickey"	0	0	4	4
-County of Maui	13-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	151	151
-County of Maui	13-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Maui	13-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	13-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Maui	13-01	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19
-County of Maui	13-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	13-01	US Representative	2	D	"HIRONO, Mazie"	0	0	103	103
-County of Maui	13-01	US Representative	2	R	"EVANS, Roger B."	0	0	18	18
-County of Maui	13-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	13-01	State Senate	6	I	"BLUMER-BUELL, John"	0	0	1	1
-County of Maui	13-01	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	104	104
-County of Maui	13-01	State Representative	13	D	"CARROLL, Mele"	0	0	94	94
-County of Maui	13-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	358	358
-County of Maui	13-02	Straight Party			INDEPENDENT PARTY (I)	0	0	13	13
-County of Maui	13-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Maui	13-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	13-02	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56
-County of Maui	13-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Maui	13-02	US Representative	2	D	"HIRONO, Mazie"	0	0	208	208
-County of Maui	13-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54
-County of Maui	13-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Maui	13-02	State Senate	6	I	"BLUMER-BUELL, John"	0	0	10	10
-County of Maui	13-02	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	230	230
-County of Maui	13-02	State Representative	13	D	"CARROLL, Mele"	0	0	213	213
-County of Maui	13-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	389	389
-County of Maui	13-03	Straight Party			INDEPENDENT PARTY (I)	0	0	21	21
-County of Maui	13-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-County of Maui	13-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Maui	13-03	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32
-County of Maui	13-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-County of Maui	13-03	US Representative	2	D	"HIRONO, Mazie"	0	0	254	254
-County of Maui	13-03	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
-County of Maui	13-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6
-County of Maui	13-03	State Senate	6	I	"BLUMER-BUELL, John"	0	0	19	19
-County of Maui	13-03	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	261	261
-County of Maui	13-03	State Representative	13	D	"CARROLL, Mele"	0	0	253	253
-County of Maui	13-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	95	95
-County of Maui	13-04	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Maui	13-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	13-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	13-04	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
-County of Maui	13-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	13-04	US Representative	2	D	"HIRONO, Mazie"	0	0	54	54
-County of Maui	13-04	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
-County of Maui	13-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	13-04	State Senate	6	I	"BLUMER-BUELL, John"	0	0	7	7
-County of Maui	13-04	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	67	67
-County of Maui	13-04	State Representative	13	D	"CARROLL, Mele"	0	0	68	68
-County of Maui	13-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	19	19
-County of Maui	13-05	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-County of Maui	13-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	13-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	13-05	Straight Party			REPUBLICAN PARTY (R)	0	0	7	7
-County of Maui	13-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Maui	13-05	US Representative	2	D	"HIRONO, Mazie"	0	0	12	12
-County of Maui	13-05	US Representative	2	R	"EVANS, Roger B."	0	0	6	6
-County of Maui	13-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	13-05	State Senate	6	I	"BLUMER-BUELL, John"	0	0	5	5
-County of Maui	13-05	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	13	13
-County of Maui	13-05	State Representative	13	D	"CARROLL, Mele"	0	0	11	11
-County of Maui	13-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	192	192
-County of Maui	13-06	Straight Party			INDEPENDENT PARTY (I)	0	0	23	23
-County of Maui	13-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	13-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	13-06	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
-County of Maui	13-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Maui	13-06	US Representative	2	D	"HIRONO, Mazie"	0	0	109	109
-County of Maui	13-06	US Representative	2	R	"EVANS, Roger B."	0	0	15	15
-County of Maui	13-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	13-06	State Senate	6	I	"BLUMER-BUELL, John"	0	0	23	23
-County of Maui	13-06	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	160	160
-County of Maui	13-06	State Representative	13	D	"CARROLL, Mele"	0	0	108	108
-County of Maui	13-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	362	362
-County of Maui	13-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-County of Maui	13-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Maui	13-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	13-07	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47
-County of Maui	13-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Maui	13-07	US Representative	2	D	"HIRONO, Mazie"	0	0	259	259
-County of Maui	13-07	US Representative	2	R	"EVANS, Roger B."	0	0	43	43
-County of Maui	13-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	13-07	State Senate	6	I	"BLUMER-BUELL, John"	0	0	4	4
-County of Maui	13-07	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	184	184
-County of Maui	13-07	State Representative	13	D	"CARROLL, Mele"	0	0	177	177
-County of Maui	13-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	59	59
-County of Maui	13-08	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	13-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	13-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	13-08	Straight Party			REPUBLICAN PARTY (R)	0	0	12	12
-County of Maui	13-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	13-08	US Representative	2	D	"HIRONO, Mazie"	0	0	32	32
-County of Maui	13-08	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
-County of Maui	13-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	13-08	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
-County of Maui	13-08	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	43	43
-County of Maui	13-08	State Representative	13	D	"CARROLL, Mele"	0	0	37	37
-County of Maui	13-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223
-County of Maui	13-09	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	13-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	13-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-County of Maui	13-09	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
-County of Maui	13-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	13-09	US Representative	2	D	"HIRONO, Mazie"	0	0	155	155
-County of Maui	13-09	US Representative	2	R	"EVANS, Roger B."	0	0	20	20
-County of Maui	13-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	13-09	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
-County of Maui	13-09	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	150	150
-County of Maui	13-09	State Representative	13	D	"CARROLL, Mele"	0	0	124	124
-County of Maui	13-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	25	25
-County of Maui	13-10	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	13-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	13-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	13-10	Straight Party			REPUBLICAN PARTY (R)	0	0	9	9
-County of Maui	13-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	13-10	US Representative	2	D	"HIRONO, Mazie"	0	0	18	18
-County of Maui	13-10	US Representative	2	R	"EVANS, Roger B."	0	0	9	9
-County of Maui	13-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	13-10	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
-County of Maui	13-10	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	17	17
-County of Maui	13-10	State Representative	13	D	"CARROLL, Mele"	0	0	16	16
-County of Maui	13-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	172	172
-County of Maui	13-11	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	13-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Maui	13-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	13-11	Straight Party			REPUBLICAN PARTY (R)	0	0	12	12
-County of Maui	13-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	13-11	US Representative	2	D	"HIRONO, Mazie"	0	0	109	109
-County of Maui	13-11	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
-County of Maui	13-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Maui	13-11	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
-County of Maui	13-11	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	116	116
-County of Maui	13-11	State Representative	13	D	"CARROLL, Mele"	0	0	103	103
-County of Maui	13-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	0	0
-County of Maui	13-12	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Maui	13-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Maui	13-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Maui	13-12	Straight Party			REPUBLICAN PARTY (R)	0	0	0	0
-County of Maui	13-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Maui	13-12	US Representative	2	D	"HIRONO, Mazie"	0	0	0	0
-County of Maui	13-12	US Representative	2	R	"EVANS, Roger B."	0	0	0	0
-County of Maui	13-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Maui	13-12	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
-County of Maui	13-12	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	0	0
-County of Maui	13-12	State Representative	13	D	"CARROLL, Mele"	0	0	0	0
-County of Kauai	14-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	442	442
-County of Kauai	14-01	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
-County of Kauai	14-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-County of Kauai	14-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Kauai	14-01	Straight Party			REPUBLICAN PARTY (R)	0	0	134	134
-County of Kauai	14-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-County of Kauai	14-01	US Representative	2	D	"HIRONO, Mazie"	0	0	232	232
-County of Kauai	14-01	US Representative	2	R	"EVANS, Roger B."	0	0	82	82
-County of Kauai	14-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
-County of Kauai	14-01	State Senate	7	D	"HOOSER, Gary L."	0	0	324	324
-County of Kauai	14-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	101	101
-County of Kauai	14-01	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	323	323
-County of Kauai	14-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	525	525
-County of Kauai	14-02	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14
-County of Kauai	14-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Kauai	14-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
-County of Kauai	14-02	Straight Party			REPUBLICAN PARTY (R)	0	0	88	88
-County of Kauai	14-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
-County of Kauai	14-02	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305
-County of Kauai	14-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54
-County of Kauai	14-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Kauai	14-02	State Senate	7	D	"HOOSER, Gary L."	0	0	390	390
-County of Kauai	14-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	61	61
-County of Kauai	14-02	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	355	355
-County of Kauai	14-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	321	321
-County of Kauai	14-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-County of Kauai	14-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Kauai	14-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Kauai	14-03	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43
-County of Kauai	14-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Kauai	14-03	US Representative	2	D	"HIRONO, Mazie"	0	0	149	149
-County of Kauai	14-03	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
-County of Kauai	14-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Kauai	14-03	State Senate	7	D	"HOOSER, Gary L."	0	0	197	197
-County of Kauai	14-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	27	27
-County of Kauai	14-03	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	173	173
-County of Kauai	14-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	1079	1079
-County of Kauai	14-04	Straight Party			INDEPENDENT PARTY (I)	0	0	19	19
-County of Kauai	14-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Kauai	14-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
-County of Kauai	14-04	Straight Party			REPUBLICAN PARTY (R)	0	0	180	180
-County of Kauai	14-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	13	13
-County of Kauai	14-04	US Representative	2	D	"HIRONO, Mazie"	0	0	595	595
-County of Kauai	14-04	US Representative	2	R	"EVANS, Roger B."	0	0	100	100
-County of Kauai	14-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Kauai	14-04	State Senate	7	D	"HOOSER, Gary L."	0	0	773	773
-County of Kauai	14-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	117	117
-County of Kauai	14-04	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	539	539
-County of Kauai	14-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311
-County of Kauai	14-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-County of Kauai	14-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Kauai	14-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-County of Kauai	14-05	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53
-County of Kauai	14-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-County of Kauai	14-05	US Representative	2	D	"HIRONO, Mazie"	0	0	161	161
-County of Kauai	14-05	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
-County of Kauai	14-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Kauai	14-05	State Senate	7	D	"HOOSER, Gary L."	0	0	202	202
-County of Kauai	14-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	43	43
-County of Kauai	14-05	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	140	140
-County of Kauai	15-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	722	722
-County of Kauai	15-01	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
-County of Kauai	15-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Kauai	15-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Kauai	15-01	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136
-County of Kauai	15-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8
-County of Kauai	15-01	US Representative	2	D	"HIRONO, Mazie"	0	0	405	405
-County of Kauai	15-01	US Representative	2	R	"EVANS, Roger B."	0	0	74	74
-County of Kauai	15-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Kauai	15-01	State Senate	7	D	"HOOSER, Gary L."	0	0	529	529
-County of Kauai	15-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	96	96
-County of Kauai	15-01	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	366	366
-County of Kauai	15-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	463	463
-County of Kauai	15-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Kauai	15-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Kauai	15-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Kauai	15-02	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
-County of Kauai	15-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Kauai	15-02	US Representative	2	D	"HIRONO, Mazie"	0	0	298	298
-County of Kauai	15-02	US Representative	2	R	"EVANS, Roger B."	0	0	21	21
-County of Kauai	15-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Kauai	15-02	State Senate	7	D	"HOOSER, Gary L."	0	0	270	270
-County of Kauai	15-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	24	24
-County of Kauai	15-02	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	244	244
-County of Kauai	15-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	537	537
-County of Kauai	15-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-County of Kauai	15-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-County of Kauai	15-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Kauai	15-03	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
-County of Kauai	15-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-County of Kauai	15-03	US Representative	2	D	"HIRONO, Mazie"	0	0	327	327
-County of Kauai	15-03	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
-County of Kauai	15-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-County of Kauai	15-03	State Senate	7	D	"HOOSER, Gary L."	0	0	323	323
-County of Kauai	15-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	56	56
-County of Kauai	15-03	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	302	302
-County of Kauai	15-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	624	624
-County of Kauai	15-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
-County of Kauai	15-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
-County of Kauai	15-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
-County of Kauai	15-04	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101
-County of Kauai	15-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-County of Kauai	15-04	US Representative	2	D	"HIRONO, Mazie"	0	0	373	373
-County of Kauai	15-04	US Representative	2	R	"EVANS, Roger B."	0	0	60	60
-County of Kauai	15-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6
-County of Kauai	15-04	State Senate	7	D	"HOOSER, Gary L."	0	0	399	399
-County of Kauai	15-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	71	71
-County of Kauai	15-04	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	364	364
-County of Kauai	15-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	257	257
-County of Kauai	15-05	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
-County of Kauai	15-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Kauai	15-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-County of Kauai	15-05	Straight Party			REPUBLICAN PARTY (R)	0	0	50	50
-County of Kauai	15-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-County of Kauai	15-05	US Representative	2	D	"HIRONO, Mazie"	0	0	137	137
-County of Kauai	15-05	US Representative	2	R	"EVANS, Roger B."	0	0	23	23
-County of Kauai	15-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Kauai	15-05	State Senate	7	D	"HOOSER, Gary L."	0	0	169	169
-County of Kauai	15-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	33	33
-County of Kauai	15-05	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	107	107
-County of Kauai	16-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	385	385
-County of Kauai	16-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Kauai	16-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-County of Kauai	16-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-County of Kauai	16-01	Straight Party			REPUBLICAN PARTY (R)	0	0	85	85
-County of Kauai	16-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-County of Kauai	16-01	US Representative	2	D	"HIRONO, Mazie"	0	0	245	245
-County of Kauai	16-01	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
-County of Kauai	16-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Kauai	16-01	State Senate	7	D	"HOOSER, Gary L."	0	0	253	253
-County of Kauai	16-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	60	60
-County of Kauai	16-01	State Representative	16	D	"SAGUM, Roland D., III"	0	0	181	181
-County of Kauai	16-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	807	807
-County of Kauai	16-02	Straight Party			INDEPENDENT PARTY (I)	0	0	13	13
-County of Kauai	16-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-County of Kauai	16-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-County of Kauai	16-02	Straight Party			REPUBLICAN PARTY (R)	0	0	165	165
-County of Kauai	16-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	12	12
-County of Kauai	16-02	US Representative	2	D	"HIRONO, Mazie"	0	0	448	448
-County of Kauai	16-02	US Representative	2	R	"EVANS, Roger B."	0	0	90	90
-County of Kauai	16-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-County of Kauai	16-02	State Senate	7	D	"HOOSER, Gary L."	0	0	549	549
-County of Kauai	16-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	128	128
-County of Kauai	16-02	State Representative	16	D	"SAGUM, Roland D., III"	0	0	349	349
-County of Kauai	16-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	590	590
-County of Kauai	16-03	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
-County of Kauai	16-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Kauai	16-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13
-County of Kauai	16-03	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
-County of Kauai	16-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8
-County of Kauai	16-03	US Representative	2	D	"HIRONO, Mazie"	0	0	377	377
-County of Kauai	16-03	US Representative	2	R	"EVANS, Roger B."	0	0	31	31
-County of Kauai	16-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Kauai	16-03	State Senate	7	D	"HOOSER, Gary L."	0	0	372	372
-County of Kauai	16-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	64	64
-County of Kauai	16-03	State Representative	16	D	"SAGUM, Roland D., III"	0	0	285	285
-County of Kauai	16-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	79	79
-County of Kauai	16-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-County of Kauai	16-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Kauai	16-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Kauai	16-04	Straight Party			REPUBLICAN PARTY (R)	0	0	4	4
-County of Kauai	16-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-County of Kauai	16-04	US Representative	2	D	"HIRONO, Mazie"	0	0	52	52
-County of Kauai	16-04	US Representative	2	R	"EVANS, Roger B."	0	0	3	3
-County of Kauai	16-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Kauai	16-04	State Senate	7	D	"HOOSER, Gary L."	0	0	45	45
-County of Kauai	16-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	2	2
-County of Kauai	16-04	State Representative	16	D	"SAGUM, Roland D., III"	0	0	43	43
-County of Kauai	16-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	373	373
-County of Kauai	16-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-County of Kauai	16-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-County of Kauai	16-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-County of Kauai	16-05	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42
-County of Kauai	16-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-County of Kauai	16-05	US Representative	2	D	"HIRONO, Mazie"	0	0	256	256
-County of Kauai	16-05	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
-County of Kauai	16-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-County of Kauai	16-05	State Senate	7	D	"HOOSER, Gary L."	0	0	203	203
-County of Kauai	16-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	32	32
-County of Kauai	16-05	State Representative	16	D	"SAGUM, Roland D., III"	0	0	203	203
-County of Kauai	16-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	484	484
-County of Kauai	16-06	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
-County of Kauai	16-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-County of Kauai	16-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13
-County of Kauai	16-06	Straight Party			REPUBLICAN PARTY (R)	0	0	68	68
-County of Kauai	16-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	9	9
-County of Kauai	16-06	US Representative	2	D	"HIRONO, Mazie"	0	0	306	306
-County of Kauai	16-06	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
-County of Kauai	16-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-County of Kauai	16-06	State Senate	7	D	"HOOSER, Gary L."	0	0	276	276
-County of Kauai	16-06	State Senate	7	R	"GEORGI, JoAnne S."	0	0	51	51
-County of Kauai	16-06	State Representative	16	D	"SAGUM, Roland D., III"	0	0	240	240
-County of Kauai	16-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	24	24
-County of Kauai	16-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-County of Kauai	16-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-County of Kauai	16-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-County of Kauai	16-07	Straight Party			REPUBLICAN PARTY (R)	0	0	6	6
-County of Kauai	16-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-County of Kauai	16-07	US Representative	2	D	"HIRONO, Mazie"	0	0	6	6
-County of Kauai	16-07	US Representative	2	R	"EVANS, Roger B."	0	0	2	2
-County of Kauai	16-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-County of Kauai	16-07	State Senate	7	D	"HOOSER, Gary L."	0	0	17	17
-County of Kauai	16-07	State Senate	7	R	"GEORGI, JoAnne S."	0	0	4	4
-County of Kauai	16-07	State Representative	16	D	"SAGUM, Roland D., III"	0	0	1	1
-City & County of Honolulu	17-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	433	433
-City & County of Honolulu	17-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	17-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	17-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	17-01	Straight Party			REPUBLICAN PARTY (R)	0	0	167	167
-City & County of Honolulu	17-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	334	334
-City & County of Honolulu	17-01	US Representative	1	R	"TATAII, Steve"	0	0	60	60
-City & County of Honolulu	17-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	17-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	17-01	State Representative	17	D	"MONK, Amy Yukiko"	0	0	281	281
-City & County of Honolulu	17-01	State Representative	17	R	"WARD, Gene"	0	0	153	153
-City & County of Honolulu	17-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317
-City & County of Honolulu	17-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	17-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	17-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	17-02	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
-City & County of Honolulu	17-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	236	236
-City & County of Honolulu	17-02	US Representative	1	R	"TATAII, Steve"	0	0	22	22
-City & County of Honolulu	17-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	17-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	17-02	State Representative	17	D	"MONK, Amy Yukiko"	0	0	191	191
-City & County of Honolulu	17-02	State Representative	17	R	"WARD, Gene"	0	0	79	79
-City & County of Honolulu	17-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	391	391
-City & County of Honolulu	17-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	17-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
-City & County of Honolulu	17-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	17-03	Straight Party			REPUBLICAN PARTY (R)	0	0	292	292
-City & County of Honolulu	17-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	273	273
-City & County of Honolulu	17-03	US Representative	1	R	"TATAII, Steve"	0	0	94	94
-City & County of Honolulu	17-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
-City & County of Honolulu	17-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	17-03	State Representative	17	D	"MONK, Amy Yukiko"	0	0	251	251
-City & County of Honolulu	17-03	State Representative	17	R	"WARD, Gene"	0	0	272	272
-City & County of Honolulu	17-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	168	168
-City & County of Honolulu	17-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	17-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	17-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	17-04	Straight Party			REPUBLICAN PARTY (R)	0	0	132	132
-City & County of Honolulu	17-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	130	130
-City & County of Honolulu	17-04	US Representative	1	R	"TATAII, Steve"	0	0	62	62
-City & County of Honolulu	17-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	17-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	17-04	State Representative	17	D	"MONK, Amy Yukiko"	0	0	120	120
-City & County of Honolulu	17-04	State Representative	17	R	"WARD, Gene"	0	0	130	130
-City & County of Honolulu	17-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	459	459
-City & County of Honolulu	17-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	17-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	17-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
-City & County of Honolulu	17-05	Straight Party			REPUBLICAN PARTY (R)	0	0	282	282
-City & County of Honolulu	17-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	359	359
-City & County of Honolulu	17-05	US Representative	1	R	"TATAII, Steve"	0	0	82	82
-City & County of Honolulu	17-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	17-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	17-05	State Representative	17	D	"MONK, Amy Yukiko"	0	0	264	264
-City & County of Honolulu	17-05	State Representative	17	R	"WARD, Gene"	0	0	274	274
-City & County of Honolulu	17-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	350	350
-City & County of Honolulu	17-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	17-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	17-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	17-06	Straight Party			REPUBLICAN PARTY (R)	0	0	151	151
-City & County of Honolulu	17-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	258	258
-City & County of Honolulu	17-06	US Representative	1	R	"TATAII, Steve"	0	0	34	34
-City & County of Honolulu	17-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	17-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	17-06	State Representative	17	D	"MONK, Amy Yukiko"	0	0	235	235
-City & County of Honolulu	17-06	State Representative	17	R	"WARD, Gene"	0	0	146	146
-City & County of Honolulu	17-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	494	494
-City & County of Honolulu	17-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	17-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	17-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	17-07	Straight Party			REPUBLICAN PARTY (R)	0	0	243	243
-City & County of Honolulu	17-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	382	382
-City & County of Honolulu	17-07	US Representative	1	R	"TATAII, Steve"	0	0	74	74
-City & County of Honolulu	17-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	17-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	17-07	State Representative	17	D	"MONK, Amy Yukiko"	0	0	332	332
-City & County of Honolulu	17-07	State Representative	17	R	"WARD, Gene"	0	0	236	236
-City & County of Honolulu	18-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	156	156
-City & County of Honolulu	18-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	18-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	18-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	18-01	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
-City & County of Honolulu	18-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	120	120
-City & County of Honolulu	18-01	US Representative	1	R	"TATAII, Steve"	0	0	51	51
-City & County of Honolulu	18-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	18-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	18-01	State Representative	18	D	"BERG, Lyla B."	0	0	112	112
-City & County of Honolulu	18-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	420	420
-City & County of Honolulu	18-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	18-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
-City & County of Honolulu	18-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
-City & County of Honolulu	18-02	Straight Party			REPUBLICAN PARTY (R)	0	0	133	133
-City & County of Honolulu	18-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	316	316
-City & County of Honolulu	18-02	US Representative	1	R	"TATAII, Steve"	0	0	121	121
-City & County of Honolulu	18-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5
-City & County of Honolulu	18-02	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	18-02	State Representative	18	D	"BERG, Lyla B."	0	0	277	277
-City & County of Honolulu	18-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	346	346
-City & County of Honolulu	18-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	18-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	18-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	18-03	Straight Party			REPUBLICAN PARTY (R)	0	0	98	98
-City & County of Honolulu	18-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	254	254
-City & County of Honolulu	18-03	US Representative	1	R	"TATAII, Steve"	0	0	87	87
-City & County of Honolulu	18-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	18-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	18-03	State Representative	18	D	"BERG, Lyla B."	0	0	241	241
-City & County of Honolulu	18-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427
-City & County of Honolulu	18-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	18-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-City & County of Honolulu	18-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
-City & County of Honolulu	18-04	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112
-City & County of Honolulu	18-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	308	308
-City & County of Honolulu	18-04	US Representative	1	R	"TATAII, Steve"	0	0	91	91
-City & County of Honolulu	18-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
-City & County of Honolulu	18-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	18-04	State Representative	18	D	"BERG, Lyla B."	0	0	325	325
-City & County of Honolulu	18-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	542	542
-City & County of Honolulu	18-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	18-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
-City & County of Honolulu	18-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	18-05	Straight Party			REPUBLICAN PARTY (R)	0	0	156	156
-City & County of Honolulu	18-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	414	414
-City & County of Honolulu	18-05	US Representative	1	R	"TATAII, Steve"	0	0	146	146
-City & County of Honolulu	18-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	18-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	18-05	State Representative	18	D	"BERG, Lyla B."	0	0	368	368
-City & County of Honolulu	18-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	321	321
-City & County of Honolulu	18-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	18-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
-City & County of Honolulu	18-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	18-06	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48
-City & County of Honolulu	18-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	236	236
-City & County of Honolulu	18-06	US Representative	1	R	"TATAII, Steve"	0	0	42	42
-City & County of Honolulu	18-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	18-06	US Representative	1	L	"ZHAO, Li"	0	0	5	5
-City & County of Honolulu	18-06	State Representative	18	D	"BERG, Lyla B."	0	0	230	230
-City & County of Honolulu	18-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	570	570
-City & County of Honolulu	18-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	18-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
-City & County of Honolulu	18-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	18-07	Straight Party			REPUBLICAN PARTY (R)	0	0	146	146
-City & County of Honolulu	18-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	417	417
-City & County of Honolulu	18-07	US Representative	1	R	"TATAII, Steve"	0	0	130	130
-City & County of Honolulu	18-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	18-07	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	18-07	State Representative	18	D	"BERG, Lyla B."	0	0	356	356
-City & County of Honolulu	19-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	430	430
-City & County of Honolulu	19-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	19-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	19-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	19-01	Straight Party			REPUBLICAN PARTY (R)	0	0	301	301
-City & County of Honolulu	19-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	321	321
-City & County of Honolulu	19-01	US Representative	1	R	"TATAII, Steve"	0	0	101	101
-City & County of Honolulu	19-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	19-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	19-01	State Representative	19	D	"ABE, Michael (Mike)"	0	0	248	248
-City & County of Honolulu	19-01	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	282	282
-City & County of Honolulu	19-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	466	466
-City & County of Honolulu	19-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	19-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	19-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	19-02	Straight Party			REPUBLICAN PARTY (R)	0	0	178	178
-City & County of Honolulu	19-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	363	363
-City & County of Honolulu	19-02	US Representative	1	R	"TATAII, Steve"	0	0	63	63
-City & County of Honolulu	19-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	19-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	19-02	State Representative	19	D	"ABE, Michael (Mike)"	0	0	251	251
-City & County of Honolulu	19-02	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	170	170
-City & County of Honolulu	19-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	355	355
-City & County of Honolulu	19-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	19-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	19-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	19-03	Straight Party			REPUBLICAN PARTY (R)	0	0	120	120
-City & County of Honolulu	19-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	268	268
-City & County of Honolulu	19-03	US Representative	1	R	"TATAII, Steve"	0	0	33	33
-City & County of Honolulu	19-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	19-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	19-03	State Representative	19	D	"ABE, Michael (Mike)"	0	0	203	203
-City & County of Honolulu	19-03	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	112	112
-City & County of Honolulu	19-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	603	603
-City & County of Honolulu	19-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	19-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	19-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	19-04	Straight Party			REPUBLICAN PARTY (R)	0	0	218	218
-City & County of Honolulu	19-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	474	474
-City & County of Honolulu	19-04	US Representative	1	R	"TATAII, Steve"	0	0	68	68
-City & County of Honolulu	19-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	19-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	19-04	State Representative	19	D	"ABE, Michael (Mike)"	0	0	332	332
-City & County of Honolulu	19-04	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	209	209
-City & County of Honolulu	19-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	363	363
-City & County of Honolulu	19-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	19-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	19-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	19-05	Straight Party			REPUBLICAN PARTY (R)	0	0	205	205
-City & County of Honolulu	19-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	281	281
-City & County of Honolulu	19-05	US Representative	1	R	"TATAII, Steve"	0	0	56	56
-City & County of Honolulu	19-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	19-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	19-05	State Representative	19	D	"ABE, Michael (Mike)"	0	0	192	192
-City & County of Honolulu	19-05	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	192	192
-City & County of Honolulu	19-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	326	326
-City & County of Honolulu	19-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	19-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	19-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	19-06	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
-City & County of Honolulu	19-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	257	257
-City & County of Honolulu	19-06	US Representative	1	R	"TATAII, Steve"	0	0	28	28
-City & County of Honolulu	19-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	19-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	19-06	State Representative	19	D	"ABE, Michael (Mike)"	0	0	195	195
-City & County of Honolulu	19-06	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	71	71
-City & County of Honolulu	19-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	233	233
-City & County of Honolulu	19-07	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	19-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	19-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	19-07	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
-City & County of Honolulu	19-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	194	194
-City & County of Honolulu	19-07	US Representative	1	R	"TATAII, Steve"	0	0	22	22
-City & County of Honolulu	19-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	19-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	19-07	State Representative	19	D	"ABE, Michael (Mike)"	0	0	141	141
-City & County of Honolulu	19-07	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	59	59
-City & County of Honolulu	20-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	332	332
-City & County of Honolulu	20-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	20-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	20-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	20-01	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47
-City & County of Honolulu	20-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	271	271
-City & County of Honolulu	20-01	US Representative	1	R	"TATAII, Steve"	0	0	26	26
-City & County of Honolulu	20-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	20-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	20-01	State Representative	20	D	"SAY, Calvin K. Y."	0	0	272	272
-City & County of Honolulu	20-01	State Representative	20	R	"ALLEN, Julia E."	0	0	40	40
-City & County of Honolulu	20-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	406	406
-City & County of Honolulu	20-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	20-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	20-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	20-02	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
-City & County of Honolulu	20-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	307	307
-City & County of Honolulu	20-02	US Representative	1	R	"TATAII, Steve"	0	0	51	51
-City & County of Honolulu	20-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	20-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	20-02	State Representative	20	D	"SAY, Calvin K. Y."	0	0	344	344
-City & County of Honolulu	20-02	State Representative	20	R	"ALLEN, Julia E."	0	0	64	64
-City & County of Honolulu	20-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	284	284
-City & County of Honolulu	20-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	20-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	20-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	20-03	Straight Party			REPUBLICAN PARTY (R)	0	0	72	72
-City & County of Honolulu	20-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	212	212
-City & County of Honolulu	20-03	US Representative	1	R	"TATAII, Steve"	0	0	40	40
-City & County of Honolulu	20-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	20-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	20-03	State Representative	20	D	"SAY, Calvin K. Y."	0	0	197	197
-City & County of Honolulu	20-03	State Representative	20	R	"ALLEN, Julia E."	0	0	57	57
-City & County of Honolulu	20-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421
-City & County of Honolulu	20-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	20-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
-City & County of Honolulu	20-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	20-04	Straight Party			REPUBLICAN PARTY (R)	0	0	86	86
-City & County of Honolulu	20-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	346	346
-City & County of Honolulu	20-04	US Representative	1	R	"TATAII, Steve"	0	0	53	53
-City & County of Honolulu	20-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	20-04	US Representative	1	L	"ZHAO, Li"	0	0	6	6
-City & County of Honolulu	20-04	State Representative	20	D	"SAY, Calvin K. Y."	0	0	295	295
-City & County of Honolulu	20-04	State Representative	20	R	"ALLEN, Julia E."	0	0	68	68
-City & County of Honolulu	20-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	646	646
-City & County of Honolulu	20-05	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14
-City & County of Honolulu	20-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-City & County of Honolulu	20-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
-City & County of Honolulu	20-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
-City & County of Honolulu	20-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	483	483
-City & County of Honolulu	20-05	US Representative	1	R	"TATAII, Steve"	0	0	42	42
-City & County of Honolulu	20-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	20-05	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	20-05	State Representative	20	D	"SAY, Calvin K. Y."	0	0	561	561
-City & County of Honolulu	20-05	State Representative	20	R	"ALLEN, Julia E."	0	0	67	67
-City & County of Honolulu	20-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	569	569
-City & County of Honolulu	20-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	20-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	20-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	20-06	Straight Party			REPUBLICAN PARTY (R)	0	0	114	114
-City & County of Honolulu	20-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	426	426
-City & County of Honolulu	20-06	US Representative	1	R	"TATAII, Steve"	0	0	65	65
-City & County of Honolulu	20-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	20-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	20-06	State Representative	20	D	"SAY, Calvin K. Y."	0	0	463	463
-City & County of Honolulu	20-06	State Representative	20	R	"ALLEN, Julia E."	0	0	99	99
-City & County of Honolulu	21-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	353	353
-City & County of Honolulu	21-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	21-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	21-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	21-01	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
-City & County of Honolulu	21-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	255	255
-City & County of Honolulu	21-01	US Representative	1	R	"TATAII, Steve"	0	0	38	38
-City & County of Honolulu	21-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	21-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	21-01	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	264	264
-City & County of Honolulu	21-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	645	645
-City & County of Honolulu	21-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	21-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	21-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
-City & County of Honolulu	21-02	Straight Party			REPUBLICAN PARTY (R)	0	0	87	87
-City & County of Honolulu	21-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	472	472
-City & County of Honolulu	21-02	US Representative	1	R	"TATAII, Steve"	0	0	78	78
-City & County of Honolulu	21-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	21-02	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	21-02	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	515	515
-City & County of Honolulu	21-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	483	483
-City & County of Honolulu	21-03	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
-City & County of Honolulu	21-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
-City & County of Honolulu	21-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	14	14
-City & County of Honolulu	21-03	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
-City & County of Honolulu	21-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	383	383
-City & County of Honolulu	21-03	US Representative	1	R	"TATAII, Steve"	0	0	98	98
-City & County of Honolulu	21-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	21-03	US Representative	1	L	"ZHAO, Li"	0	0	8	8
-City & County of Honolulu	21-03	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	322	322
-City & County of Honolulu	21-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	265	265
-City & County of Honolulu	21-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	21-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	21-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	21-04	Straight Party			REPUBLICAN PARTY (R)	0	0	98	98
-City & County of Honolulu	21-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	192	192
-City & County of Honolulu	21-04	US Representative	1	R	"TATAII, Steve"	0	0	92	92
-City & County of Honolulu	21-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
-City & County of Honolulu	21-04	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	21-04	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	184	184
-City & County of Honolulu	21-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267
-City & County of Honolulu	21-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	21-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	21-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	21-05	Straight Party			REPUBLICAN PARTY (R)	0	0	99	99
-City & County of Honolulu	21-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	216	216
-City & County of Honolulu	21-05	US Representative	1	R	"TATAII, Steve"	0	0	54	54
-City & County of Honolulu	21-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	21-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	21-05	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	134	134
-City & County of Honolulu	21-05	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	50	50
-City & County of Honolulu	21-05	State Senate	12	R	"TRIMBLE, Gordon"	0	0	92	92
-City & County of Honolulu	21-05	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	171	171
-City & County of Honolulu	21-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	252	252
-City & County of Honolulu	21-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	21-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	21-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	21-06	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
-City & County of Honolulu	21-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	191	191
-City & County of Honolulu	21-06	US Representative	1	R	"TATAII, Steve"	0	0	18	18
-City & County of Honolulu	21-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	21-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	21-06	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	187	187
-City & County of Honolulu	22-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	120	120
-City & County of Honolulu	22-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	22-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	22-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	22-01	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
-City & County of Honolulu	22-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	91	91
-City & County of Honolulu	22-01	US Representative	1	R	"TATAII, Steve"	0	0	17	17
-City & County of Honolulu	22-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	22-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	22-01	State Representative	22	D	"SAIKI, Scott K."	0	0	81	81
-City & County of Honolulu	22-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236
-City & County of Honolulu	22-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	22-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	22-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	22-02	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
-City & County of Honolulu	22-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	203	203
-City & County of Honolulu	22-02	US Representative	1	R	"TATAII, Steve"	0	0	25	25
-City & County of Honolulu	22-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	22-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	22-02	State Representative	22	D	"SAIKI, Scott K."	0	0	169	169
-City & County of Honolulu	22-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	100	100
-City & County of Honolulu	22-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	22-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	22-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	22-03	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14
-City & County of Honolulu	22-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	81	81
-City & County of Honolulu	22-03	US Representative	1	R	"TATAII, Steve"	0	0	11	11
-City & County of Honolulu	22-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	22-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	22-03	State Representative	22	D	"SAIKI, Scott K."	0	0	58	58
-City & County of Honolulu	22-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293
-City & County of Honolulu	22-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	22-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-City & County of Honolulu	22-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	22-04	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
-City & County of Honolulu	22-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	225	225
-City & County of Honolulu	22-04	US Representative	1	R	"TATAII, Steve"	0	0	42	42
-City & County of Honolulu	22-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
-City & County of Honolulu	22-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	22-04	State Representative	22	D	"SAIKI, Scott K."	0	0	220	220
-City & County of Honolulu	22-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	292	292
-City & County of Honolulu	22-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	22-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
-City & County of Honolulu	22-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	22-05	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43
-City & County of Honolulu	22-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	226	226
-City & County of Honolulu	22-05	US Representative	1	R	"TATAII, Steve"	0	0	40	40
-City & County of Honolulu	22-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5
-City & County of Honolulu	22-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	22-05	State Representative	22	D	"SAIKI, Scott K."	0	0	214	214
-City & County of Honolulu	22-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	374	374
-City & County of Honolulu	22-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	22-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	22-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	22-06	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48
-City & County of Honolulu	22-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	283	283
-City & County of Honolulu	22-06	US Representative	1	R	"TATAII, Steve"	0	0	41	41
-City & County of Honolulu	22-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	22-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	22-06	State Representative	22	D	"SAIKI, Scott K."	0	0	243	243
-City & County of Honolulu	22-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	279	279
-City & County of Honolulu	22-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	22-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	22-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	22-07	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75
-City & County of Honolulu	22-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	222	222
-City & County of Honolulu	22-07	US Representative	1	R	"TATAII, Steve"	0	0	67	67
-City & County of Honolulu	22-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	22-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	22-07	State Representative	22	D	"SAIKI, Scott K."	0	0	175	175
-City & County of Honolulu	23-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
-City & County of Honolulu	23-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	23-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	23-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	23-01	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
-City & County of Honolulu	23-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	150	150
-City & County of Honolulu	23-01	US Representative	1	R	"TATAII, Steve"	0	0	45	45
-City & County of Honolulu	23-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	23-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	23-01	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	96	96
-City & County of Honolulu	23-01	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	35	35
-City & County of Honolulu	23-01	State Senate	12	R	"TRIMBLE, Gordon"	0	0	63	63
-City & County of Honolulu	23-01	State Representative	23	D	"BROWER, Tom"	0	0	115	115
-City & County of Honolulu	23-01	State Representative	23	R	"STEVENS, Anne V."	0	0	61	61
-City & County of Honolulu	23-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200
-City & County of Honolulu	23-02	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	23-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	23-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	23-02	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
-City & County of Honolulu	23-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	152	152
-City & County of Honolulu	23-02	US Representative	1	R	"TATAII, Steve"	0	0	59	59
-City & County of Honolulu	23-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	23-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	23-02	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	109	109
-City & County of Honolulu	23-02	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	40	40
-City & County of Honolulu	23-02	State Senate	12	R	"TRIMBLE, Gordon"	0	0	77	77
-City & County of Honolulu	23-02	State Representative	23	D	"BROWER, Tom"	0	0	133	133
-City & County of Honolulu	23-02	State Representative	23	R	"STEVENS, Anne V."	0	0	77	77
-City & County of Honolulu	23-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	352	352
-City & County of Honolulu	23-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	23-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	23-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	23-03	Straight Party			REPUBLICAN PARTY (R)	0	0	185	185
-City & County of Honolulu	23-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	289	289
-City & County of Honolulu	23-03	US Representative	1	R	"TATAII, Steve"	0	0	99	99
-City & County of Honolulu	23-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	23-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	23-03	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	202	202
-City & County of Honolulu	23-03	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	62	62
-City & County of Honolulu	23-03	State Senate	12	R	"TRIMBLE, Gordon"	0	0	131	131
-City & County of Honolulu	23-03	State Representative	23	D	"BROWER, Tom"	0	0	244	244
-City & County of Honolulu	23-03	State Representative	23	R	"STEVENS, Anne V."	0	0	147	147
-City & County of Honolulu	23-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	314	314
-City & County of Honolulu	23-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	23-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	23-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	23-04	Straight Party			REPUBLICAN PARTY (R)	0	0	146	146
-City & County of Honolulu	23-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	265	265
-City & County of Honolulu	23-04	US Representative	1	R	"TATAII, Steve"	0	0	68	68
-City & County of Honolulu	23-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	23-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	23-04	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	173	173
-City & County of Honolulu	23-04	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	42	42
-City & County of Honolulu	23-04	State Senate	12	R	"TRIMBLE, Gordon"	0	0	105	105
-City & County of Honolulu	23-04	State Representative	23	D	"BROWER, Tom"	0	0	193	193
-City & County of Honolulu	23-04	State Representative	23	R	"STEVENS, Anne V."	0	0	111	111
-City & County of Honolulu	24-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	753	753
-City & County of Honolulu	24-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	24-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	24-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
-City & County of Honolulu	24-01	Straight Party			REPUBLICAN PARTY (R)	0	0	109	109
-City & County of Honolulu	24-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	558	558
-City & County of Honolulu	24-01	US Representative	1	R	"TATAII, Steve"	0	0	42	42
-City & County of Honolulu	24-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	24-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	24-01	State Representative	24	D	"CHOY, Isaac W."	0	0	476	476
-City & County of Honolulu	24-01	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	101	101
-City & County of Honolulu	24-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	414	414
-City & County of Honolulu	24-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	24-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	24-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	24-02	Straight Party			REPUBLICAN PARTY (R)	0	0	76	76
-City & County of Honolulu	24-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	309	309
-City & County of Honolulu	24-02	US Representative	1	R	"TATAII, Steve"	0	0	38	38
-City & County of Honolulu	24-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	24-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	24-02	State Representative	24	D	"CHOY, Isaac W."	0	0	247	247
-City & County of Honolulu	24-02	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	70	70
-City & County of Honolulu	24-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	346	346
-City & County of Honolulu	24-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	24-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	24-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	24-03	Straight Party			REPUBLICAN PARTY (R)	0	0	62	62
-City & County of Honolulu	24-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	280	280
-City & County of Honolulu	24-03	US Representative	1	R	"TATAII, Steve"	0	0	34	34
-City & County of Honolulu	24-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	24-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	24-03	State Representative	24	D	"CHOY, Isaac W."	0	0	169	169
-City & County of Honolulu	24-03	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	51	51
-City & County of Honolulu	24-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	414	414
-City & County of Honolulu	24-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	24-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	14	14
-City & County of Honolulu	24-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	24-04	Straight Party			REPUBLICAN PARTY (R)	0	0	91	91
-City & County of Honolulu	24-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	338	338
-City & County of Honolulu	24-04	US Representative	1	R	"TATAII, Steve"	0	0	44	44
-City & County of Honolulu	24-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5
-City & County of Honolulu	24-04	US Representative	1	L	"ZHAO, Li"	0	0	9	9
-City & County of Honolulu	24-04	State Representative	24	D	"CHOY, Isaac W."	0	0	177	177
-City & County of Honolulu	24-04	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	79	79
-City & County of Honolulu	24-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	565	565
-City & County of Honolulu	24-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	24-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
-City & County of Honolulu	24-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	24-05	Straight Party			REPUBLICAN PARTY (R)	0	0	111	111
-City & County of Honolulu	24-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	422	422
-City & County of Honolulu	24-05	US Representative	1	R	"TATAII, Steve"	0	0	57	57
-City & County of Honolulu	24-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	24-05	US Representative	1	L	"ZHAO, Li"	0	0	6	6
-City & County of Honolulu	24-05	State Representative	24	D	"CHOY, Isaac W."	0	0	337	337
-City & County of Honolulu	24-05	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	93	93
-City & County of Honolulu	24-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	671	671
-City & County of Honolulu	24-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	24-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-City & County of Honolulu	24-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	24-06	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115
-City & County of Honolulu	24-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	502	502
-City & County of Honolulu	24-06	US Representative	1	R	"TATAII, Steve"	0	0	54	54
-City & County of Honolulu	24-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	6	6
-City & County of Honolulu	24-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	24-06	State Representative	24	D	"CHOY, Isaac W."	0	0	409	409
-City & County of Honolulu	24-06	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	103	103
-City & County of Honolulu	25-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	375	375
-City & County of Honolulu	25-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	25-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	25-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	25-01	Straight Party			REPUBLICAN PARTY (R)	0	0	94	94
-City & County of Honolulu	25-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	279	279
-City & County of Honolulu	25-01	US Representative	1	R	"TATAII, Steve"	0	0	86	86
-City & County of Honolulu	25-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	25-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	25-01	State Representative	25	D	"BELATTI, Della A."	0	0	236	236
-City & County of Honolulu	25-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	377	377
-City & County of Honolulu	25-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	25-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-City & County of Honolulu	25-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	25-02	Straight Party			REPUBLICAN PARTY (R)	0	0	74	74
-City & County of Honolulu	25-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	297	297
-City & County of Honolulu	25-02	US Representative	1	R	"TATAII, Steve"	0	0	64	64
-City & County of Honolulu	25-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	25-02	US Representative	1	L	"ZHAO, Li"	0	0	5	5
-City & County of Honolulu	25-02	State Representative	25	D	"BELATTI, Della A."	0	0	250	250
-City & County of Honolulu	25-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	31	31
-City & County of Honolulu	25-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	25-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	25-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	25-03	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
-City & County of Honolulu	25-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	21	21
-City & County of Honolulu	25-03	US Representative	1	R	"TATAII, Steve"	0	0	7	7
-City & County of Honolulu	25-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	25-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	25-03	State Representative	25	D	"BELATTI, Della A."	0	0	19	19
-City & County of Honolulu	25-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	186	186
-City & County of Honolulu	25-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	25-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	25-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	25-04	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31
-City & County of Honolulu	25-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	147	147
-City & County of Honolulu	25-04	US Representative	1	R	"TATAII, Steve"	0	0	29	29
-City & County of Honolulu	25-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	25-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	25-04	State Representative	25	D	"BELATTI, Della A."	0	0	95	95
-City & County of Honolulu	25-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	394	394
-City & County of Honolulu	25-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	25-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	25-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	25-05	Straight Party			REPUBLICAN PARTY (R)	0	0	88	88
-City & County of Honolulu	25-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	318	318
-City & County of Honolulu	25-05	US Representative	1	R	"TATAII, Steve"	0	0	82	82
-City & County of Honolulu	25-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	25-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	25-05	State Representative	25	D	"BELATTI, Della A."	0	0	240	240
-City & County of Honolulu	25-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	316	316
-City & County of Honolulu	25-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	25-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	25-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	25-06	Straight Party			REPUBLICAN PARTY (R)	0	0	65	65
-City & County of Honolulu	25-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	256	256
-City & County of Honolulu	25-06	US Representative	1	R	"TATAII, Steve"	0	0	57	57
-City & County of Honolulu	25-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	25-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	25-06	State Representative	25	D	"BELATTI, Della A."	0	0	203	203
-City & County of Honolulu	25-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	285	285
-City & County of Honolulu	25-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	25-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	25-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	25-07	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
-City & County of Honolulu	25-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	225	225
-City & County of Honolulu	25-07	US Representative	1	R	"TATAII, Steve"	0	0	51	51
-City & County of Honolulu	25-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	25-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	25-07	State Representative	25	D	"BELATTI, Della A."	0	0	172	172
-City & County of Honolulu	26-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	598	598
-City & County of Honolulu	26-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	26-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
-City & County of Honolulu	26-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	26-01	Straight Party			REPUBLICAN PARTY (R)	0	0	66	66
-City & County of Honolulu	26-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	463	463
-City & County of Honolulu	26-01	US Representative	1	R	"TATAII, Steve"	0	0	55	55
-City & County of Honolulu	26-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	26-01	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	26-01	State Representative	26	D	"LUKE, Sylvia"	0	0	480	480
-City & County of Honolulu	26-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	185	185
-City & County of Honolulu	26-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	26-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	26-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	26-02	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15
-City & County of Honolulu	26-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	153	153
-City & County of Honolulu	26-02	US Representative	1	R	"TATAII, Steve"	0	0	14	14
-City & County of Honolulu	26-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	26-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	26-02	State Representative	26	D	"LUKE, Sylvia"	0	0	128	128
-City & County of Honolulu	26-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	300	300
-City & County of Honolulu	26-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	26-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	26-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
-City & County of Honolulu	26-03	Straight Party			REPUBLICAN PARTY (R)	0	0	68	68
-City & County of Honolulu	26-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	248	248
-City & County of Honolulu	26-03	US Representative	1	R	"TATAII, Steve"	0	0	62	62
-City & County of Honolulu	26-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	26-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	26-03	State Representative	26	D	"LUKE, Sylvia"	0	0	199	199
-City & County of Honolulu	26-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	207	207
-City & County of Honolulu	26-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	26-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	26-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	26-04	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
-City & County of Honolulu	26-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	163	163
-City & County of Honolulu	26-04	US Representative	1	R	"TATAII, Steve"	0	0	48	48
-City & County of Honolulu	26-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	26-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	26-04	State Representative	26	D	"LUKE, Sylvia"	0	0	129	129
-City & County of Honolulu	26-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
-City & County of Honolulu	26-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	26-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
-City & County of Honolulu	26-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	26-05	Straight Party			REPUBLICAN PARTY (R)	1	0	52	53
-City & County of Honolulu	26-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	252	252
-City & County of Honolulu	26-05	US Representative	1	R	"TATAII, Steve"	1	0	47	48
-City & County of Honolulu	26-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	26-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	26-05	State Representative	26	D	"LUKE, Sylvia"	0	0	220	220
-City & County of Honolulu	26-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	575	575
-City & County of Honolulu	26-06	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	26-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	9	9
-City & County of Honolulu	26-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	17	17
-City & County of Honolulu	26-06	Straight Party			REPUBLICAN PARTY (R)	0	0	126	126
-City & County of Honolulu	26-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	454	454
-City & County of Honolulu	26-06	US Representative	1	R	"TATAII, Steve"	0	0	117	117
-City & County of Honolulu	26-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	26-06	US Representative	1	L	"ZHAO, Li"	0	0	7	7
-City & County of Honolulu	26-06	State Representative	26	D	"LUKE, Sylvia"	0	0	418	418
-City & County of Honolulu	26-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	623	623
-City & County of Honolulu	26-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	26-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
-City & County of Honolulu	26-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	26-07	Straight Party			REPUBLICAN PARTY (R)	0	0	139	139
-City & County of Honolulu	26-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	451	451
-City & County of Honolulu	26-07	US Representative	1	R	"TATAII, Steve"	0	0	125	125
-City & County of Honolulu	26-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	26-07	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	26-07	State Representative	26	D	"LUKE, Sylvia"	0	0	485	485
-City & County of Honolulu	27-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	65	65
-City & County of Honolulu	27-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	27-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	27-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	27-01	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
-City & County of Honolulu	27-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	55	55
-City & County of Honolulu	27-01	US Representative	1	R	"TATAII, Steve"	0	0	6	6
-City & County of Honolulu	27-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	27-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	27-01	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	34	34
-City & County of Honolulu	27-01	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	19	19
-City & County of Honolulu	27-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	292	292
-City & County of Honolulu	27-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	27-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	27-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	27-02	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59
-City & County of Honolulu	27-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	240	240
-City & County of Honolulu	27-02	US Representative	1	R	"TATAII, Steve"	0	0	27	27
-City & County of Honolulu	27-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	27-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	27-02	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	174	174
-City & County of Honolulu	27-02	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	56	56
-City & County of Honolulu	27-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	668	668
-City & County of Honolulu	27-03	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	27-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	27-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	27-03	Straight Party			REPUBLICAN PARTY (R)	0	0	199	199
-City & County of Honolulu	27-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	540	540
-City & County of Honolulu	27-03	US Representative	1	R	"TATAII, Steve"	0	0	54	54
-City & County of Honolulu	27-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	27-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	27-03	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	406	406
-City & County of Honolulu	27-03	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	189	189
-City & County of Honolulu	27-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	122	122
-City & County of Honolulu	27-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	27-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	27-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	27-04	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35
-City & County of Honolulu	27-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	98	98
-City & County of Honolulu	27-04	US Representative	1	R	"TATAII, Steve"	0	0	11	11
-City & County of Honolulu	27-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	27-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	27-04	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	64	64
-City & County of Honolulu	27-04	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	34	34
-City & County of Honolulu	27-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	231	231
-City & County of Honolulu	27-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	27-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	27-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	27-05	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
-City & County of Honolulu	27-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	203	203
-City & County of Honolulu	27-05	US Representative	1	R	"TATAII, Steve"	0	0	15	15
-City & County of Honolulu	27-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
-City & County of Honolulu	27-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	27-05	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	77	77
-City & County of Honolulu	27-05	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	49	49
-City & County of Honolulu	27-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	348	348
-City & County of Honolulu	27-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	27-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	27-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	27-06	Straight Party			REPUBLICAN PARTY (R)	0	0	93	93
-City & County of Honolulu	27-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	298	298
-City & County of Honolulu	27-06	US Representative	1	R	"TATAII, Steve"	0	0	31	31
-City & County of Honolulu	27-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	27-06	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	27-06	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	161	161
-City & County of Honolulu	27-06	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	89	89
-City & County of Honolulu	27-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	112	112
-City & County of Honolulu	27-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	27-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	27-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	27-07	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31
-City & County of Honolulu	27-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	93	93
-City & County of Honolulu	27-07	US Representative	1	R	"TATAII, Steve"	0	0	11	11
-City & County of Honolulu	27-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	27-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	27-07	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	37	37
-City & County of Honolulu	27-07	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	27	27
-City & County of Honolulu	27-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	266	266
-City & County of Honolulu	27-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	27-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	27-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	27-08	Straight Party			REPUBLICAN PARTY (R)	0	0	84	84
-City & County of Honolulu	27-08	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	223	223
-City & County of Honolulu	27-08	US Representative	1	R	"TATAII, Steve"	0	0	31	31
-City & County of Honolulu	27-08	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	27-08	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	27-08	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	137	137
-City & County of Honolulu	27-08	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	79	79
-City & County of Honolulu	28-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200
-City & County of Honolulu	28-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	28-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	28-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	28-01	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
-City & County of Honolulu	28-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	155	155
-City & County of Honolulu	28-01	US Representative	1	R	"TATAII, Steve"	0	0	25	25
-City & County of Honolulu	28-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	28-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	28-01	State Representative	28	D	"RHOADS, Karl"	0	0	118	118
-City & County of Honolulu	28-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	235	235
-City & County of Honolulu	28-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	28-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	28-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	28-02	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53
-City & County of Honolulu	28-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	191	191
-City & County of Honolulu	28-02	US Representative	1	R	"TATAII, Steve"	0	0	50	50
-City & County of Honolulu	28-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
-City & County of Honolulu	28-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	28-02	State Representative	28	D	"RHOADS, Karl"	0	0	101	101
-City & County of Honolulu	28-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	135	135
-City & County of Honolulu	28-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	28-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	28-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	28-03	Straight Party			REPUBLICAN PARTY (R)	0	0	52	52
-City & County of Honolulu	28-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	110	110
-City & County of Honolulu	28-03	US Representative	1	R	"TATAII, Steve"	0	0	29	29
-City & County of Honolulu	28-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	28-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	28-03	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	83	83
-City & County of Honolulu	28-03	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	18	18
-City & County of Honolulu	28-03	State Senate	12	R	"TRIMBLE, Gordon"	0	0	47	47
-City & County of Honolulu	28-03	State Representative	28	D	"RHOADS, Karl"	0	0	83	83
-City & County of Honolulu	28-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
-City & County of Honolulu	28-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	28-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	28-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	28-04	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
-City & County of Honolulu	28-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	145	145
-City & County of Honolulu	28-04	US Representative	1	R	"TATAII, Steve"	0	0	34	34
-City & County of Honolulu	28-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	28-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	28-04	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	110	110
-City & County of Honolulu	28-04	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	29	29
-City & County of Honolulu	28-04	State Senate	12	R	"TRIMBLE, Gordon"	0	0	40	40
-City & County of Honolulu	28-04	State Representative	28	D	"RHOADS, Karl"	0	0	127	127
-City & County of Honolulu	28-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	521	521
-City & County of Honolulu	28-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	28-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
-City & County of Honolulu	28-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
-City & County of Honolulu	28-05	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108
-City & County of Honolulu	28-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	386	386
-City & County of Honolulu	28-05	US Representative	1	R	"TATAII, Steve"	0	0	68	68
-City & County of Honolulu	28-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	28-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	28-05	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	293	293
-City & County of Honolulu	28-05	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	85	85
-City & County of Honolulu	28-05	State Senate	12	R	"TRIMBLE, Gordon"	0	0	94	94
-City & County of Honolulu	28-05	State Representative	28	D	"RHOADS, Karl"	0	0	327	327
-City & County of Honolulu	28-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	138	138
-City & County of Honolulu	28-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	28-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	28-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	28-06	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22
-City & County of Honolulu	28-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	115	115
-City & County of Honolulu	28-06	US Representative	1	R	"TATAII, Steve"	0	0	16	16
-City & County of Honolulu	28-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	28-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	28-06	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	67	67
-City & County of Honolulu	28-06	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	23	23
-City & County of Honolulu	28-06	State Senate	12	R	"TRIMBLE, Gordon"	0	0	17	17
-City & County of Honolulu	28-06	State Representative	28	D	"RHOADS, Karl"	0	0	98	98
-City & County of Honolulu	29-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	360	360
-City & County of Honolulu	29-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	29-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	29-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	29-01	Straight Party			REPUBLICAN PARTY (R)	0	0	50	50
-City & County of Honolulu	29-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	265	265
-City & County of Honolulu	29-01	US Representative	1	R	"TATAII, Steve"	0	0	31	31
-City & County of Honolulu	29-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	29-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	29-01	State Representative	29	D	"MANAHAN, Joey"	0	0	252	252
-City & County of Honolulu	29-01	State Representative	29	R	"YAW, Shane D. K."	0	0	34	34
-City & County of Honolulu	29-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	389	389
-City & County of Honolulu	29-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	29-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	29-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	29-02	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
-City & County of Honolulu	29-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	320	320
-City & County of Honolulu	29-02	US Representative	1	R	"TATAII, Steve"	0	0	28	28
-City & County of Honolulu	29-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	29-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	29-02	State Representative	29	D	"MANAHAN, Joey"	0	0	290	290
-City & County of Honolulu	29-02	State Representative	29	R	"YAW, Shane D. K."	0	0	33	33
-City & County of Honolulu	29-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	265	265
-City & County of Honolulu	29-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	29-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	29-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	29-03	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
-City & County of Honolulu	29-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	211	211
-City & County of Honolulu	29-03	US Representative	1	R	"TATAII, Steve"	0	0	13	13
-City & County of Honolulu	29-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	29-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	29-03	State Representative	29	D	"MANAHAN, Joey"	0	0	173	173
-City & County of Honolulu	29-03	State Representative	29	R	"YAW, Shane D. K."	0	0	15	15
-City & County of Honolulu	29-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129
-City & County of Honolulu	29-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	29-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	29-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	29-04	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32
-City & County of Honolulu	29-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	109	109
-City & County of Honolulu	29-04	US Representative	1	R	"TATAII, Steve"	0	0	25	25
-City & County of Honolulu	29-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	29-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	29-04	State Representative	29	D	"MANAHAN, Joey"	0	0	64	64
-City & County of Honolulu	29-04	State Representative	29	R	"YAW, Shane D. K."	0	0	20	20
-City & County of Honolulu	29-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236
-City & County of Honolulu	29-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	29-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	29-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	29-05	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
-City & County of Honolulu	29-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	180	180
-City & County of Honolulu	29-05	US Representative	1	R	"TATAII, Steve"	0	0	10	10
-City & County of Honolulu	29-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	29-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	29-05	State Representative	29	D	"MANAHAN, Joey"	0	0	180	180
-City & County of Honolulu	29-05	State Representative	29	R	"YAW, Shane D. K."	0	0	9	9
-City & County of Honolulu	30-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	395	395
-City & County of Honolulu	30-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	30-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	30-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	30-01	Straight Party			REPUBLICAN PARTY (R)	0	0	70	70
-City & County of Honolulu	30-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	313	313
-City & County of Honolulu	30-01	US Representative	1	R	"TATAII, Steve"	0	0	67	67
-City & County of Honolulu	30-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	30-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	30-01	State Representative	30	D	"MIZUNO, John"	0	0	314	314
-City & County of Honolulu	30-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	339	339
-City & County of Honolulu	30-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	30-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	30-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	30-02	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
-City & County of Honolulu	30-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	264	264
-City & County of Honolulu	30-02	US Representative	1	R	"TATAII, Steve"	0	0	42	42
-City & County of Honolulu	30-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	30-02	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	30-02	State Representative	30	D	"MIZUNO, John"	0	0	242	242
-City & County of Honolulu	30-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	256	256
-City & County of Honolulu	30-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	30-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	30-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	30-03	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
-City & County of Honolulu	30-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	201	201
-City & County of Honolulu	30-03	US Representative	1	R	"TATAII, Steve"	0	0	26	26
-City & County of Honolulu	30-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	30-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	30-03	State Representative	30	D	"MIZUNO, John"	0	0	175	175
-City & County of Honolulu	30-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	175	175
-City & County of Honolulu	30-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	30-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	30-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	30-04	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
-City & County of Honolulu	30-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	127	127
-City & County of Honolulu	30-04	US Representative	1	R	"TATAII, Steve"	0	0	12	12
-City & County of Honolulu	30-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	30-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	30-04	State Representative	30	D	"MIZUNO, John"	0	0	147	147
-City & County of Honolulu	30-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	56	56
-City & County of Honolulu	30-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	30-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	30-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	30-05	Straight Party			REPUBLICAN PARTY (R)	0	0	18	18
-City & County of Honolulu	30-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	41	41
-City & County of Honolulu	30-05	US Representative	1	R	"TATAII, Steve"	0	0	17	17
-City & County of Honolulu	30-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	30-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	30-05	State Representative	30	D	"MIZUNO, John"	0	0	31	31
-City & County of Honolulu	30-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	470	470
-City & County of Honolulu	30-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	30-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	30-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	30-06	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59
-City & County of Honolulu	30-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	394	394
-City & County of Honolulu	30-06	US Representative	1	R	"TATAII, Steve"	0	0	57	57
-City & County of Honolulu	30-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	30-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	30-06	State Representative	30	D	"MIZUNO, John"	0	0	345	345
-City & County of Honolulu	31-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	491	491
-City & County of Honolulu	31-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	31-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	31-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	31-01	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54
-City & County of Honolulu	31-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	357	357
-City & County of Honolulu	31-01	US Representative	1	R	"TATAII, Steve"	0	0	46	46
-City & County of Honolulu	31-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	31-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	31-01	State Representative	31	D	"WAKAI, Glenn"	0	0	417	417
-City & County of Honolulu	31-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	515	515
-City & County of Honolulu	31-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	31-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
-City & County of Honolulu	31-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	31-02	Straight Party			REPUBLICAN PARTY (R)	0	0	72	72
-City & County of Honolulu	31-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	412	412
-City & County of Honolulu	31-02	US Representative	1	R	"TATAII, Steve"	0	0	66	66
-City & County of Honolulu	31-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	31-02	US Representative	1	L	"ZHAO, Li"	0	0	10	10
-City & County of Honolulu	31-02	State Representative	31	D	"WAKAI, Glenn"	0	0	413	413
-City & County of Honolulu	31-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	333	333
-City & County of Honolulu	31-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	31-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	31-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
-City & County of Honolulu	31-03	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55
-City & County of Honolulu	31-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	264	264
-City & County of Honolulu	31-03	US Representative	1	R	"TATAII, Steve"	0	0	53	53
-City & County of Honolulu	31-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	31-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	31-03	State Representative	31	D	"WAKAI, Glenn"	0	0	262	262
-City & County of Honolulu	31-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	347	347
-City & County of Honolulu	31-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	31-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	31-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
-City & County of Honolulu	31-04	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75
-City & County of Honolulu	31-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	261	261
-City & County of Honolulu	31-04	US Representative	1	R	"TATAII, Steve"	0	0	67	67
-City & County of Honolulu	31-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	31-04	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	31-04	State Representative	31	D	"WAKAI, Glenn"	0	0	261	261
-City & County of Honolulu	31-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	634	634
-City & County of Honolulu	31-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	31-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	31-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	31-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
-City & County of Honolulu	31-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	483	483
-City & County of Honolulu	31-05	US Representative	1	R	"TATAII, Steve"	0	0	74	74
-City & County of Honolulu	31-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	31-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	31-05	State Representative	31	D	"WAKAI, Glenn"	0	0	515	515
-City & County of Honolulu	32-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	429	429
-City & County of Honolulu	32-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	32-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	32-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	32-01	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
-City & County of Honolulu	32-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	390	390
-City & County of Honolulu	32-01	US Representative	1	R	"TATAII, Steve"	0	0	42	42
-City & County of Honolulu	32-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	32-01	State Representative	32	R	"FINNEGAN, Lynn"	0	0	95	95
-City & County of Honolulu	32-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	42	42
-City & County of Honolulu	32-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	32-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	32-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	32-02	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
-City & County of Honolulu	32-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	40	40
-City & County of Honolulu	32-02	US Representative	1	R	"TATAII, Steve"	0	0	3	3
-City & County of Honolulu	32-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	32-02	State Representative	32	R	"FINNEGAN, Lynn"	0	0	9	9
-City & County of Honolulu	32-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	22	22
-City & County of Honolulu	32-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	32-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	32-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	32-03	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19
-City & County of Honolulu	32-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	19	19
-City & County of Honolulu	32-03	US Representative	1	R	"TATAII, Steve"	0	0	13	13
-City & County of Honolulu	32-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	32-03	State Representative	32	R	"FINNEGAN, Lynn"	0	0	13	13
-City & County of Honolulu	32-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	210	210
-City & County of Honolulu	32-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	32-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	32-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	32-04	Straight Party			REPUBLICAN PARTY (R)	0	0	65	65
-City & County of Honolulu	32-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	201	201
-City & County of Honolulu	32-04	US Representative	1	R	"TATAII, Steve"	0	0	23	23
-City & County of Honolulu	32-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	32-04	State Representative	32	R	"FINNEGAN, Lynn"	0	0	61	61
-City & County of Honolulu	32-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	471	471
-City & County of Honolulu	32-05	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
-City & County of Honolulu	32-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	32-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	32-05	Straight Party			REPUBLICAN PARTY (R)	0	0	255	255
-City & County of Honolulu	32-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	429	429
-City & County of Honolulu	32-05	US Representative	1	R	"TATAII, Steve"	0	0	98	98
-City & County of Honolulu	32-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	32-05	State Representative	32	R	"FINNEGAN, Lynn"	0	0	235	235
-City & County of Honolulu	32-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	211	211
-City & County of Honolulu	32-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	32-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	32-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	32-06	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
-City & County of Honolulu	32-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	193	193
-City & County of Honolulu	32-06	US Representative	1	R	"TATAII, Steve"	0	0	19	19
-City & County of Honolulu	32-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	32-06	State Representative	32	R	"FINNEGAN, Lynn"	0	0	48	48
-City & County of Honolulu	32-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	145	145
-City & County of Honolulu	32-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	32-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	32-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	32-07	Straight Party			REPUBLICAN PARTY (R)	0	0	41	41
-City & County of Honolulu	32-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	138	138
-City & County of Honolulu	32-07	US Representative	1	R	"TATAII, Steve"	0	0	13	13
-City & County of Honolulu	32-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-07	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	32-07	State Representative	32	R	"FINNEGAN, Lynn"	0	0	38	38
-City & County of Honolulu	32-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	266	266
-City & County of Honolulu	32-08	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	32-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	32-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	32-08	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
-City & County of Honolulu	32-08	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	250	250
-City & County of Honolulu	32-08	US Representative	1	R	"TATAII, Steve"	0	0	44	44
-City & County of Honolulu	32-08	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	32-08	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	32-08	State Representative	32	R	"FINNEGAN, Lynn"	0	0	93	93
-City & County of Honolulu	33-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	77	77
-City & County of Honolulu	33-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	33-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	33-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	33-01	Straight Party			REPUBLICAN PARTY (R)	0	0	21	21
-City & County of Honolulu	33-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	58	58
-City & County of Honolulu	33-01	US Representative	1	R	"TATAII, Steve"	0	0	20	20
-City & County of Honolulu	33-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	33-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	33-01	State Representative	33	D	"OSHIRO, Blake K."	0	0	46	46
-City & County of Honolulu	33-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	205	205
-City & County of Honolulu	33-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	33-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	33-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	33-02	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34
-City & County of Honolulu	33-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	169	169
-City & County of Honolulu	33-02	US Representative	1	R	"TATAII, Steve"	0	0	32	32
-City & County of Honolulu	33-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	33-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	33-02	State Representative	33	D	"OSHIRO, Blake K."	0	0	143	143
-City & County of Honolulu	33-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	478	478
-City & County of Honolulu	33-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	33-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	33-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	33-03	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55
-City & County of Honolulu	33-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	381	381
-City & County of Honolulu	33-03	US Representative	1	R	"TATAII, Steve"	0	0	45	45
-City & County of Honolulu	33-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	33-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	33-03	State Representative	33	D	"OSHIRO, Blake K."	0	0	332	332
-City & County of Honolulu	33-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	775	775
-City & County of Honolulu	33-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
-City & County of Honolulu	33-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
-City & County of Honolulu	33-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
-City & County of Honolulu	33-04	Straight Party			REPUBLICAN PARTY (R)	0	0	149	149
-City & County of Honolulu	33-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	599	599
-City & County of Honolulu	33-04	US Representative	1	R	"TATAII, Steve"	0	0	132	132
-City & County of Honolulu	33-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
-City & County of Honolulu	33-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	33-04	State Senate	16	D	"IGE, David Y."	0	0	436	436
-City & County of Honolulu	33-04	State Representative	33	D	"OSHIRO, Blake K."	0	0	517	517
-City & County of Honolulu	33-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	455	455
-City & County of Honolulu	33-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	33-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	33-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
-City & County of Honolulu	33-05	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
-City & County of Honolulu	33-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	367	367
-City & County of Honolulu	33-05	US Representative	1	R	"TATAII, Steve"	0	0	100	100
-City & County of Honolulu	33-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	33-05	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	33-05	State Senate	16	D	"IGE, David Y."	0	0	284	284
-City & County of Honolulu	33-05	State Representative	33	D	"OSHIRO, Blake K."	0	0	308	308
-City & County of Honolulu	33-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311
-City & County of Honolulu	33-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	33-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	33-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	33-06	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55
-City & County of Honolulu	33-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	255	255
-City & County of Honolulu	33-06	US Representative	1	R	"TATAII, Steve"	0	0	49	49
-City & County of Honolulu	33-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	33-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	33-06	State Senate	16	D	"IGE, David Y."	0	0	176	176
-City & County of Honolulu	33-06	State Representative	33	D	"OSHIRO, Blake K."	0	0	198	198
-City & County of Honolulu	34-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	394	394
-City & County of Honolulu	34-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	34-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	34-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	34-01	Straight Party			REPUBLICAN PARTY (R)	0	0	64	64
-City & County of Honolulu	34-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	299	299
-City & County of Honolulu	34-01	US Representative	1	R	"TATAII, Steve"	0	0	59	59
-City & County of Honolulu	34-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	34-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	34-01	State Senate	16	D	"IGE, David Y."	0	0	244	244
-City & County of Honolulu	34-01	State Representative	34	D	"TAKAI, K. Mark"	0	0	282	282
-City & County of Honolulu	34-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	355	355
-City & County of Honolulu	34-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	34-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	34-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	34-02	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
-City & County of Honolulu	34-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	272	272
-City & County of Honolulu	34-02	US Representative	1	R	"TATAII, Steve"	0	0	78	78
-City & County of Honolulu	34-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	34-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	34-02	State Senate	16	D	"IGE, David Y."	0	0	214	214
-City & County of Honolulu	34-02	State Representative	34	D	"TAKAI, K. Mark"	0	0	261	261
-City & County of Honolulu	34-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223
-City & County of Honolulu	34-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	34-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	34-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	34-03	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
-City & County of Honolulu	34-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	179	179
-City & County of Honolulu	34-03	US Representative	1	R	"TATAII, Steve"	0	0	19	19
-City & County of Honolulu	34-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	34-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	34-03	State Senate	16	D	"IGE, David Y."	0	0	151	151
-City & County of Honolulu	34-03	State Representative	34	D	"TAKAI, K. Mark"	0	0	169	169
-City & County of Honolulu	34-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	395	395
-City & County of Honolulu	34-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	34-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	34-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	34-04	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36
-City & County of Honolulu	34-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	305	305
-City & County of Honolulu	34-04	US Representative	1	R	"TATAII, Steve"	0	0	29	29
-City & County of Honolulu	34-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	34-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	34-04	State Senate	16	D	"IGE, David Y."	0	0	244	244
-City & County of Honolulu	34-04	State Representative	34	D	"TAKAI, K. Mark"	0	0	292	292
-City & County of Honolulu	34-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	238	238
-City & County of Honolulu	34-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	34-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	34-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	34-05	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
-City & County of Honolulu	34-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	187	187
-City & County of Honolulu	34-05	US Representative	1	R	"TATAII, Steve"	0	0	21	21
-City & County of Honolulu	34-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	34-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	34-05	State Senate	16	D	"IGE, David Y."	0	0	142	142
-City & County of Honolulu	34-05	State Representative	34	D	"TAKAI, K. Mark"	0	0	160	160
-City & County of Honolulu	34-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	68	68
-City & County of Honolulu	34-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	34-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	34-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	34-06	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14
-City & County of Honolulu	34-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	61	61
-City & County of Honolulu	34-06	US Representative	1	R	"TATAII, Steve"	0	0	11	11
-City & County of Honolulu	34-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	34-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	34-06	State Senate	18	D	"SONSON, Alex M."	0	0	27	27
-City & County of Honolulu	34-06	State Senate	18	D	"NISHIHARA, Clarence"	0	0	29	29
-City & County of Honolulu	34-06	State Representative	34	D	"TAKAI, K. Mark"	0	0	52	52
-City & County of Honolulu	34-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	1034	1034
-City & County of Honolulu	34-07	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	34-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	9	9
-City & County of Honolulu	34-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	34-07	Straight Party			REPUBLICAN PARTY (R)	0	0	103	103
-City & County of Honolulu	34-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	780	780
-City & County of Honolulu	34-07	US Representative	1	R	"TATAII, Steve"	0	0	95	95
-City & County of Honolulu	34-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	34-07	US Representative	1	L	"ZHAO, Li"	0	0	5	5
-City & County of Honolulu	34-07	State Senate	16	D	"IGE, David Y."	0	0	727	727
-City & County of Honolulu	34-07	State Representative	34	D	"TAKAI, K. Mark"	0	0	809	809
-City & County of Honolulu	35-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	499	499
-City & County of Honolulu	35-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	35-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	35-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	35-01	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
-City & County of Honolulu	35-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	373	373
-City & County of Honolulu	35-01	US Representative	1	R	"TATAII, Steve"	0	0	41	41
-City & County of Honolulu	35-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	35-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	35-01	State Senate	18	D	"SONSON, Alex M."	0	0	211	211
-City & County of Honolulu	35-01	State Senate	18	D	"NISHIHARA, Clarence"	0	0	262	262
-City & County of Honolulu	35-01	State Representative	35	D	"AQUINO, Henry James C."	0	0	215	215
-City & County of Honolulu	35-01	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	178	178
-City & County of Honolulu	35-01	State Representative	35	D	"VERDADERO, Dante M."	0	0	19	19
-City & County of Honolulu	35-01	State Representative	35	D	"DOMINGO, Constante A."	0	0	21	21
-City & County of Honolulu	35-01	State Representative	35	D	"PARAYNO, Ilalo"	0	0	31	31
-City & County of Honolulu	35-01	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	46	46
-City & County of Honolulu	35-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	745	745
-City & County of Honolulu	35-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	35-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	35-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	35-02	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
-City & County of Honolulu	35-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	572	572
-City & County of Honolulu	35-02	US Representative	1	R	"TATAII, Steve"	0	0	17	17
-City & County of Honolulu	35-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	35-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	35-02	State Senate	18	D	"SONSON, Alex M."	0	0	445	445
-City & County of Honolulu	35-02	State Senate	18	D	"NISHIHARA, Clarence"	0	0	268	268
-City & County of Honolulu	35-02	State Representative	35	D	"AQUINO, Henry James C."	0	0	494	494
-City & County of Honolulu	35-02	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	147	147
-City & County of Honolulu	35-02	State Representative	35	D	"VERDADERO, Dante M."	0	0	36	36
-City & County of Honolulu	35-02	State Representative	35	D	"DOMINGO, Constante A."	0	0	16	16
-City & County of Honolulu	35-02	State Representative	35	D	"PARAYNO, Ilalo"	0	0	25	25
-City & County of Honolulu	35-02	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	32	32
-City & County of Honolulu	35-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	221	221
-City & County of Honolulu	35-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	35-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	35-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	35-03	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
-City & County of Honolulu	35-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	169	169
-City & County of Honolulu	35-03	US Representative	1	R	"TATAII, Steve"	0	0	6	6
-City & County of Honolulu	35-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	35-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	35-03	State Senate	18	D	"SONSON, Alex M."	0	0	113	113
-City & County of Honolulu	35-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	99	99
-City & County of Honolulu	35-03	State Representative	35	D	"AQUINO, Henry James C."	0	0	133	133
-City & County of Honolulu	35-03	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	30	30
-City & County of Honolulu	35-03	State Representative	35	D	"VERDADERO, Dante M."	0	0	17	17
-City & County of Honolulu	35-03	State Representative	35	D	"DOMINGO, Constante A."	0	0	10	10
-City & County of Honolulu	35-03	State Representative	35	D	"PARAYNO, Ilalo"	0	0	12	12
-City & County of Honolulu	35-03	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	14	14
-City & County of Honolulu	35-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	330	330
-City & County of Honolulu	35-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	35-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	35-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	35-04	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22
-City & County of Honolulu	35-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	272	272
-City & County of Honolulu	35-04	US Representative	1	R	"TATAII, Steve"	0	0	15	15
-City & County of Honolulu	35-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	35-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	35-04	State Senate	18	D	"SONSON, Alex M."	0	0	163	163
-City & County of Honolulu	35-04	State Senate	18	D	"NISHIHARA, Clarence"	0	0	157	157
-City & County of Honolulu	35-04	State Representative	35	D	"AQUINO, Henry James C."	0	0	192	192
-City & County of Honolulu	35-04	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	57	57
-City & County of Honolulu	35-04	State Representative	35	D	"VERDADERO, Dante M."	0	0	9	9
-City & County of Honolulu	35-04	State Representative	35	D	"DOMINGO, Constante A."	0	0	12	12
-City & County of Honolulu	35-04	State Representative	35	D	"PARAYNO, Ilalo"	0	0	33	33
-City & County of Honolulu	35-04	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	18	18
-City & County of Honolulu	35-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	279	279
-City & County of Honolulu	35-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	35-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	35-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	35-05	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
-City & County of Honolulu	35-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	231	231
-City & County of Honolulu	35-05	US Representative	1	R	"TATAII, Steve"	0	0	6	6
-City & County of Honolulu	35-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	35-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	35-05	State Senate	18	D	"SONSON, Alex M."	0	0	173	173
-City & County of Honolulu	35-05	State Senate	18	D	"NISHIHARA, Clarence"	0	0	96	96
-City & County of Honolulu	35-05	State Representative	35	D	"AQUINO, Henry James C."	0	0	176	176
-City & County of Honolulu	35-05	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	36	36
-City & County of Honolulu	35-05	State Representative	35	D	"VERDADERO, Dante M."	0	0	15	15
-City & County of Honolulu	35-05	State Representative	35	D	"DOMINGO, Constante A."	0	0	12	12
-City & County of Honolulu	35-05	State Representative	35	D	"PARAYNO, Ilalo"	0	0	27	27
-City & County of Honolulu	35-05	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	11	11
-City & County of Honolulu	35-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	862	862
-City & County of Honolulu	35-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	35-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	35-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	35-06	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35
-City & County of Honolulu	35-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	705	705
-City & County of Honolulu	35-06	US Representative	1	R	"TATAII, Steve"	0	0	16	16
-City & County of Honolulu	35-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	35-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	35-06	State Senate	18	D	"SONSON, Alex M."	0	0	515	515
-City & County of Honolulu	35-06	State Senate	18	D	"NISHIHARA, Clarence"	0	0	321	321
-City & County of Honolulu	35-06	State Representative	35	D	"AQUINO, Henry James C."	0	0	580	580
-City & County of Honolulu	35-06	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	134	134
-City & County of Honolulu	35-06	State Representative	35	D	"VERDADERO, Dante M."	0	0	24	24
-City & County of Honolulu	35-06	State Representative	35	D	"DOMINGO, Constante A."	0	0	23	23
-City & County of Honolulu	35-06	State Representative	35	D	"PARAYNO, Ilalo"	0	0	74	74
-City & County of Honolulu	35-06	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	30	30
-City & County of Honolulu	36-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	531	531
-City & County of Honolulu	36-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	36-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	36-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	36-01	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
-City & County of Honolulu	36-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	429	429
-City & County of Honolulu	36-01	US Representative	1	R	"TATAII, Steve"	0	0	46	46
-City & County of Honolulu	36-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	36-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	36-01	State Senate	16	D	"IGE, David Y."	0	0	338	338
-City & County of Honolulu	36-01	State Representative	36	D	"TAKUMI, Roy M."	0	0	372	372
-City & County of Honolulu	36-01	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	3	3
-City & County of Honolulu	36-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	384	384
-City & County of Honolulu	36-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	36-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	36-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	16	16
-City & County of Honolulu	36-02	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
-City & County of Honolulu	36-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	317	317
-City & County of Honolulu	36-02	US Representative	1	R	"TATAII, Steve"	0	0	36	36
-City & County of Honolulu	36-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	36-02	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	36-02	State Senate	16	D	"IGE, David Y."	0	0	239	239
-City & County of Honolulu	36-02	State Representative	36	D	"TAKUMI, Roy M."	0	0	249	249
-City & County of Honolulu	36-02	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	15	15
-City & County of Honolulu	36-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	273	273
-City & County of Honolulu	36-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	36-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	36-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	36-03	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59
-City & County of Honolulu	36-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	226	226
-City & County of Honolulu	36-03	US Representative	1	R	"TATAII, Steve"	0	0	59	59
-City & County of Honolulu	36-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	36-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	36-03	State Senate	18	D	"SONSON, Alex M."	0	0	98	98
-City & County of Honolulu	36-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	135	135
-City & County of Honolulu	36-03	State Representative	36	D	"TAKUMI, Roy M."	0	0	203	203
-City & County of Honolulu	36-03	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0
-City & County of Honolulu	36-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	29	29
-City & County of Honolulu	36-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	36-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	36-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	36-04	Straight Party			REPUBLICAN PARTY (R)	0	0	4	4
-City & County of Honolulu	36-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	26	26
-City & County of Honolulu	36-04	US Representative	1	R	"TATAII, Steve"	0	0	4	4
-City & County of Honolulu	36-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	36-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	36-04	State Senate	18	D	"SONSON, Alex M."	0	0	10	10
-City & County of Honolulu	36-04	State Senate	18	D	"NISHIHARA, Clarence"	0	0	15	15
-City & County of Honolulu	36-04	State Representative	36	D	"TAKUMI, Roy M."	0	0	23	23
-City & County of Honolulu	36-04	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0
-City & County of Honolulu	36-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	765	765
-City & County of Honolulu	36-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	36-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	36-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	36-05	Straight Party			REPUBLICAN PARTY (R)	0	0	69	69
-City & County of Honolulu	36-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	614	614
-City & County of Honolulu	36-05	US Representative	1	R	"TATAII, Steve"	0	0	56	56
-City & County of Honolulu	36-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	36-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	36-05	State Senate	18	D	"SONSON, Alex M."	0	0	212	212
-City & County of Honolulu	36-05	State Senate	18	D	"NISHIHARA, Clarence"	0	0	496	496
-City & County of Honolulu	36-05	State Representative	36	D	"TAKUMI, Roy M."	0	0	599	599
-City & County of Honolulu	36-05	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	4	4
-City & County of Honolulu	36-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	541	541
-City & County of Honolulu	36-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	36-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	36-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
-City & County of Honolulu	36-06	Straight Party			REPUBLICAN PARTY (R)	0	0	97	97
-City & County of Honolulu	36-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	427	427
-City & County of Honolulu	36-06	US Representative	1	R	"TATAII, Steve"	0	0	91	91
-City & County of Honolulu	36-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	36-06	US Representative	1	L	"ZHAO, Li"	0	0	4	4
-City & County of Honolulu	36-06	State Senate	16	D	"IGE, David Y."	0	0	320	320
-City & County of Honolulu	36-06	State Representative	36	D	"TAKUMI, Roy M."	0	0	355	355
-City & County of Honolulu	36-06	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	8	8
-City & County of Honolulu	36-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	396	396
-City & County of Honolulu	36-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	36-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	36-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
-City & County of Honolulu	36-07	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
-City & County of Honolulu	36-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	310	310
-City & County of Honolulu	36-07	US Representative	1	R	"TATAII, Steve"	0	0	65	65
-City & County of Honolulu	36-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	36-07	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	36-07	State Senate	16	D	"IGE, David Y."	0	0	228	228
-City & County of Honolulu	36-07	State Representative	36	D	"TAKUMI, Roy M."	0	0	247	247
-City & County of Honolulu	36-07	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	9	9
-City & County of Honolulu	37-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	940	940
-City & County of Honolulu	37-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	37-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	37-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	37-01	Straight Party			REPUBLICAN PARTY (R)	0	0	119	119
-City & County of Honolulu	37-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	753	753
-City & County of Honolulu	37-01	US Representative	1	R	"TATAII, Steve"	0	0	111	111
-City & County of Honolulu	37-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	37-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	37-01	State Senate	17	D	"KIDANI, Michelle"	0	0	420	420
-City & County of Honolulu	37-01	State Senate	17	D	"MENOR, Ron"	0	0	295	295
-City & County of Honolulu	37-01	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	162	162
-City & County of Honolulu	37-01	State Representative	37	D	"YAMANE, Ryan I."	0	0	773	773
-City & County of Honolulu	37-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	708	708
-City & County of Honolulu	37-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	37-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	37-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	37-02	Straight Party			REPUBLICAN PARTY (R)	0	0	129	129
-City & County of Honolulu	37-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	567	567
-City & County of Honolulu	37-02	US Representative	1	R	"TATAII, Steve"	0	0	117	117
-City & County of Honolulu	37-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	37-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	37-02	State Senate	17	D	"KIDANI, Michelle"	0	0	306	306
-City & County of Honolulu	37-02	State Senate	17	D	"MENOR, Ron"	0	0	276	276
-City & County of Honolulu	37-02	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	90	90
-City & County of Honolulu	37-02	State Representative	37	D	"YAMANE, Ryan I."	0	0	567	567
-City & County of Honolulu	37-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	880	880
-City & County of Honolulu	37-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	37-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	37-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	37-03	Straight Party			REPUBLICAN PARTY (R)	0	0	138	138
-City & County of Honolulu	37-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	674	674
-City & County of Honolulu	37-03	US Representative	1	R	"TATAII, Steve"	0	0	133	133
-City & County of Honolulu	37-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	37-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	37-03	State Senate	17	D	"KIDANI, Michelle"	0	0	354	354
-City & County of Honolulu	37-03	State Senate	17	D	"MENOR, Ron"	0	0	384	384
-City & County of Honolulu	37-03	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	100	100
-City & County of Honolulu	37-03	State Representative	37	D	"YAMANE, Ryan I."	0	0	684	684
-City & County of Honolulu	37-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	738	738
-City & County of Honolulu	37-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	37-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	37-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	37-04	Straight Party			REPUBLICAN PARTY (R)	0	0	121	121
-City & County of Honolulu	37-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	581	581
-City & County of Honolulu	37-04	US Representative	1	R	"TATAII, Steve"	0	0	111	111
-City & County of Honolulu	37-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	37-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	37-04	State Senate	17	D	"KIDANI, Michelle"	0	0	310	310
-City & County of Honolulu	37-04	State Senate	17	D	"MENOR, Ron"	0	0	309	309
-City & County of Honolulu	37-04	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	78	78
-City & County of Honolulu	37-04	State Representative	37	D	"YAMANE, Ryan I."	0	0	598	598
-City & County of Honolulu	38-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	818	818
-City & County of Honolulu	38-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	38-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-City & County of Honolulu	38-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13
-City & County of Honolulu	38-01	Straight Party			REPUBLICAN PARTY (R)	0	0	210	210
-City & County of Honolulu	38-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	665	665
-City & County of Honolulu	38-01	US Representative	1	R	"TATAII, Steve"	0	0	117	117
-City & County of Honolulu	38-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	38-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3
-City & County of Honolulu	38-01	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	503	503
-City & County of Honolulu	38-01	State Representative	38	D	"LEE, Marilyn B."	0	0	539	539
-City & County of Honolulu	38-01	State Representative	38	R	"APANA, Melvin K."	0	0	178	178
-City & County of Honolulu	38-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	972	972
-City & County of Honolulu	38-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	38-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	38-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	38-02	Straight Party			REPUBLICAN PARTY (R)	0	0	180	180
-City & County of Honolulu	38-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	770	770
-City & County of Honolulu	38-02	US Representative	1	R	"TATAII, Steve"	0	0	126	126
-City & County of Honolulu	38-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
-City & County of Honolulu	38-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	38-02	State Senate	17	D	"KIDANI, Michelle"	0	0	436	436
-City & County of Honolulu	38-02	State Senate	17	D	"MENOR, Ron"	0	0	388	388
-City & County of Honolulu	38-02	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	102	102
-City & County of Honolulu	38-02	State Representative	38	D	"LEE, Marilyn B."	0	0	776	776
-City & County of Honolulu	38-02	State Representative	38	R	"APANA, Melvin K."	0	0	155	155
-City & County of Honolulu	38-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	676	676
-City & County of Honolulu	38-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	38-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	38-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	38-03	Straight Party			REPUBLICAN PARTY (R)	0	0	114	114
-City & County of Honolulu	38-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	521	521
-City & County of Honolulu	38-03	US Representative	1	R	"TATAII, Steve"	0	0	74	74
-City & County of Honolulu	38-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	38-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	38-03	State Senate	17	D	"KIDANI, Michelle"	0	0	258	258
-City & County of Honolulu	38-03	State Senate	17	D	"MENOR, Ron"	0	0	269	269
-City & County of Honolulu	38-03	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	117	117
-City & County of Honolulu	38-03	State Representative	38	D	"LEE, Marilyn B."	0	0	515	515
-City & County of Honolulu	38-03	State Representative	38	R	"APANA, Melvin K."	0	0	90	90
-City & County of Honolulu	38-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	500	500
-City & County of Honolulu	38-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	38-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	38-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	38-04	Straight Party			REPUBLICAN PARTY (R)	0	0	145	145
-City & County of Honolulu	38-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	382	382
-City & County of Honolulu	38-04	US Representative	1	R	"TATAII, Steve"	0	0	94	94
-City & County of Honolulu	38-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	38-04	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	38-04	State Senate	17	D	"KIDANI, Michelle"	0	0	195	195
-City & County of Honolulu	38-04	State Senate	17	D	"MENOR, Ron"	0	0	204	204
-City & County of Honolulu	38-04	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	77	77
-City & County of Honolulu	38-04	State Representative	38	D	"LEE, Marilyn B."	0	0	380	380
-City & County of Honolulu	38-04	State Representative	38	R	"APANA, Melvin K."	0	0	118	118
-City & County of Honolulu	38-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	569	569
-City & County of Honolulu	38-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	38-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	38-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	38-05	Straight Party			REPUBLICAN PARTY (R)	0	0	111	111
-City & County of Honolulu	38-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	478	478
-City & County of Honolulu	38-05	US Representative	1	R	"TATAII, Steve"	0	0	80	80
-City & County of Honolulu	38-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	38-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	38-05	State Senate	17	D	"KIDANI, Michelle"	0	0	181	181
-City & County of Honolulu	38-05	State Senate	17	D	"MENOR, Ron"	0	0	259	259
-City & County of Honolulu	38-05	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	92	92
-City & County of Honolulu	38-05	State Representative	38	D	"LEE, Marilyn B."	0	0	426	426
-City & County of Honolulu	38-05	State Representative	38	R	"APANA, Melvin K."	0	0	88	88
-City & County of Honolulu	39-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	271	271
-City & County of Honolulu	39-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	39-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	39-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	39-01	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
-City & County of Honolulu	39-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	39-01	US Representative	2	D	"HIRONO, Mazie"	0	0	183	183
-City & County of Honolulu	39-01	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
-City & County of Honolulu	39-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	39-01	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	209	209
-City & County of Honolulu	39-01	State Representative	39	D	"OSHIRO, Marcus R."	0	0	171	171
-City & County of Honolulu	39-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	412	412
-City & County of Honolulu	39-02	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	39-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	39-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	39-02	Straight Party			REPUBLICAN PARTY (R)	0	0	49	49
-City & County of Honolulu	39-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-City & County of Honolulu	39-02	US Representative	2	D	"HIRONO, Mazie"	0	0	308	308
-City & County of Honolulu	39-02	US Representative	2	R	"EVANS, Roger B."	0	0	45	45
-City & County of Honolulu	39-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	39-02	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	317	317
-City & County of Honolulu	39-02	State Representative	39	D	"OSHIRO, Marcus R."	0	0	296	296
-City & County of Honolulu	39-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	534	534
-City & County of Honolulu	39-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	39-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	39-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	39-03	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83
-City & County of Honolulu	39-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-City & County of Honolulu	39-03	US Representative	2	D	"HIRONO, Mazie"	0	0	364	364
-City & County of Honolulu	39-03	US Representative	2	R	"EVANS, Roger B."	0	0	76	76
-City & County of Honolulu	39-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	39-03	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	400	400
-City & County of Honolulu	39-03	State Representative	39	D	"OSHIRO, Marcus R."	0	0	373	373
-City & County of Honolulu	39-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392
-City & County of Honolulu	39-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	39-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	39-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
-City & County of Honolulu	39-04	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83
-City & County of Honolulu	39-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	39-04	US Representative	2	D	"HIRONO, Mazie"	0	0	299	299
-City & County of Honolulu	39-04	US Representative	2	R	"EVANS, Roger B."	0	0	79	79
-City & County of Honolulu	39-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	39-04	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	280	280
-City & County of Honolulu	39-04	State Representative	39	D	"OSHIRO, Marcus R."	0	0	268	268
-City & County of Honolulu	39-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	121	121
-City & County of Honolulu	39-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	39-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	39-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	39-05	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35
-City & County of Honolulu	39-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	99	99
-City & County of Honolulu	39-05	US Representative	1	R	"TATAII, Steve"	0	0	35	35
-City & County of Honolulu	39-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	39-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	39-05	State Senate	17	D	"KIDANI, Michelle"	0	0	49	49
-City & County of Honolulu	39-05	State Senate	17	D	"MENOR, Ron"	0	0	46	46
-City & County of Honolulu	39-05	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	7	7
-City & County of Honolulu	39-05	State Representative	39	D	"OSHIRO, Marcus R."	0	0	81	81
-City & County of Honolulu	39-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	352	352
-City & County of Honolulu	39-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	39-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	39-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	39-06	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42
-City & County of Honolulu	39-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	39-06	US Representative	2	D	"HIRONO, Mazie"	0	0	270	270
-City & County of Honolulu	39-06	US Representative	2	R	"EVANS, Roger B."	0	0	39	39
-City & County of Honolulu	39-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
-City & County of Honolulu	39-06	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	243	243
-City & County of Honolulu	39-06	State Representative	39	D	"OSHIRO, Marcus R."	0	0	229	229
-City & County of Honolulu	40-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	231	231
-City & County of Honolulu	40-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	40-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	40-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	40-01	Straight Party			REPUBLICAN PARTY (R)	0	0	66	66
-City & County of Honolulu	40-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	40-01	US Representative	2	D	"HIRONO, Mazie"	0	0	181	181
-City & County of Honolulu	40-01	US Representative	2	R	"EVANS, Roger B."	0	0	49	49
-City & County of Honolulu	40-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	40-01	State Representative	40	D	"HAR, Sharon E."	0	0	179	179
-City & County of Honolulu	40-01	State Representative	40	R	"LEGAL,  Jack M."	0	0	47	47
-City & County of Honolulu	40-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	316	316
-City & County of Honolulu	40-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	40-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	40-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	40-02	Straight Party			REPUBLICAN PARTY (R)	0	0	118	118
-City & County of Honolulu	40-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-City & County of Honolulu	40-02	US Representative	2	D	"HIRONO, Mazie"	0	0	240	240
-City & County of Honolulu	40-02	US Representative	2	R	"EVANS, Roger B."	0	0	76	76
-City & County of Honolulu	40-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	40-02	State Representative	40	D	"HAR, Sharon E."	0	0	232	232
-City & County of Honolulu	40-02	State Representative	40	R	"LEGAL,  Jack M."	0	0	98	98
-City & County of Honolulu	40-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	463	463
-City & County of Honolulu	40-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	40-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	40-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	40-03	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154
-City & County of Honolulu	40-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-City & County of Honolulu	40-03	US Representative	2	D	"HIRONO, Mazie"	0	0	323	323
-City & County of Honolulu	40-03	US Representative	2	R	"EVANS, Roger B."	0	0	94	94
-City & County of Honolulu	40-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	40-03	State Representative	40	D	"HAR, Sharon E."	0	0	342	342
-City & County of Honolulu	40-03	State Representative	40	R	"LEGAL,  Jack M."	0	0	120	120
-City & County of Honolulu	40-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427
-City & County of Honolulu	40-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	40-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	40-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	40-04	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154
-City & County of Honolulu	40-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	40-04	US Representative	2	D	"HIRONO, Mazie"	0	0	299	299
-City & County of Honolulu	40-04	US Representative	2	R	"EVANS, Roger B."	0	0	73	73
-City & County of Honolulu	40-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	40-04	State Representative	40	D	"HAR, Sharon E."	0	0	355	355
-City & County of Honolulu	40-04	State Representative	40	R	"LEGAL,  Jack M."	0	0	126	126
-City & County of Honolulu	40-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	393	393
-City & County of Honolulu	40-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	40-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	40-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	40-05	Straight Party			REPUBLICAN PARTY (R)	0	0	166	166
-City & County of Honolulu	40-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	40-05	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305
-City & County of Honolulu	40-05	US Representative	2	R	"EVANS, Roger B."	0	0	98	98
-City & County of Honolulu	40-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	40-05	State Representative	40	D	"HAR, Sharon E."	0	0	300	300
-City & County of Honolulu	40-05	State Representative	40	R	"LEGAL,  Jack M."	0	0	142	142
-City & County of Honolulu	40-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	222	222
-City & County of Honolulu	40-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	40-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	40-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	40-06	Straight Party			REPUBLICAN PARTY (R)	0	0	142	142
-City & County of Honolulu	40-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	40-06	US Representative	2	D	"HIRONO, Mazie"	0	0	174	174
-City & County of Honolulu	40-06	US Representative	2	R	"EVANS, Roger B."	0	0	87	87
-City & County of Honolulu	40-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	40-06	State Representative	40	D	"HAR, Sharon E."	0	0	180	180
-City & County of Honolulu	40-06	State Representative	40	R	"LEGAL,  Jack M."	0	0	114	114
-City & County of Honolulu	41-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	343	343
-City & County of Honolulu	41-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	41-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	41-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	41-01	Straight Party			REPUBLICAN PARTY (R)	0	0	82	82
-City & County of Honolulu	41-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	293	293
-City & County of Honolulu	41-01	US Representative	1	R	"TATAII, Steve"	0	0	54	54
-City & County of Honolulu	41-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
-City & County of Honolulu	41-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	41-01	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	123	123
-City & County of Honolulu	41-01	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	185	185
-City & County of Honolulu	41-01	State Representative	41	R	"SANIATAN, Rito C."	0	0	62	62
-City & County of Honolulu	41-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	347	347
-City & County of Honolulu	41-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	41-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	41-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	41-02	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
-City & County of Honolulu	41-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	289	289
-City & County of Honolulu	41-02	US Representative	1	R	"TATAII, Steve"	0	0	39	39
-City & County of Honolulu	41-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	41-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	41-02	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	119	119
-City & County of Honolulu	41-02	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	197	197
-City & County of Honolulu	41-02	State Representative	41	R	"SANIATAN, Rito C."	0	0	68	68
-City & County of Honolulu	41-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	538	538
-City & County of Honolulu	41-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	41-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	41-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	41-03	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
-City & County of Honolulu	41-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	422	422
-City & County of Honolulu	41-03	US Representative	1	R	"TATAII, Steve"	0	0	17	17
-City & County of Honolulu	41-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	41-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	41-03	State Senate	18	D	"SONSON, Alex M."	0	0	237	237
-City & County of Honolulu	41-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	265	265
-City & County of Honolulu	41-03	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	242	242
-City & County of Honolulu	41-03	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	232	232
-City & County of Honolulu	41-03	State Representative	41	R	"SANIATAN, Rito C."	0	0	33	33
-City & County of Honolulu	41-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	66	66
-City & County of Honolulu	41-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	41-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	41-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	41-04	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22
-City & County of Honolulu	41-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	53	53
-City & County of Honolulu	41-04	US Representative	1	R	"TATAII, Steve"	0	0	11	11
-City & County of Honolulu	41-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	41-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	41-04	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	38	38
-City & County of Honolulu	41-04	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	17	17
-City & County of Honolulu	41-04	State Representative	41	R	"SANIATAN, Rito C."	0	0	20	20
-City & County of Honolulu	41-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	505	505
-City & County of Honolulu	41-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	41-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	41-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	41-05	Straight Party			REPUBLICAN PARTY (R)	0	0	131	131
-City & County of Honolulu	41-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	41-05	US Representative	2	D	"HIRONO, Mazie"	0	0	400	400
-City & County of Honolulu	41-05	US Representative	2	R	"EVANS, Roger B."	0	0	58	58
-City & County of Honolulu	41-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	41-05	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	255	255
-City & County of Honolulu	41-05	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	211	211
-City & County of Honolulu	41-05	State Representative	41	R	"SANIATAN, Rito C."	0	0	110	110
-City & County of Honolulu	41-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313
-City & County of Honolulu	41-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	41-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	41-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	41-06	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113
-City & County of Honolulu	41-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	41-06	US Representative	2	D	"HIRONO, Mazie"	0	0	249	249
-City & County of Honolulu	41-06	US Representative	2	R	"EVANS, Roger B."	0	0	52	52
-City & County of Honolulu	41-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	41-06	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	143	143
-City & County of Honolulu	41-06	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	133	133
-City & County of Honolulu	41-06	State Representative	41	R	"SANIATAN, Rito C."	0	0	90	90
-City & County of Honolulu	42-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	287	287
-City & County of Honolulu	42-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	42-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	42-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	42-01	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
-City & County of Honolulu	42-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	234	234
-City & County of Honolulu	42-01	US Representative	1	R	"TATAII, Steve"	0	0	10	10
-City & County of Honolulu	42-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	42-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	42-01	State Senate	18	D	"SONSON, Alex M."	0	0	148	148
-City & County of Honolulu	42-01	State Senate	18	D	"NISHIHARA, Clarence"	0	0	125	125
-City & County of Honolulu	42-01	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	23	23
-City & County of Honolulu	42-01	State Representative	42	D	"SCHULTZ, Mike P."	0	0	81	81
-City & County of Honolulu	42-01	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	158	158
-City & County of Honolulu	42-01	State Representative	42	R	"BERG, Tom"	0	0	25	25
-City & County of Honolulu	42-01	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
-City & County of Honolulu	42-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	107	107
-City & County of Honolulu	42-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	42-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	42-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	42-02	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31
-City & County of Honolulu	42-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	90	90
-City & County of Honolulu	42-02	US Representative	1	R	"TATAII, Steve"	0	0	20	20
-City & County of Honolulu	42-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	42-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	42-02	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	10	10
-City & County of Honolulu	42-02	State Representative	42	D	"SCHULTZ, Mike P."	0	0	24	24
-City & County of Honolulu	42-02	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	53	53
-City & County of Honolulu	42-02	State Representative	42	R	"BERG, Tom"	0	0	24	24
-City & County of Honolulu	42-02	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
-City & County of Honolulu	42-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	220	220
-City & County of Honolulu	42-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	42-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	42-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	42-03	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
-City & County of Honolulu	42-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	173	173
-City & County of Honolulu	42-03	US Representative	1	R	"TATAII, Steve"	0	0	18	18
-City & County of Honolulu	42-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	42-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	42-03	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	19	19
-City & County of Honolulu	42-03	State Representative	42	D	"SCHULTZ, Mike P."	0	0	97	97
-City & County of Honolulu	42-03	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	93	93
-City & County of Honolulu	42-03	State Representative	42	R	"BERG, Tom"	0	0	24	24
-City & County of Honolulu	42-03	State Representative	42	N	"BIMBO, Genaro Q."	0	0	1	1
-City & County of Honolulu	42-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	520	520
-City & County of Honolulu	42-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	42-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	42-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	42-04	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
-City & County of Honolulu	42-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	421	421
-City & County of Honolulu	42-04	US Representative	1	R	"TATAII, Steve"	0	0	17	17
-City & County of Honolulu	42-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	42-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	42-04	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	22	22
-City & County of Honolulu	42-04	State Representative	42	D	"SCHULTZ, Mike P."	0	0	177	177
-City & County of Honolulu	42-04	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	293	293
-City & County of Honolulu	42-04	State Representative	42	R	"BERG, Tom"	0	0	55	55
-City & County of Honolulu	42-04	State Representative	42	N	"BIMBO, Genaro Q."	0	0	5	5
-City & County of Honolulu	42-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	403	403
-City & County of Honolulu	42-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	42-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	42-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	42-05	Straight Party			REPUBLICAN PARTY (R)	0	0	117	117
-City & County of Honolulu	42-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	342	342
-City & County of Honolulu	42-05	US Representative	1	R	"TATAII, Steve"	0	0	48	48
-City & County of Honolulu	42-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	42-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	42-05	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	18	18
-City & County of Honolulu	42-05	State Representative	42	D	"SCHULTZ, Mike P."	0	0	187	187
-City & County of Honolulu	42-05	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	155	155
-City & County of Honolulu	42-05	State Representative	42	R	"BERG, Tom"	0	0	108	108
-City & County of Honolulu	42-05	State Representative	42	N	"BIMBO, Genaro Q."	0	0	3	3
-City & County of Honolulu	43-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	219	219
-City & County of Honolulu	43-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	43-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	43-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	43-01	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
-City & County of Honolulu	43-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	186	186
-City & County of Honolulu	43-01	US Representative	1	R	"TATAII, Steve"	0	0	30	30
-City & County of Honolulu	43-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	43-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	43-01	State Representative	43	D	"FEVELLA, Kurt"	0	0	83	83
-City & County of Honolulu	43-01	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	103	103
-City & County of Honolulu	43-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	411	411
-City & County of Honolulu	43-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	43-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	43-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	43-02	Straight Party			REPUBLICAN PARTY (R)	0	0	252	252
-City & County of Honolulu	43-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	361	361
-City & County of Honolulu	43-02	US Representative	1	R	"TATAII, Steve"	0	0	105	105
-City & County of Honolulu	43-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	43-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	43-02	State Representative	43	D	"FEVELLA, Kurt"	0	0	158	158
-City & County of Honolulu	43-02	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	236	236
-City & County of Honolulu	43-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	254	254
-City & County of Honolulu	43-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	43-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	43-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	43-03	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113
-City & County of Honolulu	43-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	206	206
-City & County of Honolulu	43-03	US Representative	1	R	"TATAII, Steve"	0	0	42	42
-City & County of Honolulu	43-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	43-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
-City & County of Honolulu	43-03	State Representative	43	D	"FEVELLA, Kurt"	0	0	132	132
-City & County of Honolulu	43-03	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	104	104
-City & County of Honolulu	43-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	272	272
-City & County of Honolulu	43-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	43-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	43-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	43-04	Straight Party			REPUBLICAN PARTY (R)	0	0	160	160
-City & County of Honolulu	43-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	230	230
-City & County of Honolulu	43-04	US Representative	1	R	"TATAII, Steve"	0	0	56	56
-City & County of Honolulu	43-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-City & County of Honolulu	43-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	43-04	State Representative	43	D	"FEVELLA, Kurt"	0	0	146	146
-City & County of Honolulu	43-04	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	156	156
-City & County of Honolulu	43-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	354	354
-City & County of Honolulu	43-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	43-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	43-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	43-05	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136
-City & County of Honolulu	43-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	297	297
-City & County of Honolulu	43-05	US Representative	1	R	"TATAII, Steve"	0	0	49	49
-City & County of Honolulu	43-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	43-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-City & County of Honolulu	43-05	State Representative	43	D	"FEVELLA, Kurt"	0	0	150	150
-City & County of Honolulu	43-05	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	128	128
-City & County of Honolulu	43-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
-City & County of Honolulu	43-06	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	43-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	43-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	43-06	Straight Party			REPUBLICAN PARTY (R)	0	0	209	209
-City & County of Honolulu	43-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	275	275
-City & County of Honolulu	43-06	US Representative	1	R	"TATAII, Steve"	0	0	59	59
-City & County of Honolulu	43-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
-City & County of Honolulu	43-06	US Representative	1	L	"ZHAO, Li"	0	0	2	2
-City & County of Honolulu	43-06	State Representative	43	D	"FEVELLA, Kurt"	0	0	128	128
-City & County of Honolulu	43-06	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	198	198
-City & County of Honolulu	44-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	126	126
-City & County of Honolulu	44-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	44-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	44-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	44-01	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34
-City & County of Honolulu	44-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	44-01	US Representative	2	D	"HIRONO, Mazie"	0	0	108	108
-City & County of Honolulu	44-01	US Representative	2	R	"EVANS, Roger B."	0	0	31	31
-City & County of Honolulu	44-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	44-01	State Representative	44	D	"AWANA, Karen Leinani"	0	0	82	82
-City & County of Honolulu	44-01	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	35	35
-City & County of Honolulu	44-01	State Representative	44	R	"KU, Tercia L."	0	0	23	23
-City & County of Honolulu	44-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	603	603
-City & County of Honolulu	44-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	44-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	44-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	44-02	Straight Party			REPUBLICAN PARTY (R)	0	0	33	33
-City & County of Honolulu	44-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	44-02	US Representative	2	D	"HIRONO, Mazie"	0	0	355	355
-City & County of Honolulu	44-02	US Representative	2	R	"EVANS, Roger B."	0	0	13	13
-City & County of Honolulu	44-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	44-02	State Senate	21	D	"HANABUSA, Colleen"	0	0	430	430
-City & County of Honolulu	44-02	State Senate	21	R	"JOHNSON, Dickyj"	0	0	16	16
-City & County of Honolulu	44-02	State Representative	44	D	"AWANA, Karen Leinani"	0	0	242	242
-City & County of Honolulu	44-02	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	315	315
-City & County of Honolulu	44-02	State Representative	44	R	"KU, Tercia L."	0	0	21	21
-City & County of Honolulu	44-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421
-City & County of Honolulu	44-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	44-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	44-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	44-03	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
-City & County of Honolulu	44-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	44-03	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300
-City & County of Honolulu	44-03	US Representative	2	R	"EVANS, Roger B."	0	0	35	35
-City & County of Honolulu	44-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	44-03	State Senate	21	D	"HANABUSA, Colleen"	0	0	295	295
-City & County of Honolulu	44-03	State Senate	21	R	"JOHNSON, Dickyj"	0	0	42	42
-City & County of Honolulu	44-03	State Representative	44	D	"AWANA, Karen Leinani"	0	0	172	172
-City & County of Honolulu	44-03	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	200	200
-City & County of Honolulu	44-03	State Representative	44	R	"KU, Tercia L."	0	0	38	38
-City & County of Honolulu	44-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	477	477
-City & County of Honolulu	44-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	44-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	44-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	44-04	Straight Party			REPUBLICAN PARTY (R)	0	0	90	90
-City & County of Honolulu	44-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	44-04	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300
-City & County of Honolulu	44-04	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
-City & County of Honolulu	44-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	44-04	State Senate	21	D	"HANABUSA, Colleen"	0	0	341	341
-City & County of Honolulu	44-04	State Senate	21	R	"JOHNSON, Dickyj"	0	0	58	58
-City & County of Honolulu	44-04	State Representative	44	D	"AWANA, Karen Leinani"	0	0	232	232
-City & County of Honolulu	44-04	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	175	175
-City & County of Honolulu	44-04	State Representative	44	R	"KU, Tercia L."	0	0	64	64
-City & County of Honolulu	45-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	637	637
-City & County of Honolulu	45-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	45-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	45-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	45-01	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101
-City & County of Honolulu	45-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	45-01	US Representative	2	D	"HIRONO, Mazie"	0	0	433	433
-City & County of Honolulu	45-01	US Representative	2	R	"EVANS, Roger B."	0	0	53	53
-City & County of Honolulu	45-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	45-01	State Senate	21	D	"HANABUSA, Colleen"	0	0	497	497
-City & County of Honolulu	45-01	State Senate	21	R	"JOHNSON, Dickyj"	0	0	58	58
-City & County of Honolulu	45-01	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	471	471
-City & County of Honolulu	45-01	State Representative	45	D	"SAYLORS, Denise"	0	0	85	85
-City & County of Honolulu	45-01	State Representative	45	R	"GAPOL, Derek A."	0	0	72	72
-City & County of Honolulu	45-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	312	312
-City & County of Honolulu	45-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	45-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	45-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	45-02	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42
-City & County of Honolulu	45-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	45-02	US Representative	2	D	"HIRONO, Mazie"	0	0	221	221
-City & County of Honolulu	45-02	US Representative	2	R	"EVANS, Roger B."	0	0	21	21
-City & County of Honolulu	45-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	45-02	State Senate	21	D	"HANABUSA, Colleen"	0	0	237	237
-City & County of Honolulu	45-02	State Senate	21	R	"JOHNSON, Dickyj"	0	0	20	20
-City & County of Honolulu	45-02	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	213	213
-City & County of Honolulu	45-02	State Representative	45	D	"SAYLORS, Denise"	0	0	53	53
-City & County of Honolulu	45-02	State Representative	45	R	"GAPOL, Derek A."	0	0	28	28
-City & County of Honolulu	45-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	136	136
-City & County of Honolulu	45-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	45-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	45-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	45-03	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24
-City & County of Honolulu	45-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	45-03	US Representative	2	D	"HIRONO, Mazie"	0	0	88	88
-City & County of Honolulu	45-03	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
-City & County of Honolulu	45-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	45-03	State Senate	21	D	"HANABUSA, Colleen"	0	0	98	98
-City & County of Honolulu	45-03	State Senate	21	R	"JOHNSON, Dickyj"	0	0	13	13
-City & County of Honolulu	45-03	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	96	96
-City & County of Honolulu	45-03	State Representative	45	D	"SAYLORS, Denise"	0	0	24	24
-City & County of Honolulu	45-03	State Representative	45	R	"GAPOL, Derek A."	0	0	13	13
-City & County of Honolulu	45-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	424	424
-City & County of Honolulu	45-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	45-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	45-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	45-04	Straight Party			REPUBLICAN PARTY (R)	0	0	91	91
-City & County of Honolulu	45-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	45-04	US Representative	2	D	"HIRONO, Mazie"	0	0	266	266
-City & County of Honolulu	45-04	US Representative	2	R	"EVANS, Roger B."	0	0	44	44
-City & County of Honolulu	45-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	45-04	State Senate	21	D	"HANABUSA, Colleen"	0	0	291	291
-City & County of Honolulu	45-04	State Senate	21	R	"JOHNSON, Dickyj"	0	0	56	56
-City & County of Honolulu	45-04	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	265	265
-City & County of Honolulu	45-04	State Representative	45	D	"SAYLORS, Denise"	0	0	110	110
-City & County of Honolulu	45-04	State Representative	45	R	"GAPOL, Derek A."	0	0	63	63
-City & County of Honolulu	46-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	225	225
-City & County of Honolulu	46-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	46-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	46-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	46-01	Straight Party			REPUBLICAN PARTY (R)	0	0	164	164
-City & County of Honolulu	46-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	46-01	US Representative	2	D	"HIRONO, Mazie"	0	0	152	152
-City & County of Honolulu	46-01	US Representative	2	R	"EVANS, Roger B."	0	0	106	106
-City & County of Honolulu	46-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	46-01	State Senate	23	D	"HEE, Clayton"	0	0	162	162
-City & County of Honolulu	46-01	State Senate	23	D	"MURAKI, Noel S."	0	0	35	35
-City & County of Honolulu	46-01	State Senate	23	R	"FALE, Richard"	0	0	117	117
-City & County of Honolulu	46-01	State Representative	46	D	"LUNASCO, Ollie"	0	0	6	6
-City & County of Honolulu	46-01	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	155	155
-City & County of Honolulu	46-01	State Representative	46	D	"WASSON, Dawn K."	0	0	50	50
-City & County of Honolulu	46-01	State Representative	46	R	"PHILIPS, Carol"	0	0	102	102
-City & County of Honolulu	46-01	State Representative	46	R	"RIVIERE, Gil"	0	0	49	49
-City & County of Honolulu	46-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	42	42
-City & County of Honolulu	46-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	46-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	46-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	46-02	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
-City & County of Honolulu	46-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	46-02	US Representative	2	D	"HIRONO, Mazie"	0	0	33	33
-City & County of Honolulu	46-02	US Representative	2	R	"EVANS, Roger B."	0	0	5	5
-City & County of Honolulu	46-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	46-02	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	30	30
-City & County of Honolulu	46-02	State Representative	46	D	"LUNASCO, Ollie"	0	0	8	8
-City & County of Honolulu	46-02	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	28	28
-City & County of Honolulu	46-02	State Representative	46	D	"WASSON, Dawn K."	0	0	3	3
-City & County of Honolulu	46-02	State Representative	46	R	"PHILIPS, Carol"	0	0	6	6
-City & County of Honolulu	46-02	State Representative	46	R	"RIVIERE, Gil"	0	0	1	1
-City & County of Honolulu	46-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	481	481
-City & County of Honolulu	46-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	46-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	46-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	46-03	Straight Party			REPUBLICAN PARTY (R)	0	0	222	222
-City & County of Honolulu	46-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	46-03	US Representative	2	D	"HIRONO, Mazie"	0	0	346	346
-City & County of Honolulu	46-03	US Representative	2	R	"EVANS, Roger B."	0	0	79	79
-City & County of Honolulu	46-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	46-03	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	352	352
-City & County of Honolulu	46-03	State Representative	46	D	"LUNASCO, Ollie"	0	0	91	91
-City & County of Honolulu	46-03	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	328	328
-City & County of Honolulu	46-03	State Representative	46	D	"WASSON, Dawn K."	0	0	39	39
-City & County of Honolulu	46-03	State Representative	46	R	"PHILIPS, Carol"	0	0	100	100
-City & County of Honolulu	46-03	State Representative	46	R	"RIVIERE, Gil"	0	0	119	119
-City & County of Honolulu	46-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392
-City & County of Honolulu	46-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	46-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	46-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	46-04	Straight Party			REPUBLICAN PARTY (R)	0	0	208	208
-City & County of Honolulu	46-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	46-04	US Representative	2	D	"HIRONO, Mazie"	0	0	307	307
-City & County of Honolulu	46-04	US Representative	2	R	"EVANS, Roger B."	0	0	70	70
-City & County of Honolulu	46-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	46-04	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	289	289
-City & County of Honolulu	46-04	State Representative	46	D	"LUNASCO, Ollie"	0	0	57	57
-City & County of Honolulu	46-04	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	289	289
-City & County of Honolulu	46-04	State Representative	46	D	"WASSON, Dawn K."	0	0	25	25
-City & County of Honolulu	46-04	State Representative	46	R	"PHILIPS, Carol"	0	0	88	88
-City & County of Honolulu	46-04	State Representative	46	R	"RIVIERE, Gil"	0	0	117	117
-City & County of Honolulu	46-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	254	254
-City & County of Honolulu	46-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	46-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	46-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	46-05	Straight Party			REPUBLICAN PARTY (R)	0	0	295	295
-City & County of Honolulu	46-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	46-05	US Representative	2	D	"HIRONO, Mazie"	0	0	174	174
-City & County of Honolulu	46-05	US Representative	2	R	"EVANS, Roger B."	0	0	106	106
-City & County of Honolulu	46-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	46-05	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	154	154
-City & County of Honolulu	46-05	State Representative	46	D	"LUNASCO, Ollie"	0	0	31	31
-City & County of Honolulu	46-05	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	160	160
-City & County of Honolulu	46-05	State Representative	46	D	"WASSON, Dawn K."	0	0	35	35
-City & County of Honolulu	46-05	State Representative	46	R	"PHILIPS, Carol"	0	0	108	108
-City & County of Honolulu	46-05	State Representative	46	R	"RIVIERE, Gil"	0	0	186	186
-City & County of Honolulu	46-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	220	220
-City & County of Honolulu	46-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	46-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	46-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	46-06	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115
-City & County of Honolulu	46-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	46-06	US Representative	2	D	"HIRONO, Mazie"	0	0	177	177
-City & County of Honolulu	46-06	US Representative	2	R	"EVANS, Roger B."	0	0	51	51
-City & County of Honolulu	46-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	46-06	State Senate	23	D	"HEE, Clayton"	0	0	153	153
-City & County of Honolulu	46-06	State Senate	23	D	"MURAKI, Noel S."	0	0	29	29
-City & County of Honolulu	46-06	State Senate	23	R	"FALE, Richard"	0	0	66	66
-City & County of Honolulu	46-06	State Representative	46	D	"LUNASCO, Ollie"	0	0	26	26
-City & County of Honolulu	46-06	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	130	130
-City & County of Honolulu	46-06	State Representative	46	D	"WASSON, Dawn K."	0	0	51	51
-City & County of Honolulu	46-06	State Representative	46	R	"PHILIPS, Carol"	0	0	55	55
-City & County of Honolulu	46-06	State Representative	46	R	"RIVIERE, Gil"	0	0	50	50
-City & County of Honolulu	47-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	496	496
-City & County of Honolulu	47-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	47-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	47-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	47-01	Straight Party			REPUBLICAN PARTY (R)	0	0	258	258
-City & County of Honolulu	47-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	47-01	US Representative	2	D	"HIRONO, Mazie"	0	0	348	348
-City & County of Honolulu	47-01	US Representative	2	R	"EVANS, Roger B."	0	0	107	107
-City & County of Honolulu	47-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	47-01	State Senate	23	D	"HEE, Clayton"	0	0	309	309
-City & County of Honolulu	47-01	State Senate	23	D	"MURAKI, Noel S."	0	0	112	112
-City & County of Honolulu	47-01	State Senate	23	R	"FALE, Richard"	0	0	129	129
-City & County of Honolulu	47-01	State Representative	47	D	"PACHECO, Maria"	0	0	131	131
-City & County of Honolulu	47-01	State Representative	47	D	"WOOLEY, Jessica"	0	0	299	299
-City & County of Honolulu	47-01	State Representative	47	R	"MEYER, Colleen"	0	0	223	223
-City & County of Honolulu	47-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	383	383
-City & County of Honolulu	47-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	47-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	47-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	47-02	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113
-City & County of Honolulu	47-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	47-02	US Representative	2	D	"HIRONO, Mazie"	0	0	288	288
-City & County of Honolulu	47-02	US Representative	2	R	"EVANS, Roger B."	0	0	33	33
-City & County of Honolulu	47-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	47-02	State Senate	23	D	"HEE, Clayton"	0	0	253	253
-City & County of Honolulu	47-02	State Senate	23	D	"MURAKI, Noel S."	0	0	81	81
-City & County of Honolulu	47-02	State Senate	23	R	"FALE, Richard"	0	0	34	34
-City & County of Honolulu	47-02	State Representative	47	D	"PACHECO, Maria"	0	0	74	74
-City & County of Honolulu	47-02	State Representative	47	D	"WOOLEY, Jessica"	0	0	265	265
-City & County of Honolulu	47-02	State Representative	47	R	"MEYER, Colleen"	0	0	109	109
-City & County of Honolulu	47-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	387	387
-City & County of Honolulu	47-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	47-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	47-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	47-03	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136
-City & County of Honolulu	47-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	47-03	US Representative	2	D	"HIRONO, Mazie"	0	0	310	310
-City & County of Honolulu	47-03	US Representative	2	R	"EVANS, Roger B."	0	0	63	63
-City & County of Honolulu	47-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	47-03	State Senate	23	D	"HEE, Clayton"	0	0	255	255
-City & County of Honolulu	47-03	State Senate	23	D	"MURAKI, Noel S."	0	0	93	93
-City & County of Honolulu	47-03	State Senate	23	R	"FALE, Richard"	0	0	60	60
-City & County of Honolulu	47-03	State Representative	47	D	"PACHECO, Maria"	0	0	82	82
-City & County of Honolulu	47-03	State Representative	47	D	"WOOLEY, Jessica"	0	0	270	270
-City & County of Honolulu	47-03	State Representative	47	R	"MEYER, Colleen"	0	0	129	129
-City & County of Honolulu	47-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	147	147
-City & County of Honolulu	47-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	47-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	47-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	47-04	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36
-City & County of Honolulu	47-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-City & County of Honolulu	47-04	US Representative	2	D	"HIRONO, Mazie"	0	0	117	117
-City & County of Honolulu	47-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17
-City & County of Honolulu	47-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	47-04	State Senate	23	D	"HEE, Clayton"	0	0	93	93
-City & County of Honolulu	47-04	State Senate	23	D	"MURAKI, Noel S."	0	0	33	33
-City & County of Honolulu	47-04	State Senate	23	R	"FALE, Richard"	0	0	13	13
-City & County of Honolulu	47-04	State Representative	47	D	"PACHECO, Maria"	0	0	22	22
-City & County of Honolulu	47-04	State Representative	47	D	"WOOLEY, Jessica"	0	0	98	98
-City & County of Honolulu	47-04	State Representative	47	R	"MEYER, Colleen"	0	0	34	34
-City & County of Honolulu	47-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	87	87
-City & County of Honolulu	47-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	47-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	47-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	47-05	Straight Party			REPUBLICAN PARTY (R)	0	0	37	37
-City & County of Honolulu	47-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	47-05	US Representative	2	D	"HIRONO, Mazie"	0	0	73	73
-City & County of Honolulu	47-05	US Representative	2	R	"EVANS, Roger B."	0	0	19	19
-City & County of Honolulu	47-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	47-05	State Senate	23	D	"HEE, Clayton"	0	0	44	44
-City & County of Honolulu	47-05	State Senate	23	D	"MURAKI, Noel S."	0	0	35	35
-City & County of Honolulu	47-05	State Senate	23	R	"FALE, Richard"	0	0	20	20
-City & County of Honolulu	47-05	State Representative	47	D	"PACHECO, Maria"	0	0	20	20
-City & County of Honolulu	47-05	State Representative	47	D	"WOOLEY, Jessica"	0	0	55	55
-City & County of Honolulu	47-05	State Representative	47	R	"MEYER, Colleen"	0	0	35	35
-City & County of Honolulu	47-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	984	984
-City & County of Honolulu	47-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	47-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
-City & County of Honolulu	47-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	47-06	Straight Party			REPUBLICAN PARTY (R)	0	0	240	240
-City & County of Honolulu	47-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-City & County of Honolulu	47-06	US Representative	2	D	"HIRONO, Mazie"	0	0	730	730
-City & County of Honolulu	47-06	US Representative	2	R	"EVANS, Roger B."	0	0	90	90
-City & County of Honolulu	47-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	7	7
-City & County of Honolulu	47-06	State Senate	23	D	"HEE, Clayton"	0	0	645	645
-City & County of Honolulu	47-06	State Senate	23	D	"MURAKI, Noel S."	0	0	220	220
-City & County of Honolulu	47-06	State Senate	23	R	"FALE, Richard"	0	0	85	85
-City & County of Honolulu	47-06	State Representative	47	D	"PACHECO, Maria"	0	0	160	160
-City & County of Honolulu	47-06	State Representative	47	D	"WOOLEY, Jessica"	0	0	683	683
-City & County of Honolulu	47-06	State Representative	47	R	"MEYER, Colleen"	0	0	231	231
-City & County of Honolulu	48-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	600	600
-City & County of Honolulu	48-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	48-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	48-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	48-01	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112
-City & County of Honolulu	48-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	48-01	US Representative	2	D	"HIRONO, Mazie"	0	0	481	481
-City & County of Honolulu	48-01	US Representative	2	R	"EVANS, Roger B."	0	0	85	85
-City & County of Honolulu	48-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	48-01	State Senate	23	D	"HEE, Clayton"	0	0	356	356
-City & County of Honolulu	48-01	State Senate	23	D	"MURAKI, Noel S."	0	0	150	150
-City & County of Honolulu	48-01	State Senate	23	R	"FALE, Richard"	0	0	75	75
-City & County of Honolulu	48-01	State Representative	48	D	"ITO, Ken"	0	0	452	452
-City & County of Honolulu	48-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	486	486
-City & County of Honolulu	48-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	48-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	48-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	48-02	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108
-City & County of Honolulu	48-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-City & County of Honolulu	48-02	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380
-City & County of Honolulu	48-02	US Representative	2	R	"EVANS, Roger B."	0	0	104	104
-City & County of Honolulu	48-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	48-02	State Representative	48	D	"ITO, Ken"	0	0	355	355
-City & County of Honolulu	48-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	642	642
-City & County of Honolulu	48-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	48-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	48-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
-City & County of Honolulu	48-03	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115
-City & County of Honolulu	48-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-City & County of Honolulu	48-03	US Representative	2	D	"HIRONO, Mazie"	0	0	487	487
-City & County of Honolulu	48-03	US Representative	2	R	"EVANS, Roger B."	0	0	107	107
-City & County of Honolulu	48-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	48-03	State Representative	48	D	"ITO, Ken"	0	0	493	493
-City & County of Honolulu	48-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	833	833
-City & County of Honolulu	48-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
-City & County of Honolulu	48-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	48-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	48-04	Straight Party			REPUBLICAN PARTY (R)	0	0	128	128
-City & County of Honolulu	48-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	9	9
-City & County of Honolulu	48-04	US Representative	2	D	"HIRONO, Mazie"	0	0	667	667
-City & County of Honolulu	48-04	US Representative	2	R	"EVANS, Roger B."	0	0	121	121
-City & County of Honolulu	48-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
-City & County of Honolulu	48-04	State Representative	48	D	"ITO, Ken"	0	0	659	659
-City & County of Honolulu	48-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267
-City & County of Honolulu	48-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	48-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	48-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-City & County of Honolulu	48-05	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48
-City & County of Honolulu	48-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-City & County of Honolulu	48-05	US Representative	2	D	"HIRONO, Mazie"	0	0	205	205
-City & County of Honolulu	48-05	US Representative	2	R	"EVANS, Roger B."	0	0	41	41
-City & County of Honolulu	48-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	48-05	State Senate	23	D	"HEE, Clayton"	0	0	150	150
-City & County of Honolulu	48-05	State Senate	23	D	"MURAKI, Noel S."	0	0	82	82
-City & County of Honolulu	48-05	State Senate	23	R	"FALE, Richard"	0	0	35	35
-City & County of Honolulu	48-05	State Representative	48	D	"ITO, Ken"	0	0	204	204
-City & County of Honolulu	49-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	513	513
-City & County of Honolulu	49-01	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15
-City & County of Honolulu	49-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	49-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	49-01	Straight Party			REPUBLICAN PARTY (R)	0	0	192	192
-City & County of Honolulu	49-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
-City & County of Honolulu	49-01	US Representative	2	D	"HIRONO, Mazie"	0	0	361	361
-City & County of Honolulu	49-01	US Representative	2	R	"EVANS, Roger B."	0	0	182	182
-City & County of Honolulu	49-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-City & County of Honolulu	49-01	State Representative	49	D	"CHONG, Pono"	0	0	343	343
-City & County of Honolulu	49-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	283	283
-City & County of Honolulu	49-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	49-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	49-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	49-02	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
-City & County of Honolulu	49-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	49-02	US Representative	2	D	"HIRONO, Mazie"	0	0	226	226
-City & County of Honolulu	49-02	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
-City & County of Honolulu	49-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	49-02	State Representative	49	D	"CHONG, Pono"	0	0	192	192
-City & County of Honolulu	49-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	578	578
-City & County of Honolulu	49-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	49-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	49-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	49-03	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154
-City & County of Honolulu	49-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-City & County of Honolulu	49-03	US Representative	2	D	"HIRONO, Mazie"	0	0	422	422
-City & County of Honolulu	49-03	US Representative	2	R	"EVANS, Roger B."	0	0	143	143
-City & County of Honolulu	49-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
-City & County of Honolulu	49-03	State Representative	49	D	"CHONG, Pono"	0	0	410	410
-City & County of Honolulu	49-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	232	232
-City & County of Honolulu	49-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	49-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	49-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	49-04	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75
-City & County of Honolulu	49-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	49-04	US Representative	2	D	"HIRONO, Mazie"	0	0	175	175
-City & County of Honolulu	49-04	US Representative	2	R	"EVANS, Roger B."	0	0	74	74
-City & County of Honolulu	49-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	49-04	State Representative	49	D	"CHONG, Pono"	0	0	149	149
-City & County of Honolulu	49-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317
-City & County of Honolulu	49-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	49-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	49-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	49-05	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
-City & County of Honolulu	49-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	49-05	US Representative	2	D	"HIRONO, Mazie"	0	0	235	235
-City & County of Honolulu	49-05	US Representative	2	R	"EVANS, Roger B."	0	0	103	103
-City & County of Honolulu	49-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-City & County of Honolulu	49-05	State Representative	49	D	"CHONG, Pono"	0	0	212	212
-City & County of Honolulu	49-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	417	417
-City & County of Honolulu	49-06	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
-City & County of Honolulu	49-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	49-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	49-06	Straight Party			REPUBLICAN PARTY (R)	0	0	69	69
-City & County of Honolulu	49-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
-City & County of Honolulu	49-06	US Representative	2	D	"HIRONO, Mazie"	0	0	338	338
-City & County of Honolulu	49-06	US Representative	2	R	"EVANS, Roger B."	0	0	69	69
-City & County of Honolulu	49-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	49-06	State Representative	49	D	"CHONG, Pono"	0	0	251	251
-City & County of Honolulu	49-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	575	575
-City & County of Honolulu	49-07	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
-City & County of Honolulu	49-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	49-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
-City & County of Honolulu	49-07	Straight Party			REPUBLICAN PARTY (R)	0	0	143	143
-City & County of Honolulu	49-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-City & County of Honolulu	49-07	US Representative	2	D	"HIRONO, Mazie"	0	0	463	463
-City & County of Honolulu	49-07	US Representative	2	R	"EVANS, Roger B."	0	0	117	117
-City & County of Honolulu	49-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-City & County of Honolulu	49-07	State Senate	23	D	"HEE, Clayton"	0	0	319	319
-City & County of Honolulu	49-07	State Senate	23	D	"MURAKI, Noel S."	0	0	154	154
-City & County of Honolulu	49-07	State Senate	23	R	"FALE, Richard"	0	0	87	87
-City & County of Honolulu	49-07	State Representative	49	D	"CHONG, Pono"	0	0	430	430
-City & County of Honolulu	50-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	275	275
-City & County of Honolulu	50-01	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14
-City & County of Honolulu	50-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	50-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
-City & County of Honolulu	50-01	Straight Party			REPUBLICAN PARTY (R)	0	0	202	202
-City & County of Honolulu	50-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
-City & County of Honolulu	50-01	US Representative	2	D	"HIRONO, Mazie"	0	0	253	253
-City & County of Honolulu	50-01	US Representative	2	R	"EVANS, Roger B."	0	0	58	58
-City & County of Honolulu	50-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	50-01	State Representative	50	R	"THIELEN, Cynthia"	0	0	184	184
-City & County of Honolulu	50-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311
-City & County of Honolulu	50-02	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15
-City & County of Honolulu	50-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	50-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	50-02	Straight Party			REPUBLICAN PARTY (R)	0	0	174	174
-City & County of Honolulu	50-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	15	15
-City & County of Honolulu	50-02	US Representative	2	D	"HIRONO, Mazie"	0	0	286	286
-City & County of Honolulu	50-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54
-City & County of Honolulu	50-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
-City & County of Honolulu	50-02	State Representative	50	R	"THIELEN, Cynthia"	0	0	155	155
-City & County of Honolulu	50-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	214	214
-City & County of Honolulu	50-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	50-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	50-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	50-03	Straight Party			REPUBLICAN PARTY (R)	0	0	140	140
-City & County of Honolulu	50-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	50-03	US Representative	2	D	"HIRONO, Mazie"	0	0	201	201
-City & County of Honolulu	50-03	US Representative	2	R	"EVANS, Roger B."	0	0	39	39
-City & County of Honolulu	50-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	50-03	State Representative	50	R	"THIELEN, Cynthia"	0	0	121	121
-City & County of Honolulu	50-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
-City & County of Honolulu	50-04	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
-City & County of Honolulu	50-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	50-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
-City & County of Honolulu	50-04	Straight Party			REPUBLICAN PARTY (R)	0	0	151	151
-City & County of Honolulu	50-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10
-City & County of Honolulu	50-04	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300
-City & County of Honolulu	50-04	US Representative	2	R	"EVANS, Roger B."	0	0	47	47
-City & County of Honolulu	50-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	50-04	State Representative	50	R	"THIELEN, Cynthia"	0	0	133	133
-City & County of Honolulu	50-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313
-City & County of Honolulu	50-05	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
-City & County of Honolulu	50-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	50-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
-City & County of Honolulu	50-05	Straight Party			REPUBLICAN PARTY (R)	0	0	270	270
-City & County of Honolulu	50-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8
-City & County of Honolulu	50-05	US Representative	2	D	"HIRONO, Mazie"	0	0	296	296
-City & County of Honolulu	50-05	US Representative	2	R	"EVANS, Roger B."	0	0	83	83
-City & County of Honolulu	50-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	50-05	State Representative	50	R	"THIELEN, Cynthia"	0	0	244	244
-City & County of Honolulu	50-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293
-City & County of Honolulu	50-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
-City & County of Honolulu	50-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	50-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
-City & County of Honolulu	50-06	Straight Party			REPUBLICAN PARTY (R)	0	0	282	282
-City & County of Honolulu	50-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
-City & County of Honolulu	50-06	US Representative	2	D	"HIRONO, Mazie"	0	0	265	265
-City & County of Honolulu	50-06	US Representative	2	R	"EVANS, Roger B."	0	0	76	76
-City & County of Honolulu	50-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	50-06	State Representative	50	R	"THIELEN, Cynthia"	0	0	248	248
-City & County of Honolulu	50-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	117	117
-City & County of Honolulu	50-07	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
-City & County of Honolulu	50-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
-City & County of Honolulu	50-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	50-07	Straight Party			REPUBLICAN PARTY (R)	0	0	137	137
-City & County of Honolulu	50-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
-City & County of Honolulu	50-07	US Representative	2	D	"HIRONO, Mazie"	0	0	106	106
-City & County of Honolulu	50-07	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
-City & County of Honolulu	50-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
-City & County of Honolulu	50-07	State Representative	50	R	"THIELEN, Cynthia"	0	0	129	129
-City & County of Honolulu	51-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	327	327
-City & County of Honolulu	51-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
-City & County of Honolulu	51-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
-City & County of Honolulu	51-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	51-01	Straight Party			REPUBLICAN PARTY (R)	0	0	161	161
-City & County of Honolulu	51-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
-City & County of Honolulu	51-01	US Representative	2	D	"HIRONO, Mazie"	0	0	195	195
-City & County of Honolulu	51-01	US Representative	2	R	"EVANS, Roger B."	0	0	65	65
-City & County of Honolulu	51-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	51-01	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	82	82
-City & County of Honolulu	51-01	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	12	12
-City & County of Honolulu	51-01	State Representative	51	D	"LEE, Chris Kalani"	0	0	210	210
-City & County of Honolulu	51-01	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	149	149
-City & County of Honolulu	51-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	567	567
-City & County of Honolulu	51-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	51-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
-City & County of Honolulu	51-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	51-02	Straight Party			REPUBLICAN PARTY (R)	0	0	92	92
-City & County of Honolulu	51-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	51-02	US Representative	2	D	"HIRONO, Mazie"	0	0	381	381
-City & County of Honolulu	51-02	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
-City & County of Honolulu	51-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
-City & County of Honolulu	51-02	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	304	304
-City & County of Honolulu	51-02	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	12	12
-City & County of Honolulu	51-02	State Representative	51	D	"LEE, Chris Kalani"	0	0	225	225
-City & County of Honolulu	51-02	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	85	85
-City & County of Honolulu	51-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	663	663
-City & County of Honolulu	51-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
-City & County of Honolulu	51-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	51-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
-City & County of Honolulu	51-03	Straight Party			REPUBLICAN PARTY (R)	0	0	82	82
-City & County of Honolulu	51-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
-City & County of Honolulu	51-03	US Representative	2	D	"HIRONO, Mazie"	0	0	423	423
-City & County of Honolulu	51-03	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
-City & County of Honolulu	51-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	51-03	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	340	340
-City & County of Honolulu	51-03	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	21	21
-City & County of Honolulu	51-03	State Representative	51	D	"LEE, Chris Kalani"	0	0	285	285
-City & County of Honolulu	51-03	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	78	78
-City & County of Honolulu	51-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	132	132
-City & County of Honolulu	51-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
-City & County of Honolulu	51-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-City & County of Honolulu	51-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	51-04	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34
-City & County of Honolulu	51-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
-City & County of Honolulu	51-04	US Representative	2	D	"HIRONO, Mazie"	0	0	102	102
-City & County of Honolulu	51-04	US Representative	2	R	"EVANS, Roger B."	0	0	13	13
-City & County of Honolulu	51-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-City & County of Honolulu	51-04	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	35	35
-City & County of Honolulu	51-04	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	7	7
-City & County of Honolulu	51-04	State Representative	51	D	"LEE, Chris Kalani"	0	0	87	87
-City & County of Honolulu	51-04	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	32	32
-City & County of Honolulu	51-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	706	706
-City & County of Honolulu	51-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
-City & County of Honolulu	51-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	51-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	51-05	Straight Party			REPUBLICAN PARTY (R)	0	0	176	176
-City & County of Honolulu	51-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
-City & County of Honolulu	51-05	US Representative	2	D	"HIRONO, Mazie"	0	0	467	467
-City & County of Honolulu	51-05	US Representative	2	R	"EVANS, Roger B."	0	0	62	62
-City & County of Honolulu	51-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	51-05	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	241	241
-City & County of Honolulu	51-05	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	21	21
-City & County of Honolulu	51-05	State Representative	51	D	"LEE, Chris Kalani"	0	0	414	414
-City & County of Honolulu	51-05	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	170	170
-City & County of Honolulu	51-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	360	360
-City & County of Honolulu	51-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
-City & County of Honolulu	51-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
-City & County of Honolulu	51-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
-City & County of Honolulu	51-06	Straight Party			REPUBLICAN PARTY (R)	0	0	137	137
-City & County of Honolulu	51-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
-City & County of Honolulu	51-06	US Representative	2	D	"HIRONO, Mazie"	0	0	224	224
-City & County of Honolulu	51-06	US Representative	2	R	"EVANS, Roger B."	0	0	60	60
-City & County of Honolulu	51-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
-City & County of Honolulu	51-06	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	85	85
-City & County of Honolulu	51-06	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	26	26
-City & County of Honolulu	51-06	State Representative	51	D	"LEE, Chris Kalani"	0	0	229	229
-City & County of Honolulu	51-06	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	129	129
-City & County of Honolulu	51-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	162	162
-City & County of Honolulu	51-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-City & County of Honolulu	51-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
-City & County of Honolulu	51-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
-City & County of Honolulu	51-07	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83
-City & County of Honolulu	51-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-City & County of Honolulu	51-07	US Representative	2	D	"HIRONO, Mazie"	0	0	106	106
-City & County of Honolulu	51-07	US Representative	2	R	"EVANS, Roger B."	0	0	34	34
-City & County of Honolulu	51-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
-City & County of Honolulu	51-07	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	29	29
-City & County of Honolulu	51-07	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	6	6
-City & County of Honolulu	51-07	State Representative	51	D	"LEE, Chris Kalani"	0	0	109	109
-City & County of Honolulu	51-07	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	69	69
-	AB-01	Straight Party			DEMOCRATIC PARTY (D)	174	312	0	486
-	AB-01	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
-	AB-01	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
-	AB-01	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7
-	AB-01	Straight Party			REPUBLICAN PARTY (R)	27	27	0	54
-	AB-01	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1
-	AB-01	US Representative	2	D	"HIRONO, Mazie"	146	242	0	388
-	AB-01	US Representative	2	R	"EVANS, Roger B."	22	17	0	39
-	AB-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
-	AB-01	State Senate	3	D	"ISBELL, Virginia"	30	31	0	61
-	AB-01	State Senate	3	D	"GREEN, Josh"	137	264	0	401
-	AB-01	State Representative	1	D	"FUJIYAMA, Ken"	12	49	0	61
-	AB-01	State Representative	1	D	"KIM, Jo"	44	70	0	114
-	AB-01	State Representative	1	D	"NAKASHIMA, Mark M."	84	146	0	230
-	AB-01	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	16	11	0	27
-	AB-01	State Representative	1	R	"OFFENBAKER, Steven A."	14	11	0	25
-	AB-01	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	8	8	0	16
-	AB-02	Straight Party			DEMOCRATIC PARTY (D)	721	460	0	1181
-	AB-02	Straight Party			INDEPENDENT PARTY (I)	2	2	0	4
-	AB-02	Straight Party			LIBERTARIAN PARTY (L)	2	1	0	3
-	AB-02	Straight Party			NONPARTISAN BALLOT (N)	1	5	0	6
-	AB-02	Straight Party			REPUBLICAN PARTY (R)	75	67	0	142
-	AB-02	US Representative	2	I	"STENSHOL, Shaun"	2	2	0	4
-	AB-02	US Representative	2	D	"HIRONO, Mazie"	574	360	0	934
-	AB-02	US Representative	2	R	"EVANS, Roger B."	45	44	0	89
-	AB-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2
-	AB-02	State Senate	1	D	"TAKAMINE, Dwight Y."	627	380	0	1007
-	AB-02	State Senate	1	R	"HONG, Ted H.S."	58	62	0	120
-	AB-02	State Representative	1	D	"FUJIYAMA, Ken"	75	59	0	134
-	AB-02	State Representative	1	D	"KIM, Jo"	144	115	0	259
-	AB-02	State Representative	1	D	"NAKASHIMA, Mark M."	437	230	0	667
-	AB-02	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	16	17	0	33
-	AB-02	State Representative	1	R	"OFFENBAKER, Steven A."	37	41	0	78
-	AB-02	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	15	10	0	25
-	AB-03	Straight Party			DEMOCRATIC PARTY (D)	23	34	0	57
-	AB-03	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
-	AB-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-03	Straight Party			REPUBLICAN PARTY (R)	12	10	0	22
-	AB-03	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1
-	AB-03	US Representative	2	D	"HIRONO, Mazie"	20	25	0	45
-	AB-03	US Representative	2	R	"EVANS, Roger B."	8	9	0	17
-	AB-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-03	State Senate	1	D	"TAKAMINE, Dwight Y."	17	23	0	40
-	AB-03	State Senate	1	R	"HONG, Ted H.S."	10	9	0	19
-	AB-03	State Representative	1	D	"FUJIYAMA, Ken"	3	7	0	10
-	AB-03	State Representative	1	D	"KIM, Jo"	3	12	0	15
-	AB-03	State Representative	1	D	"NAKASHIMA, Mark M."	10	8	0	18
-	AB-03	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	1	0	0	1
-	AB-03	State Representative	1	R	"OFFENBAKER, Steven A."	6	6	0	12
-	AB-03	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	5	1	0	6
-	AB-04	Straight Party			DEMOCRATIC PARTY (D)	726	830	0	1556
-	AB-04	Straight Party			INDEPENDENT PARTY (I)	5	7	0	12
-	AB-04	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
-	AB-04	Straight Party			NONPARTISAN BALLOT (N)	7	9	0	16
-	AB-04	Straight Party			REPUBLICAN PARTY (R)	145	126	0	271
-	AB-04	US Representative	2	I	"STENSHOL, Shaun"	3	6	0	9
-	AB-04	US Representative	2	D	"HIRONO, Mazie"	575	593	0	1168
-	AB-04	US Representative	2	R	"EVANS, Roger B."	86	57	0	143
-	AB-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2
-	AB-04	State Senate	1	D	"TAKAMINE, Dwight Y."	568	596	0	1164
-	AB-04	State Senate	1	R	"HONG, Ted H.S."	132	118	0	250
-	AB-04	State Representative	2	D	"CHANG, Jerry Leslie"	554	603	0	1157
-	AB-05	Straight Party			DEMOCRATIC PARTY (D)	283	349	0	632
-	AB-05	Straight Party			INDEPENDENT PARTY (I)	1	6	0	7
-	AB-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-05	Straight Party			NONPARTISAN BALLOT (N)	3	3	0	6
-	AB-05	Straight Party			REPUBLICAN PARTY (R)	39	52	0	91
-	AB-05	US Representative	2	I	"STENSHOL, Shaun"	1	4	0	5
-	AB-05	US Representative	2	D	"HIRONO, Mazie"	243	252	0	495
-	AB-05	US Representative	2	R	"EVANS, Roger B."	17	32	0	49
-	AB-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-05	State Senate	1	D	"TAKAMINE, Dwight Y."	215	248	0	463
-	AB-05	State Senate	1	R	"HONG, Ted H.S."	36	48	0	84
-	AB-05	State Representative	2	D	"CHANG, Jerry Leslie"	215	248	0	463
-	AB-06	Straight Party			DEMOCRATIC PARTY (D)	854	874	0	1728
-	AB-06	Straight Party			INDEPENDENT PARTY (I)	5	3	0	8
-	AB-06	Straight Party			LIBERTARIAN PARTY (L)	3	2	0	5
-	AB-06	Straight Party			NONPARTISAN BALLOT (N)	5	8	0	13
-	AB-06	Straight Party			REPUBLICAN PARTY (R)	74	67	0	141
-	AB-06	US Representative	2	I	"STENSHOL, Shaun"	5	2	0	7
-	AB-06	US Representative	2	D	"HIRONO, Mazie"	725	710	0	1435
-	AB-06	US Representative	2	R	"EVANS, Roger B."	53	48	0	101
-	AB-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	2	0	5
-	AB-06	State Representative	3	D	"TSUJI, Clifton (Clift)"	713	737	0	1450
-	AB-06	State Representative	3	R	"TAVARES, Deirdre (Moana)"	54	45	0	99
-	AB-07	Straight Party			DEMOCRATIC PARTY (D)	67	68	0	135
-	AB-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-07	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-07	Straight Party			REPUBLICAN PARTY (R)	6	3	0	9
-	AB-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-	AB-07	US Representative	2	D	"HIRONO, Mazie"	59	57	0	116
-	AB-07	US Representative	2	R	"EVANS, Roger B."	4	2	0	6
-	AB-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
-	AB-07	State Representative	3	D	"TSUJI, Clifton (Clift)"	55	61	0	116
-	AB-07	State Representative	3	R	"TAVARES, Deirdre (Moana)"	5	3	0	8
-	AB-08	Straight Party			DEMOCRATIC PARTY (D)	61	69	0	130
-	AB-08	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-08	Straight Party			REPUBLICAN PARTY (R)	2	12	0	14
-	AB-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-	AB-08	US Representative	2	D	"HIRONO, Mazie"	52	56	0	108
-	AB-08	US Representative	2	R	"EVANS, Roger B."	1	7	0	8
-	AB-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-08	State Senate	1	D	"TAKAMINE, Dwight Y."	51	47	0	98
-	AB-08	State Senate	1	R	"HONG, Ted H.S."	2	7	0	9
-	AB-08	State Representative	3	D	"TSUJI, Clifton (Clift)"	51	57	0	108
-	AB-08	State Representative	3	R	"TAVARES, Deirdre (Moana)"	1	5	0	6
-	AB-09	Straight Party			DEMOCRATIC PARTY (D)	273	361	0	634
-	AB-09	Straight Party			INDEPENDENT PARTY (I)	1	3	0	4
-	AB-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-09	Straight Party			NONPARTISAN BALLOT (N)	1	6	0	7
-	AB-09	Straight Party			REPUBLICAN PARTY (R)	38	32	0	70
-	AB-09	US Representative	2	I	"STENSHOL, Shaun"	1	3	0	4
-	AB-09	US Representative	2	D	"HIRONO, Mazie"	226	282	0	508
-	AB-09	US Representative	2	R	"EVANS, Roger B."	21	16	0	37
-	AB-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-09	State Senate	1	D	"TAKAMINE, Dwight Y."	219	276	0	495
-	AB-09	State Senate	1	R	"HONG, Ted H.S."	33	26	0	59
-	AB-09	State Representative	3	D	"TSUJI, Clifton (Clift)"	214	283	0	497
-	AB-09	State Representative	3	R	"TAVARES, Deirdre (Moana)"	15	14	0	29
-	AB-10	Straight Party			DEMOCRATIC PARTY (D)	180	225	0	405
-	AB-10	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
-	AB-10	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-10	Straight Party			NONPARTISAN BALLOT (N)	0	4	0	4
-	AB-10	Straight Party			REPUBLICAN PARTY (R)	15	12	0	27
-	AB-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-	AB-10	US Representative	2	D	"HIRONO, Mazie"	152	180	0	332
-	AB-10	US Representative	2	R	"EVANS, Roger B."	11	7	0	18
-	AB-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
-	AB-10	State Representative	3	D	"TSUJI, Clifton (Clift)"	156	170	0	326
-	AB-10	State Representative	3	R	"TAVARES, Deirdre (Moana)"	7	6	0	13
-	AB-11	Straight Party			DEMOCRATIC PARTY (D)	59	89	0	148
-	AB-11	Straight Party			INDEPENDENT PARTY (I)	1	3	0	4
-	AB-11	Straight Party			LIBERTARIAN PARTY (L)	0	1	0	1
-	AB-11	Straight Party			NONPARTISAN BALLOT (N)	6	4	0	10
-	AB-11	Straight Party			REPUBLICAN PARTY (R)	10	17	0	27
-	AB-11	US Representative	2	I	"STENSHOL, Shaun"	1	3	0	4
-	AB-11	US Representative	2	D	"HIRONO, Mazie"	47	78	0	125
-	AB-11	US Representative	2	R	"EVANS, Roger B."	8	10	0	18
-	AB-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1
-	AB-11	State Representative	4	D	"HANOHANO, Faye P."	28	37	0	65
-	AB-11	State Representative	4	D	"MARZI, Anthony (Tony)"	10	17	0	27
-	AB-11	State Representative	4	D	"SPARKS, Steven B."	7	27	0	34
-	AB-11	State Representative	4	R	"BLAS, Fred"	9	12	0	21
-	AB-12	Straight Party			DEMOCRATIC PARTY (D)	73	73	0	146
-	AB-12	Straight Party			INDEPENDENT PARTY (I)	1	2	0	3
-	AB-12	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-12	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-12	Straight Party			REPUBLICAN PARTY (R)	15	13	0	28
-	AB-12	US Representative	2	I	"STENSHOL, Shaun"	1	2	0	3
-	AB-12	US Representative	2	D	"HIRONO, Mazie"	60	59	0	119
-	AB-12	US Representative	2	R	"EVANS, Roger B."	13	9	0	22
-	AB-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
-	AB-12	State Representative	4	D	"HANOHANO, Faye P."	30	41	0	71
-	AB-12	State Representative	4	D	"MARZI, Anthony (Tony)"	13	14	0	27
-	AB-12	State Representative	4	D	"SPARKS, Steven B."	19	5	0	24
-	AB-12	State Representative	4	R	"BLAS, Fred"	14	11	0	25
-	AB-13	Straight Party			DEMOCRATIC PARTY (D)	472	637	0	1109
-	AB-13	Straight Party			INDEPENDENT PARTY (I)	8	11	0	19
-	AB-13	Straight Party			LIBERTARIAN PARTY (L)	1	2	0	3
-	AB-13	Straight Party			NONPARTISAN BALLOT (N)	6	12	0	18
-	AB-13	Straight Party			REPUBLICAN PARTY (R)	125	145	0	270
-	AB-13	US Representative	2	I	"STENSHOL, Shaun"	8	9	0	17
-	AB-13	US Representative	2	D	"HIRONO, Mazie"	356	460	0	816
-	AB-13	US Representative	2	R	"EVANS, Roger B."	84	78	0	162
-	AB-13	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	2	0	3
-	AB-13	State Representative	4	D	"HANOHANO, Faye P."	226	278	0	504
-	AB-13	State Representative	4	D	"MARZI, Anthony (Tony)"	140	211	0	351
-	AB-13	State Representative	4	D	"SPARKS, Steven B."	60	100	0	160
-	AB-13	State Representative	4	R	"BLAS, Fred"	93	114	0	207
-	AB-14	Straight Party			DEMOCRATIC PARTY (D)	31	27	0	58
-	AB-14	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-14	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-14	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-14	Straight Party			REPUBLICAN PARTY (R)	7	8	0	15
-	AB-14	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-	AB-14	US Representative	2	D	"HIRONO, Mazie"	26	23	0	49
-	AB-14	US Representative	2	R	"EVANS, Roger B."	7	7	0	14
-	AB-14	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-14	State Representative	5	D	"HERKES, Robert (Bob)"	24	19	0	43
-	AB-15	Straight Party			DEMOCRATIC PARTY (D)	337	439	0	776
-	AB-15	Straight Party			INDEPENDENT PARTY (I)	13	11	0	24
-	AB-15	Straight Party			LIBERTARIAN PARTY (L)	6	3	0	9
-	AB-15	Straight Party			NONPARTISAN BALLOT (N)	7	12	0	19
-	AB-15	Straight Party			REPUBLICAN PARTY (R)	37	71	0	108
-	AB-15	US Representative	2	I	"STENSHOL, Shaun"	11	9	0	20
-	AB-15	US Representative	2	D	"HIRONO, Mazie"	280	356	0	636
-	AB-15	US Representative	2	R	"EVANS, Roger B."	34	65	0	99
-	AB-15	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	6	3	0	9
-	AB-15	State Representative	5	D	"HERKES, Robert (Bob)"	233	287	0	520
-	AB-16	Straight Party			DEMOCRATIC PARTY (D)	110	64	0	174
-	AB-16	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-16	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-16	Straight Party			NONPARTISAN BALLOT (N)	7	0	0	7
-	AB-16	Straight Party			REPUBLICAN PARTY (R)	12	1	0	13
-	AB-16	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-	AB-16	US Representative	2	D	"HIRONO, Mazie"	82	49	0	131
-	AB-16	US Representative	2	R	"EVANS, Roger B."	11	1	0	12
-	AB-16	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-16	State Senate	3	D	"ISBELL, Virginia"	29	19	0	48
-	AB-16	State Senate	3	D	"GREEN, Josh"	78	43	0	121
-	AB-16	State Representative	5	D	"HERKES, Robert (Bob)"	73	41	0	114
-	AB-17	Straight Party			DEMOCRATIC PARTY (D)	256	203	0	459
-	AB-17	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
-	AB-17	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-17	Straight Party			NONPARTISAN BALLOT (N)	2	2	0	4
-	AB-17	Straight Party			REPUBLICAN PARTY (R)	23	27	0	50
-	AB-17	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5
-	AB-17	US Representative	2	D	"HIRONO, Mazie"	201	156	0	357
-	AB-17	US Representative	2	R	"EVANS, Roger B."	21	23	0	44
-	AB-17	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-17	State Senate	3	D	"ISBELL, Virginia"	89	63	0	152
-	AB-17	State Senate	3	D	"GREEN, Josh"	153	129	0	282
-	AB-17	State Representative	5	D	"HERKES, Robert (Bob)"	174	134	0	308
-	AB-18	Straight Party			DEMOCRATIC PARTY (D)	274	471	0	745
-	AB-18	Straight Party			INDEPENDENT PARTY (I)	3	4	0	7
-	AB-18	Straight Party			LIBERTARIAN PARTY (L)	0	2	0	2
-	AB-18	Straight Party			NONPARTISAN BALLOT (N)	4	10	0	14
-	AB-18	Straight Party			REPUBLICAN PARTY (R)	107	122	0	229
-	AB-18	US Representative	2	I	"STENSHOL, Shaun"	2	3	0	5
-	AB-18	US Representative	2	D	"HIRONO, Mazie"	189	345	0	534
-	AB-18	US Representative	2	R	"EVANS, Roger B."	74	70	0	144
-	AB-18	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	2	0	2
-	AB-18	State Senate	3	D	"ISBELL, Virginia"	46	49	0	95
-	AB-18	State Senate	3	D	"GREEN, Josh"	220	408	0	628
-	AB-18	State Representative	6	D	"COFFMAN, Denny"	102	232	0	334
-	AB-18	State Representative	6	D	"LESLIE, Gene (Bucky)"	80	108	0	188
-	AB-18	State Representative	6	D	"MACGREGOR, Maegan"	37	63	0	100
-	AB-18	State Representative	6	R	"SMITH, Andy"	100	108	0	208
-	AB-19	Straight Party			DEMOCRATIC PARTY (D)	215	351	0	566
-	AB-19	Straight Party			INDEPENDENT PARTY (I)	0	2	0	2
-	AB-19	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
-	AB-19	Straight Party			NONPARTISAN BALLOT (N)	0	9	0	9
-	AB-19	Straight Party			REPUBLICAN PARTY (R)	81	91	0	172
-	AB-19	US Representative	2	I	"STENSHOL, Shaun"	0	2	0	2
-	AB-19	US Representative	2	D	"HIRONO, Mazie"	150	267	0	417
-	AB-19	US Representative	2	R	"EVANS, Roger B."	54	61	0	115
-	AB-19	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
-	AB-19	State Senate	3	D	"ISBELL, Virginia"	48	63	0	111
-	AB-19	State Senate	3	D	"GREEN, Josh"	161	276	0	437
-	AB-19	State Representative	6	D	"COFFMAN, Denny"	69	153	0	222
-	AB-19	State Representative	6	D	"LESLIE, Gene (Bucky)"	40	95	0	135
-	AB-19	State Representative	6	D	"MACGREGOR, Maegan"	45	52	0	97
-	AB-19	State Representative	6	R	"SMITH, Andy"	74	81	0	155
-	AB-20	Straight Party			DEMOCRATIC PARTY (D)	183	307	0	490
-	AB-20	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
-	AB-20	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
-	AB-20	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7
-	AB-20	Straight Party			REPUBLICAN PARTY (R)	50	56	0	106
-	AB-20	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
-	AB-20	US Representative	2	D	"HIRONO, Mazie"	121	222	0	343
-	AB-20	US Representative	2	R	"EVANS, Roger B."	48	43	0	91
-	AB-20	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
-	AB-20	State Senate	3	D	"ISBELL, Virginia"	34	62	0	96
-	AB-20	State Senate	3	D	"GREEN, Josh"	136	234	0	370
-	AB-20	State Representative	7	D	"EVANS, Cindy"	117	238	0	355
-	AB-20	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	27	24	0	51
-	AB-20	State Representative	7	R	"KAILIMAI, B.J."	10	21	0	31
-	AB-21	Straight Party			DEMOCRATIC PARTY (D)	107	90	0	197
-	AB-21	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
-	AB-21	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
-	AB-21	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
-	AB-21	Straight Party			REPUBLICAN PARTY (R)	35	24	0	59
-	AB-21	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
-	AB-21	US Representative	2	D	"HIRONO, Mazie"	75	73	0	148
-	AB-21	US Representative	2	R	"EVANS, Roger B."	32	19	0	51
-	AB-21	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	1	0	4
-	AB-21	State Senate	3	D	"ISBELL, Virginia"	22	27	0	49
-	AB-21	State Senate	3	D	"GREEN, Josh"	74	60	0	134
-	AB-21	State Representative	7	D	"EVANS, Cindy"	89	78	0	167
-	AB-21	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	22	13	0	35
-	AB-21	State Representative	7	R	"KAILIMAI, B.J."	5	9	0	14
-	AB-22	Straight Party			DEMOCRATIC PARTY (D)	125	452	0	577
-	AB-22	Straight Party			INDEPENDENT PARTY (I)	4	1	0	5
-	AB-22	Straight Party			LIBERTARIAN PARTY (L)	0	2	0	2
-	AB-22	Straight Party			NONPARTISAN BALLOT (N)	1	2	0	3
-	AB-22	Straight Party			REPUBLICAN PARTY (R)	37	131	0	168
-	AB-22	US Representative	2	I	"STENSHOL, Shaun"	4	0	0	4
-	AB-22	US Representative	2	D	"HIRONO, Mazie"	98	331	0	429
-	AB-22	US Representative	2	R	"EVANS, Roger B."	23	86	0	109
-	AB-22	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	2	0	2
-	AB-22	State Senate	1	D	"TAKAMINE, Dwight Y."	103	345	0	448
-	AB-22	State Senate	1	R	"HONG, Ted H.S."	33	104	0	137
-	AB-22	State Representative	7	D	"EVANS, Cindy"	95	322	0	417
-	AB-22	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	17	63	0	80
-	AB-22	State Representative	7	R	"KAILIMAI, B.J."	11	51	0	62
-	AB-23	Straight Party			DEMOCRATIC PARTY (D)	33	85	0	118
-	AB-23	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-23	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-23	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-23	Straight Party			REPUBLICAN PARTY (R)	18	19	0	37
-	AB-23	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
-	AB-23	US Representative	2	D	"HIRONO, Mazie"	24	61	0	85
-	AB-23	US Representative	2	R	"EVANS, Roger B."	10	12	0	22
-	AB-23	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-23	State Senate	1	D	"TAKAMINE, Dwight Y."	28	64	0	92
-	AB-23	State Senate	1	R	"HONG, Ted H.S."	13	11	0	24
-	AB-23	State Representative	7	D	"EVANS, Cindy"	22	61	0	83
-	AB-23	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	5	12	0	17
-	AB-23	State Representative	7	R	"KAILIMAI, B.J."	7	3	0	10
-	AB-24	Straight Party			DEMOCRATIC PARTY (D)	1077	560	0	1637
-	AB-24	Straight Party			INDEPENDENT PARTY (I)	7	9	0	16
-	AB-24	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
-	AB-24	Straight Party			NONPARTISAN BALLOT (N)	6	3	0	9
-	AB-24	Straight Party			REPUBLICAN PARTY (R)	82	62	0	144
-	AB-24	US Representative	2	I	"STENSHOL, Shaun"	7	8	0	15
-	AB-24	US Representative	2	D	"HIRONO, Mazie"	888	470	0	1358
-	AB-24	US Representative	2	R	"EVANS, Roger B."	75	56	0	131
-	AB-24	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	1	0	4
-	AB-24	State Representative	8	D	"KAMA, Tasha"	360	200	0	560
-	AB-24	State Representative	8	D	"SOUKI, Joe"	648	331	0	979
-	AB-25	Straight Party			DEMOCRATIC PARTY (D)	1034	367	0	1401
-	AB-25	Straight Party			INDEPENDENT PARTY (I)	6	2	0	8
-	AB-25	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
-	AB-25	Straight Party			NONPARTISAN BALLOT (N)	4	1	0	5
-	AB-25	Straight Party			REPUBLICAN PARTY (R)	84	47	0	131
-	AB-25	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5
-	AB-25	US Representative	2	D	"HIRONO, Mazie"	925	318	0	1243
-	AB-25	US Representative	2	R	"EVANS, Roger B."	57	31	0	88
-	AB-25	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
-	AB-25	State Representative	9	D	"NAKASONE, Bob"	799	288	0	1087
-	AB-25	State Representative	9	R	"KAHULA, Henry P., Jr."	55	36	0	91
-	AB-26	Straight Party			DEMOCRATIC PARTY (D)	332	234	0	566
-	AB-26	Straight Party			INDEPENDENT PARTY (I)	9	4	0	13
-	AB-26	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
-	AB-26	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6
-	AB-26	Straight Party			REPUBLICAN PARTY (R)	104	63	0	167
-	AB-26	US Representative	2	I	"STENSHOL, Shaun"	7	3	0	10
-	AB-26	US Representative	2	D	"HIRONO, Mazie"	272	167	0	439
-	AB-26	US Representative	2	R	"EVANS, Roger B."	50	42	0	92
-	AB-26	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
-	AB-26	State Senate	5	D	"BAKER, Roz"	253	157	0	410
-	AB-26	State Senate	5	D	"MULVIHILL, Bart"	63	63	0	126
-	AB-26	State Senate	5	R	"SHIELDS, Jan"	93	56	0	149
-	AB-26	State Representative	10	D	"MCKELVEY, Angus"	260	194	0	454
-	AB-26	State Representative	10	R	"MADDEN, Ramon K."	51	45	0	96
-	AB-27	Straight Party			DEMOCRATIC PARTY (D)	366	159	0	525
-	AB-27	Straight Party			INDEPENDENT PARTY (I)	11	2	0	13
-	AB-27	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-27	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-27	Straight Party			REPUBLICAN PARTY (R)	214	56	0	270
-	AB-27	US Representative	2	I	"STENSHOL, Shaun"	8	1	0	9
-	AB-27	US Representative	2	D	"HIRONO, Mazie"	287	113	0	400
-	AB-27	US Representative	2	R	"EVANS, Roger B."	134	24	0	158
-	AB-27	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
-	AB-27	State Senate	5	D	"BAKER, Roz"	218	93	0	311
-	AB-27	State Senate	5	D	"MULVIHILL, Bart"	110	53	0	163
-	AB-27	State Senate	5	R	"SHIELDS, Jan"	183	44	0	227
-	AB-27	State Representative	11	D	"GINGERICH, Michael"	97	46	0	143
-	AB-27	State Representative	11	D	"BERTRAM, Joe, III"	234	100	0	334
-	AB-27	State Representative	11	R	"FONTAINE, George R."	164	33	0	197
-	AB-28	Straight Party			DEMOCRATIC PARTY (D)	1051	381	0	1432
-	AB-28	Straight Party			INDEPENDENT PARTY (I)	9	5	0	14
-	AB-28	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-28	Straight Party			NONPARTISAN BALLOT (N)	7	1	0	8
-	AB-28	Straight Party			REPUBLICAN PARTY (R)	150	37	0	187
-	AB-28	US Representative	2	I	"STENSHOL, Shaun"	3	3	0	6
-	AB-28	US Representative	2	D	"HIRONO, Mazie"	820	292	0	1112
-	AB-28	US Representative	2	R	"EVANS, Roger B."	79	15	0	94
-	AB-28	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-28	State Senate	6	I	"BLUMER-BUELL, John"	6	2	0	8
-	AB-28	State Senate	6	D	"ENGLISH, J. Kalani"	755	272	0	1027
-	AB-28	State Representative	12	D	"YAMASHITA, Kyle"	770	250	0	1020
-	AB-28	State Representative	12	D	"STARR, Summer"	235	118	0	353
-	AB-28	State Representative	12	R	"VIERRA, Mickey"	127	25	0	152
-	AB-29	Straight Party			DEMOCRATIC PARTY (D)	488	438	0	926
-	AB-29	Straight Party			INDEPENDENT PARTY (I)	23	10	0	33
-	AB-29	Straight Party			LIBERTARIAN PARTY (L)	0	1	0	1
-	AB-29	Straight Party			NONPARTISAN BALLOT (N)	9	4	0	13
-	AB-29	Straight Party			REPUBLICAN PARTY (R)	65	60	0	125
-	AB-29	US Representative	2	I	"STENSHOL, Shaun"	9	5	0	14
-	AB-29	US Representative	2	D	"HIRONO, Mazie"	379	340	0	719
-	AB-29	US Representative	2	R	"EVANS, Roger B."	57	57	0	114
-	AB-29	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1
-	AB-29	State Senate	6	I	"BLUMER-BUELL, John"	20	9	0	29
-	AB-29	State Senate	6	D	"ENGLISH, J. Kalani"	340	333	0	673
-	AB-29	State Representative	13	D	"CARROLL, Mele"	352	334	0	686
-	AB-30	Straight Party			DEMOCRATIC PARTY (D)	13	0	0	13
-	AB-30	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
-	AB-30	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-30	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-30	Straight Party			REPUBLICAN PARTY (R)	3	0	0	3
-	AB-30	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
-	AB-30	US Representative	2	D	"HIRONO, Mazie"	11	0	0	11
-	AB-30	US Representative	2	R	"EVANS, Roger B."	3	0	0	3
-	AB-30	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-30	State Senate	6	I	"BLUMER-BUELL, John"	2	0	0	2
-	AB-30	State Senate	6	D	"ENGLISH, J. Kalani"	9	0	0	9
-	AB-30	State Representative	13	D	"CARROLL, Mele"	8	0	0	8
-	AB-31	Straight Party			DEMOCRATIC PARTY (D)	1291	610	0	1901
-	AB-31	Straight Party			INDEPENDENT PARTY (I)	15	4	0	19
-	AB-31	Straight Party			LIBERTARIAN PARTY (L)	8	1	0	9
-	AB-31	Straight Party			NONPARTISAN BALLOT (N)	20	6	0	26
-	AB-31	Straight Party			REPUBLICAN PARTY (R)	212	86	0	298
-	AB-31	US Representative	2	I	"STENSHOL, Shaun"	11	2	0	13
-	AB-31	US Representative	2	D	"HIRONO, Mazie"	942	408	0	1350
-	AB-31	US Representative	2	R	"EVANS, Roger B."	146	51	0	197
-	AB-31	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	8	1	0	9
-	AB-31	State Senate	7	D	"HOOSER, Gary L."	901	424	0	1325
-	AB-31	State Senate	7	R	"GEORGI, JoAnne S."	171	63	0	234
-	AB-31	State Representative	14	D	"MORITA, Hermina (Mina)"	838	368	0	1206
-	AB-32	Straight Party			DEMOCRATIC PARTY (D)	1692	1167	0	2859
-	AB-32	Straight Party			INDEPENDENT PARTY (I)	13	12	0	25
-	AB-32	Straight Party			LIBERTARIAN PARTY (L)	7	6	0	13
-	AB-32	Straight Party			NONPARTISAN BALLOT (N)	25	13	0	38
-	AB-32	Straight Party			REPUBLICAN PARTY (R)	260	133	0	393
-	AB-32	US Representative	2	I	"STENSHOL, Shaun"	10	4	0	14
-	AB-32	US Representative	2	D	"HIRONO, Mazie"	1260	826	0	2086
-	AB-32	US Representative	2	R	"EVANS, Roger B."	178	64	0	242
-	AB-32	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	7	6	0	13
-	AB-32	State Senate	7	D	"HOOSER, Gary L."	1146	784	0	1930
-	AB-32	State Senate	7	R	"GEORGI, JoAnne S."	210	85	0	295
-	AB-32	State Representative	15	D	"TOKIOKA, James Kunane"	1083	737	0	1820
-	AB-33	Straight Party			DEMOCRATIC PARTY (D)	1327	583	0	1910
-	AB-33	Straight Party			INDEPENDENT PARTY (I)	14	8	0	22
-	AB-33	Straight Party			LIBERTARIAN PARTY (L)	2	3	0	5
-	AB-33	Straight Party			NONPARTISAN BALLOT (N)	16	5	0	21
-	AB-33	Straight Party			REPUBLICAN PARTY (R)	178	84	0	262
-	AB-33	US Representative	2	I	"STENSHOL, Shaun"	9	5	0	14
-	AB-33	US Representative	2	D	"HIRONO, Mazie"	954	400	0	1354
-	AB-33	US Representative	2	R	"EVANS, Roger B."	124	35	0	159
-	AB-33	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	3	0	5
-	AB-33	State Senate	7	D	"HOOSER, Gary L."	826	362	0	1188
-	AB-33	State Senate	7	R	"GEORGI, JoAnne S."	138	59	0	197
-	AB-33	State Representative	16	D	"SAGUM, Roland D., III"	778	351	0	1129
-	AB-34	Straight Party			DEMOCRATIC PARTY (D)	1624	305	0	1929
-	AB-34	Straight Party			INDEPENDENT PARTY (I)	20	4	0	24
-	AB-34	Straight Party			LIBERTARIAN PARTY (L)	9	1	0	10
-	AB-34	Straight Party			NONPARTISAN BALLOT (N)	21	4	0	25
-	AB-34	Straight Party			REPUBLICAN PARTY (R)	787	99	0	886
-	AB-34	US Representative	1	D	"ABERCROMBIE, Neil"	1304	246	0	1550
-	AB-34	US Representative	1	R	"TATAII, Steve"	318	49	0	367
-	AB-34	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	1	0	4
-	AB-34	US Representative	1	L	"ZHAO, Li"	6	0	0	6
-	AB-34	State Representative	17	D	"MONK, Amy Yukiko"	1030	223	0	1253
-	AB-34	State Representative	17	R	"WARD, Gene"	754	97	0	851
-	AB-35	Straight Party			DEMOCRATIC PARTY (D)	1606	289	0	1895
-	AB-35	Straight Party			INDEPENDENT PARTY (I)	21	5	0	26
-	AB-35	Straight Party			LIBERTARIAN PARTY (L)	13	1	0	14
-	AB-35	Straight Party			NONPARTISAN BALLOT (N)	30	3	0	33
-	AB-35	Straight Party			REPUBLICAN PARTY (R)	422	61	0	483
-	AB-35	US Representative	1	D	"ABERCROMBIE, Neil"	1239	227	0	1466
-	AB-35	US Representative	1	R	"TATAII, Steve"	370	55	0	425
-	AB-35	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4
-	AB-35	US Representative	1	L	"ZHAO, Li"	9	1	0	10
-	AB-35	State Representative	18	D	"BERG, Lyla B."	1137	212	0	1349
-	AB-36	Straight Party			DEMOCRATIC PARTY (D)	1357	257	0	1614
-	AB-36	Straight Party			INDEPENDENT PARTY (I)	7	0	0	7
-	AB-36	Straight Party			LIBERTARIAN PARTY (L)	8	3	0	11
-	AB-36	Straight Party			NONPARTISAN BALLOT (N)	18	2	0	20
-	AB-36	Straight Party			REPUBLICAN PARTY (R)	664	76	0	740
-	AB-36	US Representative	1	D	"ABERCROMBIE, Neil"	1095	212	0	1307
-	AB-36	US Representative	1	R	"TATAII, Steve"	226	24	0	250
-	AB-36	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	2	0	4
-	AB-36	US Representative	1	L	"ZHAO, Li"	5	1	0	6
-	AB-36	State Representative	19	D	"ABE, Michael (Mike)"	836	155	0	991
-	AB-36	State Representative	19	R	"MARUMOTO, Barbara C."	638	68	0	706
-	AB-37	Straight Party			DEMOCRATIC PARTY (D)	163	19	0	182
-	AB-37	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-37	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-37	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-37	Straight Party			REPUBLICAN PARTY (R)	51	10	0	61
-	AB-37	US Representative	1	D	"ABERCROMBIE, Neil"	128	16	0	144
-	AB-37	US Representative	1	R	"TATAII, Steve"	15	4	0	19
-	AB-37	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-37	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-37	State Representative	19	D	"ABE, Michael (Mike)"	105	11	0	116
-	AB-37	State Representative	19	R	"MARUMOTO, Barbara C."	49	8	0	57
-	AB-38	Straight Party			DEMOCRATIC PARTY (D)	1112	218	0	1330
-	AB-38	Straight Party			INDEPENDENT PARTY (I)	4	0	0	4
-	AB-38	Straight Party			LIBERTARIAN PARTY (L)	6	1	0	7
-	AB-38	Straight Party			NONPARTISAN BALLOT (N)	12	2	0	14
-	AB-38	Straight Party			REPUBLICAN PARTY (R)	148	30	0	178
-	AB-38	US Representative	1	D	"ABERCROMBIE, Neil"	901	169	0	1070
-	AB-38	US Representative	1	R	"TATAII, Steve"	103	25	0	128
-	AB-38	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	1	0	3
-	AB-38	US Representative	1	L	"ZHAO, Li"	4	0	0	4
-	AB-38	State Representative	20	D	"SAY, Calvin K. Y."	976	189	0	1165
-	AB-38	State Representative	20	R	"ALLEN, Julia E."	131	26	0	157
-	AB-39	Straight Party			DEMOCRATIC PARTY (D)	420	79	0	499
-	AB-39	Straight Party			INDEPENDENT PARTY (I)	2	2	0	4
-	AB-39	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5
-	AB-39	Straight Party			NONPARTISAN BALLOT (N)	3	3	0	6
-	AB-39	Straight Party			REPUBLICAN PARTY (R)	89	20	0	109
-	AB-39	US Representative	1	D	"ABERCROMBIE, Neil"	345	65	0	410
-	AB-39	US Representative	1	R	"TATAII, Steve"	53	14	0	67
-	AB-39	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
-	AB-39	US Representative	1	L	"ZHAO, Li"	0	1	0	1
-	AB-39	State Representative	20	D	"SAY, Calvin K. Y."	315	64	0	379
-	AB-39	State Representative	20	R	"ALLEN, Julia E."	76	17	0	93
-	AB-40	Straight Party			DEMOCRATIC PARTY (D)	936	202	0	1138
-	AB-40	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
-	AB-40	Straight Party			LIBERTARIAN PARTY (L)	8	1	0	9
-	AB-40	Straight Party			NONPARTISAN BALLOT (N)	8	1	0	9
-	AB-40	Straight Party			REPUBLICAN PARTY (R)	125	30	0	155
-	AB-40	US Representative	1	D	"ABERCROMBIE, Neil"	735	160	0	895
-	AB-40	US Representative	1	R	"TATAII, Steve"	113	28	0	141
-	AB-40	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
-	AB-40	US Representative	1	L	"ZHAO, Li"	5	1	0	6
-	AB-40	State Representative	21	D	"NISHIMOTO, Scott Y."	773	168	0	941
-	AB-41	Straight Party			DEMOCRATIC PARTY (D)	98	17	0	115
-	AB-41	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2
-	AB-41	Straight Party			LIBERTARIAN PARTY (L)	6	1	0	7
-	AB-41	Straight Party			NONPARTISAN BALLOT (N)	2	1	0	3
-	AB-41	Straight Party			REPUBLICAN PARTY (R)	60	5	0	65
-	AB-41	US Representative	1	D	"ABERCROMBIE, Neil"	69	14	0	83
-	AB-41	US Representative	1	R	"TATAII, Steve"	55	5	0	60
-	AB-41	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	0	0	6
-	AB-41	US Representative	1	L	"ZHAO, Li"	0	1	0	1
-	AB-41	State Representative	21	D	"NISHIMOTO, Scott Y."	64	13	0	77
-	AB-42	Straight Party			DEMOCRATIC PARTY (D)	128	36	0	164
-	AB-42	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
-	AB-42	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
-	AB-42	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
-	AB-42	Straight Party			REPUBLICAN PARTY (R)	62	15	0	77
-	AB-42	US Representative	1	D	"ABERCROMBIE, Neil"	113	32	0	145
-	AB-42	US Representative	1	R	"TATAII, Steve"	43	13	0	56
-	AB-42	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-42	US Representative	1	L	"ZHAO, Li"	3	0	0	3
-	AB-42	State Senate	12	D	"GALUTERIA, Brickwood M."	76	16	0	92
-	AB-42	State Senate	12	D	"MIDDLETON, Carlton N."	30	14	0	44
-	AB-42	State Senate	12	R	"TRIMBLE, Gordon"	58	13	0	71
-	AB-42	State Representative	21	D	"NISHIMOTO, Scott Y."	103	32	0	135
-	AB-43	Straight Party			DEMOCRATIC PARTY (D)	1042	239	0	1281
-	AB-43	Straight Party			INDEPENDENT PARTY (I)	11	4	0	15
-	AB-43	Straight Party			LIBERTARIAN PARTY (L)	11	0	0	11
-	AB-43	Straight Party			NONPARTISAN BALLOT (N)	12	2	0	14
-	AB-43	Straight Party			REPUBLICAN PARTY (R)	189	30	0	219
-	AB-43	US Representative	1	D	"ABERCROMBIE, Neil"	861	185	0	1046
-	AB-43	US Representative	1	R	"TATAII, Steve"	171	24	0	195
-	AB-43	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4
-	AB-43	US Representative	1	L	"ZHAO, Li"	6	0	0	6
-	AB-43	State Representative	22	D	"SAIKI, Scott K."	787	173	0	960
-	AB-44	Straight Party			DEMOCRATIC PARTY (D)	909	300	0	1209
-	AB-44	Straight Party			INDEPENDENT PARTY (I)	29	1	0	30
-	AB-44	Straight Party			LIBERTARIAN PARTY (L)	17	1	0	18
-	AB-44	Straight Party			NONPARTISAN BALLOT (N)	22	3	0	25
-	AB-44	Straight Party			REPUBLICAN PARTY (R)	467	107	0	574
-	AB-44	US Representative	1	D	"ABERCROMBIE, Neil"	792	245	0	1037
-	AB-44	US Representative	1	R	"TATAII, Steve"	299	57	0	356
-	AB-44	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	1	0	7
-	AB-44	US Representative	1	L	"ZHAO, Li"	9	0	0	9
-	AB-44	State Senate	12	D	"GALUTERIA, Brickwood M."	490	184	0	674
-	AB-44	State Senate	12	D	"MIDDLETON, Carlton N."	194	51	0	245
-	AB-44	State Senate	12	R	"TRIMBLE, Gordon"	373	86	0	459
-	AB-44	State Representative	23	D	"BROWER, Tom"	635	198	0	833
-	AB-44	State Representative	23	R	"STEVENS, Anne V."	389	81	0	470
-	AB-45	Straight Party			DEMOCRATIC PARTY (D)	1705	375	0	2080
-	AB-45	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13
-	AB-45	Straight Party			LIBERTARIAN PARTY (L)	16	2	0	18
-	AB-45	Straight Party			NONPARTISAN BALLOT (N)	23	5	0	28
-	AB-45	Straight Party			REPUBLICAN PARTY (R)	333	65	0	398
-	AB-45	US Representative	1	D	"ABERCROMBIE, Neil"	1430	312	0	1742
-	AB-45	US Representative	1	R	"TATAII, Steve"	202	30	0	232
-	AB-45	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	0	0	6
-	AB-45	US Representative	1	L	"ZHAO, Li"	10	2	0	12
-	AB-45	State Representative	24	D	"CHOY, Isaac W."	950	256	0	1206
-	AB-45	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	270	52	0	322
-	AB-46	Straight Party			DEMOCRATIC PARTY (D)	808	230	0	1038
-	AB-46	Straight Party			INDEPENDENT PARTY (I)	11	3	0	14
-	AB-46	Straight Party			LIBERTARIAN PARTY (L)	16	5	0	21
-	AB-46	Straight Party			NONPARTISAN BALLOT (N)	9	3	0	12
-	AB-46	Straight Party			REPUBLICAN PARTY (R)	163	52	0	215
-	AB-46	US Representative	1	D	"ABERCROMBIE, Neil"	648	181	0	829
-	AB-46	US Representative	1	R	"TATAII, Steve"	151	43	0	194
-	AB-46	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	9	4	0	13
-	AB-46	US Representative	1	L	"ZHAO, Li"	7	1	0	8
-	AB-46	State Representative	25	D	"BELATTI, Della A."	553	152	0	705
-	AB-47	Straight Party			DEMOCRATIC PARTY (D)	593	120	0	713
-	AB-47	Straight Party			INDEPENDENT PARTY (I)	8	2	0	10
-	AB-47	Straight Party			LIBERTARIAN PARTY (L)	6	4	0	10
-	AB-47	Straight Party			NONPARTISAN BALLOT (N)	9	0	0	9
-	AB-47	Straight Party			REPUBLICAN PARTY (R)	105	21	0	126
-	AB-47	US Representative	1	D	"ABERCROMBIE, Neil"	485	98	0	583
-	AB-47	US Representative	1	R	"TATAII, Steve"	95	18	0	113
-	AB-47	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	3	0	5
-	AB-47	US Representative	1	L	"ZHAO, Li"	4	1	0	5
-	AB-47	State Representative	25	D	"BELATTI, Della A."	346	77	0	423
-	AB-48	Straight Party			DEMOCRATIC PARTY (D)	1546	434	0	1980
-	AB-48	Straight Party			INDEPENDENT PARTY (I)	21	8	0	29
-	AB-48	Straight Party			LIBERTARIAN PARTY (L)	17	6	0	23
-	AB-48	Straight Party			NONPARTISAN BALLOT (N)	19	7	0	26
-	AB-48	Straight Party			REPUBLICAN PARTY (R)	275	67	0	342
-	AB-48	US Representative	1	D	"ABERCROMBIE, Neil"	1259	355	0	1614
-	AB-48	US Representative	1	R	"TATAII, Steve"	248	55	0	303
-	AB-48	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	10	1	0	11
-	AB-48	US Representative	1	L	"ZHAO, Li"	7	4	0	11
-	AB-48	State Representative	26	D	"LUKE, Sylvia"	1140	341	0	1481
-	AB-49	Straight Party			DEMOCRATIC PARTY (D)	1059	238	0	1297
-	AB-49	Straight Party			INDEPENDENT PARTY (I)	2	1	0	3
-	AB-49	Straight Party			LIBERTARIAN PARTY (L)	5	0	0	5
-	AB-49	Straight Party			NONPARTISAN BALLOT (N)	13	4	0	17
-	AB-49	Straight Party			REPUBLICAN PARTY (R)	313	65	0	378
-	AB-49	US Representative	1	D	"ABERCROMBIE, Neil"	904	195	0	1099
-	AB-49	US Representative	1	R	"TATAII, Steve"	128	33	0	161
-	AB-49	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
-	AB-49	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-49	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	577	140	0	717
-	AB-49	State Representative	27	R	"CHING, Corinne Wei Lan"	296	58	0	354
-	AB-50	Straight Party			DEMOCRATIC PARTY (D)	68	15	0	83
-	AB-50	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
-	AB-50	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-50	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-50	Straight Party			REPUBLICAN PARTY (R)	31	4	0	35
-	AB-50	US Representative	1	D	"ABERCROMBIE, Neil"	57	12	0	69
-	AB-50	US Representative	1	R	"TATAII, Steve"	18	1	0	19
-	AB-50	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-50	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-50	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	35	8	0	43
-	AB-50	State Representative	27	R	"CHING, Corinne Wei Lan"	29	4	0	33
-	AB-51	Straight Party			DEMOCRATIC PARTY (D)	133	41	0	174
-	AB-51	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-51	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-51	Straight Party			NONPARTISAN BALLOT (N)	0	1	0	1
-	AB-51	Straight Party			REPUBLICAN PARTY (R)	18	6	0	24
-	AB-51	US Representative	1	D	"ABERCROMBIE, Neil"	101	38	0	139
-	AB-51	US Representative	1	R	"TATAII, Steve"	9	5	0	14
-	AB-51	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-51	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-51	State Representative	28	D	"RHOADS, Karl"	89	20	0	109
-	AB-52	Straight Party			DEMOCRATIC PARTY (D)	158	33	0	191
-	AB-52	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
-	AB-52	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-52	Straight Party			NONPARTISAN BALLOT (N)	3	5	0	8
-	AB-52	Straight Party			REPUBLICAN PARTY (R)	18	5	0	23
-	AB-52	US Representative	1	D	"ABERCROMBIE, Neil"	134	27	0	161
-	AB-52	US Representative	1	R	"TATAII, Steve"	15	5	0	20
-	AB-52	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-52	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-52	State Representative	28	D	"RHOADS, Karl"	90	20	0	110
-	AB-53	Straight Party			DEMOCRATIC PARTY (D)	545	207	0	752
-	AB-53	Straight Party			INDEPENDENT PARTY (I)	8	1	0	9
-	AB-53	Straight Party			LIBERTARIAN PARTY (L)	10	0	0	10
-	AB-53	Straight Party			NONPARTISAN BALLOT (N)	11	4	0	15
-	AB-53	Straight Party			REPUBLICAN PARTY (R)	163	59	0	222
-	AB-53	US Representative	1	D	"ABERCROMBIE, Neil"	446	166	0	612
-	AB-53	US Representative	1	R	"TATAII, Steve"	112	36	0	148
-	AB-53	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
-	AB-53	US Representative	1	L	"ZHAO, Li"	7	0	0	7
-	AB-53	State Senate	12	D	"GALUTERIA, Brickwood M."	302	133	0	435
-	AB-53	State Senate	12	D	"MIDDLETON, Carlton N."	116	32	0	148
-	AB-53	State Senate	12	R	"TRIMBLE, Gordon"	150	55	0	205
-	AB-53	State Representative	28	D	"RHOADS, Karl"	403	160	0	563
-	AB-54	Straight Party			DEMOCRATIC PARTY (D)	177	40	0	217
-	AB-54	Straight Party			INDEPENDENT PARTY (I)	0	2	0	2
-	AB-54	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-54	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-54	Straight Party			REPUBLICAN PARTY (R)	38	11	0	49
-	AB-54	US Representative	1	D	"ABERCROMBIE, Neil"	152	34	0	186
-	AB-54	US Representative	1	R	"TATAII, Steve"	28	4	0	32
-	AB-54	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-54	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-54	State Senate	12	D	"GALUTERIA, Brickwood M."	121	22	0	143
-	AB-54	State Senate	12	D	"MIDDLETON, Carlton N."	34	9	0	43
-	AB-54	State Senate	12	R	"TRIMBLE, Gordon"	33	10	0	43
-	AB-54	State Representative	28	D	"RHOADS, Karl"	143	33	0	176
-	AB-55	Straight Party			DEMOCRATIC PARTY (D)	714	126	0	840
-	AB-55	Straight Party			INDEPENDENT PARTY (I)	2	3	0	5
-	AB-55	Straight Party			LIBERTARIAN PARTY (L)	6	0	0	6
-	AB-55	Straight Party			NONPARTISAN BALLOT (N)	6	0	0	6
-	AB-55	Straight Party			REPUBLICAN PARTY (R)	100	23	0	123
-	AB-55	US Representative	1	D	"ABERCROMBIE, Neil"	603	106	0	709
-	AB-55	US Representative	1	R	"TATAII, Steve"	71	17	0	88
-	AB-55	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-55	US Representative	1	L	"ZHAO, Li"	5	0	0	5
-	AB-55	State Representative	29	D	"MANAHAN, Joey"	558	84	0	642
-	AB-55	State Representative	29	R	"YAW, Shane D. K."	81	16	0	97
-	AB-56	Straight Party			DEMOCRATIC PARTY (D)	567	122	0	689
-	AB-56	Straight Party			INDEPENDENT PARTY (I)	7	1	0	8
-	AB-56	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5
-	AB-56	Straight Party			NONPARTISAN BALLOT (N)	6	1	0	7
-	AB-56	Straight Party			REPUBLICAN PARTY (R)	74	18	0	92
-	AB-56	US Representative	1	D	"ABERCROMBIE, Neil"	476	102	0	578
-	AB-56	US Representative	1	R	"TATAII, Steve"	61	17	0	78
-	AB-56	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-56	US Representative	1	L	"ZHAO, Li"	4	1	0	5
-	AB-56	State Representative	30	D	"MIZUNO, John"	460	87	0	547
-	AB-57	Straight Party			DEMOCRATIC PARTY (D)	257	47	0	304
-	AB-57	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
-	AB-57	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-57	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2
-	AB-57	Straight Party			REPUBLICAN PARTY (R)	17	8	0	25
-	AB-57	US Representative	1	D	"ABERCROMBIE, Neil"	235	35	0	270
-	AB-57	US Representative	1	R	"TATAII, Steve"	12	5	0	17
-	AB-57	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-57	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-57	State Representative	30	D	"MIZUNO, John"	203	39	0	242
-	AB-58	Straight Party			DEMOCRATIC PARTY (D)	295	71	0	366
-	AB-58	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-58	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-58	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2
-	AB-58	Straight Party			REPUBLICAN PARTY (R)	22	10	0	32
-	AB-58	US Representative	1	D	"ABERCROMBIE, Neil"	241	59	0	300
-	AB-58	US Representative	1	R	"TATAII, Steve"	18	6	0	24
-	AB-58	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-58	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-58	State Representative	31	D	"WAKAI, Glenn"	260	59	0	319
-	AB-59	Straight Party			DEMOCRATIC PARTY (D)	982	213	0	1195
-	AB-59	Straight Party			INDEPENDENT PARTY (I)	9	2	0	11
-	AB-59	Straight Party			LIBERTARIAN PARTY (L)	14	1	0	15
-	AB-59	Straight Party			NONPARTISAN BALLOT (N)	13	2	0	15
-	AB-59	Straight Party			REPUBLICAN PARTY (R)	186	31	0	217
-	AB-59	US Representative	1	D	"ABERCROMBIE, Neil"	807	168	0	975
-	AB-59	US Representative	1	R	"TATAII, Steve"	176	23	0	199
-	AB-59	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	1	0	7
-	AB-59	US Representative	1	L	"ZHAO, Li"	8	0	0	8
-	AB-59	State Representative	31	D	"WAKAI, Glenn"	792	159	0	951
-	AB-60	Straight Party			DEMOCRATIC PARTY (D)	418	114	0	532
-	AB-60	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
-	AB-60	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
-	AB-60	Straight Party			NONPARTISAN BALLOT (N)	6	0	0	6
-	AB-60	Straight Party			REPUBLICAN PARTY (R)	124	28	0	152
-	AB-60	US Representative	1	D	"ABERCROMBIE, Neil"	387	102	0	489
-	AB-60	US Representative	1	R	"TATAII, Steve"	55	12	0	67
-	AB-60	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	1	0	2
-	AB-60	US Representative	1	L	"ZHAO, Li"	2	0	0	2
-	AB-60	State Representative	32	R	"FINNEGAN, Lynn"	115	24	0	139
-	AB-61	Straight Party			DEMOCRATIC PARTY (D)	327	93	0	420
-	AB-61	Straight Party			INDEPENDENT PARTY (I)	6	2	0	8
-	AB-61	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
-	AB-61	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
-	AB-61	Straight Party			REPUBLICAN PARTY (R)	204	20	0	224
-	AB-61	US Representative	1	D	"ABERCROMBIE, Neil"	302	86	0	388
-	AB-61	US Representative	1	R	"TATAII, Steve"	101	4	0	105
-	AB-61	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-61	US Representative	1	L	"ZHAO, Li"	2	0	0	2
-	AB-61	State Representative	32	R	"FINNEGAN, Lynn"	197	19	0	216
-	AB-62	Straight Party			DEMOCRATIC PARTY (D)	437	161	0	598
-	AB-62	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
-	AB-62	Straight Party			LIBERTARIAN PARTY (L)	5	2	0	7
-	AB-62	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6
-	AB-62	Straight Party			REPUBLICAN PARTY (R)	62	19	0	81
-	AB-62	US Representative	1	D	"ABERCROMBIE, Neil"	364	130	0	494
-	AB-62	US Representative	1	R	"TATAII, Steve"	51	13	0	64
-	AB-62	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	0	0	2
-	AB-62	US Representative	1	L	"ZHAO, Li"	3	1	0	4
-	AB-62	State Representative	33	D	"OSHIRO, Blake K."	333	119	0	452
-	AB-63	Straight Party			DEMOCRATIC PARTY (D)	927	385	0	1312
-	AB-63	Straight Party			INDEPENDENT PARTY (I)	7	4	0	11
-	AB-63	Straight Party			LIBERTARIAN PARTY (L)	10	1	0	11
-	AB-63	Straight Party			NONPARTISAN BALLOT (N)	10	2	0	12
-	AB-63	Straight Party			REPUBLICAN PARTY (R)	162	53	0	215
-	AB-63	US Representative	1	D	"ABERCROMBIE, Neil"	750	309	0	1059
-	AB-63	US Representative	1	R	"TATAII, Steve"	155	36	0	191
-	AB-63	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	0	0	2
-	AB-63	US Representative	1	L	"ZHAO, Li"	8	0	0	8
-	AB-63	State Senate	16	D	"IGE, David Y."	593	265	0	858
-	AB-63	State Representative	33	D	"OSHIRO, Blake K."	655	297	0	952
-	AB-64	Straight Party			DEMOCRATIC PARTY (D)	1681	458	0	2139
-	AB-64	Straight Party			INDEPENDENT PARTY (I)	8	2	0	10
-	AB-64	Straight Party			LIBERTARIAN PARTY (L)	10	1	0	11
-	AB-64	Straight Party			NONPARTISAN BALLOT (N)	15	1	0	16
-	AB-64	Straight Party			REPUBLICAN PARTY (R)	205	44	0	249
-	AB-64	US Representative	1	D	"ABERCROMBIE, Neil"	1354	372	0	1726
-	AB-64	US Representative	1	R	"TATAII, Steve"	182	37	0	219
-	AB-64	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	7	0	0	7
-	AB-64	US Representative	1	L	"ZHAO, Li"	3	1	0	4
-	AB-64	State Senate	16	D	"IGE, David Y."	1236	349	0	1585
-	AB-64	State Representative	34	D	"TAKAI, K. Mark"	1376	374	0	1750
-	AB-65	Straight Party			DEMOCRATIC PARTY (D)	78	10	0	88
-	AB-65	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
-	AB-65	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-65	Straight Party			NONPARTISAN BALLOT (N)	1	1	0	2
-	AB-65	Straight Party			REPUBLICAN PARTY (R)	13	1	0	14
-	AB-65	US Representative	1	D	"ABERCROMBIE, Neil"	63	9	0	72
-	AB-65	US Representative	1	R	"TATAII, Steve"	13	0	0	13
-	AB-65	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-65	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-65	State Senate	18	D	"SONSON, Alex M."	37	5	0	42
-	AB-65	State Senate	18	D	"NISHIHARA, Clarence"	34	4	0	38
-	AB-65	State Representative	34	D	"TAKAI, K. Mark"	63	7	0	70
-	AB-66	Straight Party			DEMOCRATIC PARTY (D)	230	43	0	273
-	AB-66	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2
-	AB-66	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-66	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-66	Straight Party			REPUBLICAN PARTY (R)	16	11	0	27
-	AB-66	US Representative	1	D	"ABERCROMBIE, Neil"	186	37	0	223
-	AB-66	US Representative	1	R	"TATAII, Steve"	9	7	0	16
-	AB-66	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-66	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-66	State Senate	18	D	"SONSON, Alex M."	74	19	0	93
-	AB-66	State Senate	18	D	"NISHIHARA, Clarence"	147	23	0	170
-	AB-66	State Representative	35	D	"AQUINO, Henry James C."	98	21	0	119
-	AB-66	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	77	13	0	90
-	AB-66	State Representative	35	D	"VERDADERO, Dante M."	3	1	0	4
-	AB-66	State Representative	35	D	"DOMINGO, Constante A."	9	2	0	11
-	AB-66	State Representative	35	D	"PARAYNO, Ilalo"	18	1	0	19
-	AB-66	State Representative	35	R	"ANTONIO, Steven Bolosan"	15	7	0	22
-	AB-67	Straight Party			DEMOCRATIC PARTY (D)	1020	141	0	1161
-	AB-67	Straight Party			INDEPENDENT PARTY (I)	3	0	0	3
-	AB-67	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
-	AB-67	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2
-	AB-67	Straight Party			REPUBLICAN PARTY (R)	56	11	0	67
-	AB-67	US Representative	1	D	"ABERCROMBIE, Neil"	865	123	0	988
-	AB-67	US Representative	1	R	"TATAII, Steve"	37	7	0	44
-	AB-67	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-67	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-67	State Senate	18	D	"SONSON, Alex M."	593	61	0	654
-	AB-67	State Senate	18	D	"NISHIHARA, Clarence"	397	73	0	470
-	AB-67	State Representative	35	D	"AQUINO, Henry James C."	571	79	0	650
-	AB-67	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	233	21	0	254
-	AB-67	State Representative	35	D	"VERDADERO, Dante M."	54	10	0	64
-	AB-67	State Representative	35	D	"DOMINGO, Constante A."	66	8	0	74
-	AB-67	State Representative	35	D	"PARAYNO, Ilalo"	46	12	0	58
-	AB-67	State Representative	35	R	"ANTONIO, Steven Bolosan"	48	10	0	58
-	AB-68	Straight Party			DEMOCRATIC PARTY (D)	952	220	0	1172
-	AB-68	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
-	AB-68	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
-	AB-68	Straight Party			NONPARTISAN BALLOT (N)	18	2	0	20
-	AB-68	Straight Party			REPUBLICAN PARTY (R)	89	17	0	106
-	AB-68	US Representative	1	D	"ABERCROMBIE, Neil"	764	182	0	946
-	AB-68	US Representative	1	R	"TATAII, Steve"	75	14	0	89
-	AB-68	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-68	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-68	State Senate	16	D	"IGE, David Y."	681	164	0	845
-	AB-68	State Representative	36	D	"TAKUMI, Roy M."	702	171	0	873
-	AB-68	State Representative	36	N	"LUM LEE, Christopher-Travis"	15	1	0	16
-	AB-69	Straight Party			DEMOCRATIC PARTY (D)	563	107	0	670
-	AB-69	Straight Party			INDEPENDENT PARTY (I)	4	3	0	7
-	AB-69	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-69	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6
-	AB-69	Straight Party			REPUBLICAN PARTY (R)	42	10	0	52
-	AB-69	US Representative	1	D	"ABERCROMBIE, Neil"	464	80	0	544
-	AB-69	US Representative	1	R	"TATAII, Steve"	38	6	0	44
-	AB-69	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-69	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-69	State Senate	18	D	"SONSON, Alex M."	146	26	0	172
-	AB-69	State Senate	18	D	"NISHIHARA, Clarence"	371	72	0	443
-	AB-69	State Representative	36	D	"TAKUMI, Roy M."	456	88	0	544
-	AB-69	State Representative	36	N	"LUM LEE, Christopher-Travis"	2	2	0	4
-	AB-70	Straight Party			DEMOCRATIC PARTY (D)	12	5	0	17
-	AB-70	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-70	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-70	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-70	Straight Party			REPUBLICAN PARTY (R)	2	0	0	2
-	AB-70	US Representative	1	D	"ABERCROMBIE, Neil"	11	5	0	16
-	AB-70	US Representative	1	R	"TATAII, Steve"	2	0	0	2
-	AB-70	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-70	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-70	State Senate	18	D	"SONSON, Alex M."	1	1	0	2
-	AB-70	State Senate	18	D	"NISHIHARA, Clarence"	11	3	0	14
-	AB-70	State Representative	36	D	"TAKUMI, Roy M."	12	4	0	16
-	AB-70	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0
-	AB-71	Straight Party			DEMOCRATIC PARTY (D)	400	84	0	484
-	AB-71	Straight Party			INDEPENDENT PARTY (I)	3	2	0	5
-	AB-71	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
-	AB-71	Straight Party			NONPARTISAN BALLOT (N)	0	1	0	1
-	AB-71	Straight Party			REPUBLICAN PARTY (R)	56	9	0	65
-	AB-71	US Representative	1	D	"ABERCROMBIE, Neil"	341	77	0	418
-	AB-71	US Representative	1	R	"TATAII, Steve"	50	7	0	57
-	AB-71	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-71	US Representative	1	L	"ZHAO, Li"	2	0	0	2
-	AB-71	State Senate	17	D	"KIDANI, Michelle"	162	42	0	204
-	AB-71	State Senate	17	D	"MENOR, Ron"	151	30	0	181
-	AB-71	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	52	8	0	60
-	AB-71	State Representative	37	D	"YAMANE, Ryan I."	339	75	0	414
-	AB-72	Straight Party			DEMOCRATIC PARTY (D)	1004	201	0	1205
-	AB-72	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2
-	AB-72	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
-	AB-72	Straight Party			NONPARTISAN BALLOT (N)	1	2	0	3
-	AB-72	Straight Party			REPUBLICAN PARTY (R)	116	18	0	134
-	AB-72	US Representative	1	D	"ABERCROMBIE, Neil"	784	165	0	949
-	AB-72	US Representative	1	R	"TATAII, Steve"	107	14	0	121
-	AB-72	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4
-	AB-72	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-72	State Senate	17	D	"KIDANI, Michelle"	427	82	0	509
-	AB-72	State Senate	17	D	"MENOR, Ron"	431	83	0	514
-	AB-72	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	105	28	0	133
-	AB-72	State Representative	37	D	"YAMANE, Ryan I."	825	171	0	996
-	AB-73	Straight Party			DEMOCRATIC PARTY (D)	447	90	0	537
-	AB-73	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
-	AB-73	Straight Party			LIBERTARIAN PARTY (L)	6	0	0	6
-	AB-73	Straight Party			NONPARTISAN BALLOT (N)	9	1	0	10
-	AB-73	Straight Party			REPUBLICAN PARTY (R)	74	14	0	88
-	AB-73	US Representative	1	D	"ABERCROMBIE, Neil"	372	70	0	442
-	AB-73	US Representative	1	R	"TATAII, Steve"	51	9	0	60
-	AB-73	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-73	US Representative	1	L	"ZHAO, Li"	5	0	0	5
-	AB-73	State Senate	22	D	"BUNDA, Robert (Bobby)"	283	64	0	347
-	AB-73	State Representative	38	D	"LEE, Marilyn B."	315	70	0	385
-	AB-73	State Representative	38	R	"APANA, Melvin K."	65	13	0	78
-	AB-74	Straight Party			DEMOCRATIC PARTY (D)	513	85	0	598
-	AB-74	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
-	AB-74	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
-	AB-74	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
-	AB-74	Straight Party			REPUBLICAN PARTY (R)	57	11	0	68
-	AB-74	US Representative	1	D	"ABERCROMBIE, Neil"	413	76	0	489
-	AB-74	US Representative	1	R	"TATAII, Steve"	42	7	0	49
-	AB-74	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-74	US Representative	1	L	"ZHAO, Li"	1	1	0	2
-	AB-74	State Senate	17	D	"KIDANI, Michelle"	227	33	0	260
-	AB-74	State Senate	17	D	"MENOR, Ron"	193	36	0	229
-	AB-74	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	58	9	0	67
-	AB-74	State Representative	38	D	"LEE, Marilyn B."	412	67	0	479
-	AB-74	State Representative	38	R	"APANA, Melvin K."	48	8	0	56
-	AB-75	Straight Party			DEMOCRATIC PARTY (D)	829	170	0	999
-	AB-75	Straight Party			INDEPENDENT PARTY (I)	5	1	0	6
-	AB-75	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5
-	AB-75	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-75	Straight Party			REPUBLICAN PARTY (R)	113	20	0	133
-	AB-75	US Representative	1	D	"ABERCROMBIE, Neil"	666	134	0	800
-	AB-75	US Representative	1	R	"TATAII, Steve"	87	17	0	104
-	AB-75	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	1	0	2
-	AB-75	US Representative	1	L	"ZHAO, Li"	3	0	0	3
-	AB-75	State Senate	17	D	"KIDANI, Michelle"	320	61	0	381
-	AB-75	State Senate	17	D	"MENOR, Ron"	337	68	0	405
-	AB-75	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	131	30	0	161
-	AB-75	State Representative	38	D	"LEE, Marilyn B."	657	140	0	797
-	AB-75	State Representative	38	R	"APANA, Melvin K."	101	16	0	117
-	AB-76	Straight Party			DEMOCRATIC PARTY (D)	859	89	0	948
-	AB-76	Straight Party			INDEPENDENT PARTY (I)	9	0	0	9
-	AB-76	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
-	AB-76	Straight Party			NONPARTISAN BALLOT (N)	15	1	0	16
-	AB-76	Straight Party			REPUBLICAN PARTY (R)	132	14	0	146
-	AB-76	US Representative	2	I	"STENSHOL, Shaun"	7	0	0	7
-	AB-76	US Representative	2	D	"HIRONO, Mazie"	706	71	0	777
-	AB-76	US Representative	2	R	"EVANS, Roger B."	122	12	0	134
-	AB-76	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1
-	AB-76	State Senate	22	D	"BUNDA, Robert (Bobby)"	634	71	0	705
-	AB-76	State Representative	39	D	"OSHIRO, Marcus R."	641	74	0	715
-	AB-77	Straight Party			DEMOCRATIC PARTY (D)	48	8	0	56
-	AB-77	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-77	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-77	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-77	Straight Party			REPUBLICAN PARTY (R)	16	2	0	18
-	AB-77	US Representative	1	D	"ABERCROMBIE, Neil"	33	7	0	40
-	AB-77	US Representative	1	R	"TATAII, Steve"	16	1	0	17
-	AB-77	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-77	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-77	State Senate	17	D	"KIDANI, Michelle"	19	6	0	25
-	AB-77	State Senate	17	D	"MENOR, Ron"	22	0	0	22
-	AB-77	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	4	1	0	5
-	AB-77	State Representative	39	D	"OSHIRO, Marcus R."	29	6	0	35
-	AB-78	Straight Party			DEMOCRATIC PARTY (D)	512	243	0	755
-	AB-78	Straight Party			INDEPENDENT PARTY (I)	8	3	0	11
-	AB-78	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
-	AB-78	Straight Party			NONPARTISAN BALLOT (N)	10	3	0	13
-	AB-78	Straight Party			REPUBLICAN PARTY (R)	184	57	0	241
-	AB-78	US Representative	2	I	"STENSHOL, Shaun"	6	1	0	7
-	AB-78	US Representative	2	D	"HIRONO, Mazie"	379	200	0	579
-	AB-78	US Representative	2	R	"EVANS, Roger B."	136	44	0	180
-	AB-78	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
-	AB-78	State Representative	40	D	"HAR, Sharon E."	435	212	0	647
-	AB-78	State Representative	40	R	"LEGAL,  Jack M."	166	52	0	218
-	AB-79	Straight Party			DEMOCRATIC PARTY (D)	301	128	0	429
-	AB-79	Straight Party			INDEPENDENT PARTY (I)	4	0	0	4
-	AB-79	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
-	AB-79	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
-	AB-79	Straight Party			REPUBLICAN PARTY (R)	97	40	0	137
-	AB-79	US Representative	2	I	"STENSHOL, Shaun"	3	0	0	3
-	AB-79	US Representative	2	D	"HIRONO, Mazie"	242	99	0	341
-	AB-79	US Representative	2	R	"EVANS, Roger B."	75	28	0	103
-	AB-79	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
-	AB-79	State Representative	40	D	"HAR, Sharon E."	232	109	0	341
-	AB-79	State Representative	40	R	"LEGAL,  Jack M."	84	32	0	116
-	AB-80	Straight Party			DEMOCRATIC PARTY (D)	351	89	0	440
-	AB-80	Straight Party			INDEPENDENT PARTY (I)	4	2	0	6
-	AB-80	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-80	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-80	Straight Party			REPUBLICAN PARTY (R)	75	7	0	82
-	AB-80	US Representative	1	D	"ABERCROMBIE, Neil"	287	80	0	367
-	AB-80	US Representative	1	R	"TATAII, Steve"	48	5	0	53
-	AB-80	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-80	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-80	State Representative	41	D	"CULLEN, Ty Diaz"	83	26	0	109
-	AB-80	State Representative	41	D	"KARAMATSU, Jon Riki"	225	58	0	283
-	AB-80	State Representative	41	R	"SANIATAN, Rito C."	63	6	0	69
-	AB-81	Straight Party			DEMOCRATIC PARTY (D)	174	27	0	201
-	AB-81	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-81	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-81	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-81	Straight Party			REPUBLICAN PARTY (R)	17	0	0	17
-	AB-81	US Representative	1	D	"ABERCROMBIE, Neil"	158	21	0	179
-	AB-81	US Representative	1	R	"TATAII, Steve"	8	0	0	8
-	AB-81	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-81	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-81	State Senate	18	D	"SONSON, Alex M."	57	7	0	64
-	AB-81	State Senate	18	D	"NISHIHARA, Clarence"	113	19	0	132
-	AB-81	State Representative	41	D	"CULLEN, Ty Diaz"	58	10	0	68
-	AB-81	State Representative	41	D	"KARAMATSU, Jon Riki"	113	15	0	128
-	AB-81	State Representative	41	R	"SANIATAN, Rito C."	13	0	0	13
-	AB-82	Straight Party			DEMOCRATIC PARTY (D)	311	79	0	390
-	AB-82	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
-	AB-82	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-82	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
-	AB-82	Straight Party			REPUBLICAN PARTY (R)	91	12	0	103
-	AB-82	US Representative	2	I	"STENSHOL, Shaun"	1	0	0	1
-	AB-82	US Representative	2	D	"HIRONO, Mazie"	270	66	0	336
-	AB-82	US Representative	2	R	"EVANS, Roger B."	60	5	0	65
-	AB-82	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-82	State Representative	41	D	"CULLEN, Ty Diaz"	114	27	0	141
-	AB-82	State Representative	41	D	"KARAMATSU, Jon Riki"	167	48	0	215
-	AB-82	State Representative	41	R	"SANIATAN, Rito C."	79	7	0	86
-	AB-83	Straight Party			DEMOCRATIC PARTY (D)	148	13	0	161
-	AB-83	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-83	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-83	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-83	Straight Party			REPUBLICAN PARTY (R)	5	0	0	5
-	AB-83	US Representative	1	D	"ABERCROMBIE, Neil"	120	7	0	127
-	AB-83	US Representative	1	R	"TATAII, Steve"	2	0	0	2
-	AB-83	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-83	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-83	State Senate	18	D	"SONSON, Alex M."	55	4	0	59
-	AB-83	State Senate	18	D	"NISHIHARA, Clarence"	88	8	0	96
-	AB-83	State Representative	42	D	"RODRIGUEZ, Rey R."	11	1	0	12
-	AB-83	State Representative	42	D	"SCHULTZ, Mike P."	52	7	0	59
-	AB-83	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	73	4	0	77
-	AB-83	State Representative	42	R	"BERG, Tom"	4	0	0	4
-	AB-83	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
-	AB-84	Straight Party			DEMOCRATIC PARTY (D)	31	8	0	39
-	AB-84	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
-	AB-84	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-84	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-84	Straight Party			REPUBLICAN PARTY (R)	1	1	0	2
-	AB-84	US Representative	1	D	"ABERCROMBIE, Neil"	28	6	0	34
-	AB-84	US Representative	1	R	"TATAII, Steve"	1	0	0	1
-	AB-84	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
-	AB-84	US Representative	1	L	"ZHAO, Li"	0	0	0	0
-	AB-84	State Representative	42	D	"RODRIGUEZ, Rey R."	4	1	0	5
-	AB-84	State Representative	42	D	"SCHULTZ, Mike P."	12	2	0	14
-	AB-84	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	11	4	0	15
-	AB-84	State Representative	42	R	"BERG, Tom"	1	1	0	2
-	AB-84	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
-	AB-85	Straight Party			DEMOCRATIC PARTY (D)	499	115	0	614
-	AB-85	Straight Party			INDEPENDENT PARTY (I)	2	1	0	3
-	AB-85	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
-	AB-85	Straight Party			NONPARTISAN BALLOT (N)	4	0	0	4
-	AB-85	Straight Party			REPUBLICAN PARTY (R)	86	21	0	107
-	AB-85	US Representative	1	D	"ABERCROMBIE, Neil"	433	98	0	531
-	AB-85	US Representative	1	R	"TATAII, Steve"	47	16	0	63
-	AB-85	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-85	US Representative	1	L	"ZHAO, Li"	1	0	0	1
-	AB-85	State Representative	42	D	"RODRIGUEZ, Rey R."	34	14	0	48
-	AB-85	State Representative	42	D	"SCHULTZ, Mike P."	216	48	0	264
-	AB-85	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	217	48	0	265
-	AB-85	State Representative	42	R	"BERG, Tom"	76	21	0	97
-	AB-85	State Representative	42	N	"BIMBO, Genaro Q."	3	0	0	3
-	AB-86	Straight Party			DEMOCRATIC PARTY (D)	660	165	0	825
-	AB-86	Straight Party			INDEPENDENT PARTY (I)	12	5	0	17
-	AB-86	Straight Party			LIBERTARIAN PARTY (L)	2	1	0	3
-	AB-86	Straight Party			NONPARTISAN BALLOT (N)	8	2	0	10
-	AB-86	Straight Party			REPUBLICAN PARTY (R)	385	84	0	469
-	AB-86	US Representative	1	D	"ABERCROMBIE, Neil"	606	145	0	751
-	AB-86	US Representative	1	R	"TATAII, Steve"	154	47	0	201
-	AB-86	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	AB-86	US Representative	1	L	"ZHAO, Li"	1	1	0	2
-	AB-86	State Representative	43	D	"FEVELLA, Kurt"	317	108	0	425
-	AB-86	State Representative	43	R	"PINE, Kymberly (Marcos)"	368	79	0	447
-	AB-87	Straight Party			DEMOCRATIC PARTY (D)	36	11	0	47
-	AB-87	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
-	AB-87	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-87	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	AB-87	Straight Party			REPUBLICAN PARTY (R)	13	4	0	17
-	AB-87	US Representative	2	I	"STENSHOL, Shaun"	1	0	0	1
-	AB-87	US Representative	2	D	"HIRONO, Mazie"	35	9	0	44
-	AB-87	US Representative	2	R	"EVANS, Roger B."	11	4	0	15
-	AB-87	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-87	State Representative	44	D	"AWANA, Karen Leinani"	18	8	0	26
-	AB-87	State Representative	44	D	"AIPOALANI, Hanalei Y."	9	2	0	11
-	AB-87	State Representative	44	R	"KU, Tercia L."	9	3	0	12
-	AB-88	Straight Party			DEMOCRATIC PARTY (D)	480	164	0	644
-	AB-88	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
-	AB-88	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
-	AB-88	Straight Party			NONPARTISAN BALLOT (N)	3	1	0	4
-	AB-88	Straight Party			REPUBLICAN PARTY (R)	92	28	0	120
-	AB-88	US Representative	2	I	"STENSHOL, Shaun"	5	2	0	7
-	AB-88	US Representative	2	D	"HIRONO, Mazie"	373	131	0	504
-	AB-88	US Representative	2	R	"EVANS, Roger B."	65	24	0	89
-	AB-88	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
-	AB-88	State Senate	21	D	"HANABUSA, Colleen"	379	131	0	510
-	AB-88	State Senate	21	R	"JOHNSON, Dickyj"	65	19	0	84
-	AB-88	State Representative	44	D	"AWANA, Karen Leinani"	243	75	0	318
-	AB-88	State Representative	44	D	"AIPOALANI, Hanalei Y."	198	78	0	276
-	AB-88	State Representative	44	R	"KU, Tercia L."	71	20	0	91
-	AB-89	Straight Party			DEMOCRATIC PARTY (D)	562	135	0	697
-	AB-89	Straight Party			INDEPENDENT PARTY (I)	9	1	0	10
-	AB-89	Straight Party			LIBERTARIAN PARTY (L)	1	2	0	3
-	AB-89	Straight Party			NONPARTISAN BALLOT (N)	2	1	0	3
-	AB-89	Straight Party			REPUBLICAN PARTY (R)	95	21	0	116
-	AB-89	US Representative	2	I	"STENSHOL, Shaun"	5	1	0	6
-	AB-89	US Representative	2	D	"HIRONO, Mazie"	441	109	0	550
-	AB-89	US Representative	2	R	"EVANS, Roger B."	65	14	0	79
-	AB-89	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	2	0	3
-	AB-89	State Senate	21	D	"HANABUSA, Colleen"	451	113	0	564
-	AB-89	State Senate	21	R	"JOHNSON, Dickyj"	66	14	0	80
-	AB-89	State Representative	45	D	"SHIMABUKURO, Maile S. L."	432	99	0	531
-	AB-89	State Representative	45	D	"SAYLORS, Denise"	94	30	0	124
-	AB-89	State Representative	45	R	"GAPOL, Derek A."	73	13	0	86
-	AB-90	Straight Party			DEMOCRATIC PARTY (D)	58	21	0	79
-	AB-90	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
-	AB-90	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-90	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-90	Straight Party			REPUBLICAN PARTY (R)	36	15	0	51
-	AB-90	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
-	AB-90	US Representative	2	D	"HIRONO, Mazie"	51	12	0	63
-	AB-90	US Representative	2	R	"EVANS, Roger B."	25	11	0	36
-	AB-90	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-90	State Senate	23	D	"HEE, Clayton"	39	14	0	53
-	AB-90	State Senate	23	D	"MURAKI, Noel S."	16	5	0	21
-	AB-90	State Senate	23	R	"FALE, Richard"	26	13	0	39
-	AB-90	State Representative	46	D	"LUNASCO, Ollie"	5	6	0	11
-	AB-90	State Representative	46	D	"MAGAOAY, Michael Y."	35	11	0	46
-	AB-90	State Representative	46	D	"WASSON, Dawn K."	12	4	0	16
-	AB-90	State Representative	46	R	"PHILIPS, Carol"	20	9	0	29
-	AB-90	State Representative	46	R	"RIVIERE, Gil"	16	4	0	20
-	AB-91	Straight Party			DEMOCRATIC PARTY (D)	479	51	0	530
-	AB-91	Straight Party			INDEPENDENT PARTY (I)	5	1	0	6
-	AB-91	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
-	AB-91	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-91	Straight Party			REPUBLICAN PARTY (R)	193	16	0	209
-	AB-91	US Representative	2	I	"STENSHOL, Shaun"	5	1	0	6
-	AB-91	US Representative	2	D	"HIRONO, Mazie"	383	40	0	423
-	AB-91	US Representative	2	R	"EVANS, Roger B."	93	9	0	102
-	AB-91	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4
-	AB-91	State Senate	22	D	"BUNDA, Robert (Bobby)"	380	36	0	416
-	AB-91	State Representative	46	D	"LUNASCO, Ollie"	90	11	0	101
-	AB-91	State Representative	46	D	"MAGAOAY, Michael Y."	309	33	0	342
-	AB-91	State Representative	46	D	"WASSON, Dawn K."	55	4	0	59
-	AB-91	State Representative	46	R	"PHILIPS, Carol"	95	3	0	98
-	AB-91	State Representative	46	R	"RIVIERE, Gil"	92	13	0	105
-	AB-92	Straight Party			DEMOCRATIC PARTY (D)	891	497	0	1388
-	AB-92	Straight Party			INDEPENDENT PARTY (I)	12	2	0	14
-	AB-92	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
-	AB-92	Straight Party			NONPARTISAN BALLOT (N)	3	2	0	5
-	AB-92	Straight Party			REPUBLICAN PARTY (R)	260	140	0	400
-	AB-92	US Representative	2	I	"STENSHOL, Shaun"	10	2	0	12
-	AB-92	US Representative	2	D	"HIRONO, Mazie"	714	404	0	1118
-	AB-92	US Representative	2	R	"EVANS, Roger B."	128	64	0	192
-	AB-92	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
-	AB-92	State Senate	23	D	"HEE, Clayton"	562	314	0	876
-	AB-92	State Senate	23	D	"MURAKI, Noel S."	256	148	0	404
-	AB-92	State Senate	23	R	"FALE, Richard"	126	62	0	188
-	AB-92	State Representative	47	D	"PACHECO, Maria"	162	97	0	259
-	AB-92	State Representative	47	D	"WOOLEY, Jessica"	601	352	0	953
-	AB-92	State Representative	47	R	"MEYER, Colleen"	236	132	0	368
-	AB-93	Straight Party			DEMOCRATIC PARTY (D)	51	55	0	106
-	AB-93	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
-	AB-93	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
-	AB-93	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	AB-93	Straight Party			REPUBLICAN PARTY (R)	21	10	0	31
-	AB-93	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1
-	AB-93	US Representative	2	D	"HIRONO, Mazie"	45	49	0	94
-	AB-93	US Representative	2	R	"EVANS, Roger B."	15	2	0	17
-	AB-93	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
-	AB-93	State Senate	23	D	"HEE, Clayton"	36	24	0	60
-	AB-93	State Senate	23	D	"MURAKI, Noel S."	10	23	0	33
-	AB-93	State Senate	23	R	"FALE, Richard"	16	2	0	18
-	AB-93	State Representative	47	D	"PACHECO, Maria"	4	11	0	15
-	AB-93	State Representative	47	D	"WOOLEY, Jessica"	37	35	0	72
-	AB-93	State Representative	47	R	"MEYER, Colleen"	21	8	0	29
-	AB-94	Straight Party			DEMOCRATIC PARTY (D)	345	218	0	563
-	AB-94	Straight Party			INDEPENDENT PARTY (I)	4	1	0	5
-	AB-94	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
-	AB-94	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7
-	AB-94	Straight Party			REPUBLICAN PARTY (R)	50	35	0	85
-	AB-94	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5
-	AB-94	US Representative	2	D	"HIRONO, Mazie"	292	185	0	477
-	AB-94	US Representative	2	R	"EVANS, Roger B."	44	30	0	74
-	AB-94	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
-	AB-94	State Senate	23	D	"HEE, Clayton"	200	125	0	325
-	AB-94	State Senate	23	D	"MURAKI, Noel S."	107	59	0	166
-	AB-94	State Senate	23	R	"FALE, Richard"	41	23	0	64
-	AB-94	State Representative	48	D	"ITO, Ken"	296	190	0	486
-	AB-95	Straight Party			DEMOCRATIC PARTY (D)	1164	573	0	1737
-	AB-95	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13
-	AB-95	Straight Party			LIBERTARIAN PARTY (L)	5	2	0	7
-	AB-95	Straight Party			NONPARTISAN BALLOT (N)	12	3	0	15
-	AB-95	Straight Party			REPUBLICAN PARTY (R)	170	65	0	235
-	AB-95	US Representative	2	I	"STENSHOL, Shaun"	8	1	0	9
-	AB-95	US Representative	2	D	"HIRONO, Mazie"	990	486	0	1476
-	AB-95	US Representative	2	R	"EVANS, Roger B."	160	60	0	220
-	AB-95	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	5	2	0	7
-	AB-95	State Representative	48	D	"ITO, Ken"	928	451	0	1379
-	AB-96	Straight Party			DEMOCRATIC PARTY (D)	909	318	0	1227
-	AB-96	Straight Party			INDEPENDENT PARTY (I)	11	5	0	16
-	AB-96	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
-	AB-96	Straight Party			NONPARTISAN BALLOT (N)	14	6	0	20
-	AB-96	Straight Party			REPUBLICAN PARTY (R)	226	65	0	291
-	AB-96	US Representative	2	I	"STENSHOL, Shaun"	11	4	0	15
-	AB-96	US Representative	2	D	"HIRONO, Mazie"	758	258	0	1016
-	AB-96	US Representative	2	R	"EVANS, Roger B."	214	60	0	274
-	AB-96	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4
-	AB-96	State Representative	49	D	"CHONG, Pono"	653	226	0	879
-	AB-97	Straight Party			DEMOCRATIC PARTY (D)	286	180	0	466
-	AB-97	Straight Party			INDEPENDENT PARTY (I)	3	2	0	5
-	AB-97	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
-	AB-97	Straight Party			NONPARTISAN BALLOT (N)	5	4	0	9
-	AB-97	Straight Party			REPUBLICAN PARTY (R)	73	56	0	129
-	AB-97	US Representative	2	I	"STENSHOL, Shaun"	3	2	0	5
-	AB-97	US Representative	2	D	"HIRONO, Mazie"	237	144	0	381
-	AB-97	US Representative	2	R	"EVANS, Roger B."	63	45	0	108
-	AB-97	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
-	AB-97	State Senate	23	D	"HEE, Clayton"	160	96	0	256
-	AB-97	State Senate	23	D	"MURAKI, Noel S."	81	62	0	143
-	AB-97	State Senate	23	R	"FALE, Richard"	61	42	0	103
-	AB-97	State Representative	49	D	"CHONG, Pono"	233	140	0	373
-	AB-98	Straight Party			DEMOCRATIC PARTY (D)	628	292	0	920
-	AB-98	Straight Party			INDEPENDENT PARTY (I)	17	5	0	22
-	AB-98	Straight Party			LIBERTARIAN PARTY (L)	8	2	0	10
-	AB-98	Straight Party			NONPARTISAN BALLOT (N)	11	1	0	12
-	AB-98	Straight Party			REPUBLICAN PARTY (R)	554	138	0	692
-	AB-98	US Representative	2	I	"STENSHOL, Shaun"	13	2	0	15
-	AB-98	US Representative	2	D	"HIRONO, Mazie"	583	263	0	846
-	AB-98	US Representative	2	R	"EVANS, Roger B."	218	58	0	276
-	AB-98	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	8	2	0	10
-	AB-98	State Representative	50	R	"THIELEN, Cynthia"	511	122	0	633
-	AB-99	Straight Party			DEMOCRATIC PARTY (D)	985	338	0	1323
-	AB-99	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13
-	AB-99	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
-	AB-99	Straight Party			NONPARTISAN BALLOT (N)	4	1	0	5
-	AB-99	Straight Party			REPUBLICAN PARTY (R)	237	71	0	308
-	AB-99	US Representative	2	I	"STENSHOL, Shaun"	7	2	0	9
-	AB-99	US Representative	2	D	"HIRONO, Mazie"	753	265	0	1018
-	AB-99	US Representative	2	R	"EVANS, Roger B."	118	32	0	150
-	AB-99	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2
-	AB-99	State Representative	51	D	"ANDERSON, J. Ikaika"	326	135	0	461
-	AB-99	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	27	6	0	33
-	AB-99	State Representative	51	D	"LEE, Chris Kalani"	563	170	0	733
-	AB-99	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	229	57	0	286
-	Overseas 100	Straight Party			DEMOCRATIC PARTY (D)	97	0	0	97
-	Overseas 100	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
-	Overseas 100	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
-	Overseas 100	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
-	Overseas 100	Straight Party			REPUBLICAN PARTY (R)	19	0	0	19
-	Overseas 100	US Representative	1	D	"ABERCROMBIE, Neil"	96	0	0	96
-	Overseas 100	US Representative	1	R	"TATAII, Steve"	19	0	0	19
-	Overseas 100	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
-	Overseas 100	US Representative	1	L	"ZHAO, Li"	3	0	0	3
-	Overseas 101	Straight Party			DEMOCRATIC PARTY (D)	80	0	0	80
-	Overseas 101	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
-	Overseas 101	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
-	Overseas 101	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
-	Overseas 101	Straight Party			REPUBLICAN PARTY (R)	18	0	0	18
-	Overseas 101	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
-	Overseas 101	US Representative	2	D	"HIRONO, Mazie"	80	0	0	80
-	Overseas 101	US Representative	2	R	"EVANS, Roger B."	18	0	0	18
-	Overseas 101	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4
+county,precinct,office,district,party,candidate,absentee,early_votes,election_day,votes
+County of Hawaii,01-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,427,427
+County of Hawaii,01-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Hawaii,01-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,01-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,01-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,44,44
+County of Hawaii,01-01,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,01-01,US Representative,2,D,"HIRONO, Mazie",0,0,321,321
+County of Hawaii,01-01,US Representative,2,R,"EVANS, Roger B.",0,0,36,36
+County of Hawaii,01-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,01-01,State Senate,3,D,"ISBELL, Virginia",0,0,60,60
+County of Hawaii,01-01,State Senate,3,D,"GREEN, Josh",0,0,344,344
+County of Hawaii,01-01,State Representative,1,D,"FUJIYAMA, Ken",0,0,53,53
+County of Hawaii,01-01,State Representative,1,D,"KIM, Jo",0,0,91,91
+County of Hawaii,01-01,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,219,219
+County of Hawaii,01-01,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,17,17
+County of Hawaii,01-01,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,22,22
+County of Hawaii,01-01,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,17,17
+County of Hawaii,01-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,241,241
+County of Hawaii,01-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,01-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,01-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,29,29
+County of Hawaii,01-02,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,01-02,US Representative,2,D,"HIRONO, Mazie",0,0,171,171
+County of Hawaii,01-02,US Representative,2,R,"EVANS, Roger B.",0,0,25,25
+County of Hawaii,01-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-02,State Senate,3,D,"ISBELL, Virginia",0,0,36,36
+County of Hawaii,01-02,State Senate,3,D,"GREEN, Josh",0,0,195,195
+County of Hawaii,01-02,State Representative,1,D,"FUJIYAMA, Ken",0,0,35,35
+County of Hawaii,01-02,State Representative,1,D,"KIM, Jo",0,0,72,72
+County of Hawaii,01-02,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,86,86
+County of Hawaii,01-02,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,14,14
+County of Hawaii,01-02,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,13,13
+County of Hawaii,01-02,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,10,10
+County of Hawaii,01-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,82,82
+County of Hawaii,01-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Hawaii,01-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,01-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,01-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,11,11
+County of Hawaii,01-03,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,01-03,US Representative,2,D,"HIRONO, Mazie",0,0,55,55
+County of Hawaii,01-03,US Representative,2,R,"EVANS, Roger B.",0,0,6,6
+County of Hawaii,01-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,01-03,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,61,61
+County of Hawaii,01-03,State Senate,1,R,"HONG, Ted H.S.",0,0,9,9
+County of Hawaii,01-03,State Representative,1,D,"FUJIYAMA, Ken",0,0,7,7
+County of Hawaii,01-03,State Representative,1,D,"KIM, Jo",0,0,32,32
+County of Hawaii,01-03,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,24,24
+County of Hawaii,01-03,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,6,6
+County of Hawaii,01-03,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,7,7
+County of Hawaii,01-03,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,0,0
+County of Hawaii,01-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,582,582
+County of Hawaii,01-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,01-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,01-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,01-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,58,58
+County of Hawaii,01-04,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,01-04,US Representative,2,D,"HIRONO, Mazie",0,0,401,401
+County of Hawaii,01-04,US Representative,2,R,"EVANS, Roger B.",0,0,30,30
+County of Hawaii,01-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,01-04,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,472,472
+County of Hawaii,01-04,State Senate,1,R,"HONG, Ted H.S.",0,0,50,50
+County of Hawaii,01-04,State Representative,1,D,"FUJIYAMA, Ken",0,0,30,30
+County of Hawaii,01-04,State Representative,1,D,"KIM, Jo",0,0,252,252
+County of Hawaii,01-04,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,250,250
+County of Hawaii,01-04,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,13,13
+County of Hawaii,01-04,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,39,39
+County of Hawaii,01-04,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,10,10
+County of Hawaii,01-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,246,246
+County of Hawaii,01-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,01-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Hawaii,01-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,23,23
+County of Hawaii,01-05,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,01-05,US Representative,2,D,"HIRONO, Mazie",0,0,162,162
+County of Hawaii,01-05,US Representative,2,R,"EVANS, Roger B.",0,0,13,13
+County of Hawaii,01-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,01-05,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,191,191
+County of Hawaii,01-05,State Senate,1,R,"HONG, Ted H.S.",0,0,22,22
+County of Hawaii,01-05,State Representative,1,D,"FUJIYAMA, Ken",0,0,22,22
+County of Hawaii,01-05,State Representative,1,D,"KIM, Jo",0,0,121,121
+County of Hawaii,01-05,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,79,79
+County of Hawaii,01-05,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,6,6
+County of Hawaii,01-05,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,12,12
+County of Hawaii,01-05,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,4,4
+County of Hawaii,01-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,56,56
+County of Hawaii,01-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Hawaii,01-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,01-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,10,10
+County of Hawaii,01-06,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,01-06,US Representative,2,D,"HIRONO, Mazie",0,0,42,42
+County of Hawaii,01-06,US Representative,2,R,"EVANS, Roger B.",0,0,8,8
+County of Hawaii,01-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-06,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,42,42
+County of Hawaii,01-06,State Senate,1,R,"HONG, Ted H.S.",0,0,8,8
+County of Hawaii,01-06,State Representative,1,D,"FUJIYAMA, Ken",0,0,7,7
+County of Hawaii,01-06,State Representative,1,D,"KIM, Jo",0,0,12,12
+County of Hawaii,01-06,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,33,33
+County of Hawaii,01-06,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,1,1
+County of Hawaii,01-06,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,8,8
+County of Hawaii,01-06,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,1,1
+County of Hawaii,01-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,185,185
+County of Hawaii,01-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Hawaii,01-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,01-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,28,28
+County of Hawaii,01-07,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,01-07,US Representative,2,D,"HIRONO, Mazie",0,0,132,132
+County of Hawaii,01-07,US Representative,2,R,"EVANS, Roger B.",0,0,20,20
+County of Hawaii,01-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-07,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,161,161
+County of Hawaii,01-07,State Senate,1,R,"HONG, Ted H.S.",0,0,25,25
+County of Hawaii,01-07,State Representative,1,D,"FUJIYAMA, Ken",0,0,29,29
+County of Hawaii,01-07,State Representative,1,D,"KIM, Jo",0,0,61,61
+County of Hawaii,01-07,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,58,58
+County of Hawaii,01-07,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,8,8
+County of Hawaii,01-07,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,19,19
+County of Hawaii,01-07,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,4,4
+County of Hawaii,01-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,73,73
+County of Hawaii,01-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,01-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,21,21
+County of Hawaii,01-08,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,01-08,US Representative,2,D,"HIRONO, Mazie",0,0,51,51
+County of Hawaii,01-08,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Hawaii,01-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-08,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,55,55
+County of Hawaii,01-08,State Senate,1,R,"HONG, Ted H.S.",0,0,19,19
+County of Hawaii,01-08,State Representative,1,D,"FUJIYAMA, Ken",0,0,8,8
+County of Hawaii,01-08,State Representative,1,D,"KIM, Jo",0,0,20,20
+County of Hawaii,01-08,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,28,28
+County of Hawaii,01-08,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,6,6
+County of Hawaii,01-08,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,15,15
+County of Hawaii,01-08,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,2,2
+County of Hawaii,01-09,Straight Party,,,DEMOCRATIC PARTY (D),0,0,74,74
+County of Hawaii,01-09,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-09,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-09,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,01-09,Straight Party,,,REPUBLICAN PARTY (R),0,0,8,8
+County of Hawaii,01-09,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,01-09,US Representative,2,D,"HIRONO, Mazie",0,0,56,56
+County of Hawaii,01-09,US Representative,2,R,"EVANS, Roger B.",0,0,5,5
+County of Hawaii,01-09,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-09,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,63,63
+County of Hawaii,01-09,State Senate,1,R,"HONG, Ted H.S.",0,0,6,6
+County of Hawaii,01-09,State Representative,1,D,"FUJIYAMA, Ken",0,0,24,24
+County of Hawaii,01-09,State Representative,1,D,"KIM, Jo",0,0,18,18
+County of Hawaii,01-09,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,25,25
+County of Hawaii,01-09,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,2,2
+County of Hawaii,01-09,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,5,5
+County of Hawaii,01-09,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,3,3
+County of Hawaii,01-10,Straight Party,,,DEMOCRATIC PARTY (D),0,0,116,116
+County of Hawaii,01-10,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-10,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-10,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,01-10,Straight Party,,,REPUBLICAN PARTY (R),0,0,18,18
+County of Hawaii,01-10,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,01-10,US Representative,2,D,"HIRONO, Mazie",0,0,77,77
+County of Hawaii,01-10,US Representative,2,R,"EVANS, Roger B.",0,0,9,9
+County of Hawaii,01-10,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-10,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,99,99
+County of Hawaii,01-10,State Senate,1,R,"HONG, Ted H.S.",0,0,17,17
+County of Hawaii,01-10,State Representative,1,D,"FUJIYAMA, Ken",0,0,22,22
+County of Hawaii,01-10,State Representative,1,D,"KIM, Jo",0,0,22,22
+County of Hawaii,01-10,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,43,43
+County of Hawaii,01-10,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,4,4
+County of Hawaii,01-10,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,8,8
+County of Hawaii,01-10,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,3,3
+County of Hawaii,01-11,Straight Party,,,DEMOCRATIC PARTY (D),0,0,313,313
+County of Hawaii,01-11,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-11,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-11,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+County of Hawaii,01-11,Straight Party,,,REPUBLICAN PARTY (R),0,0,17,17
+County of Hawaii,01-11,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,01-11,US Representative,2,D,"HIRONO, Mazie",0,0,247,247
+County of Hawaii,01-11,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Hawaii,01-11,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-11,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,283,283
+County of Hawaii,01-11,State Senate,1,R,"HONG, Ted H.S.",0,0,15,15
+County of Hawaii,01-11,State Representative,1,D,"FUJIYAMA, Ken",0,0,52,52
+County of Hawaii,01-11,State Representative,1,D,"KIM, Jo",0,0,51,51
+County of Hawaii,01-11,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,170,170
+County of Hawaii,01-11,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,12,12
+County of Hawaii,01-11,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,11,11
+County of Hawaii,01-11,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,2,2
+County of Hawaii,01-12,Straight Party,,,DEMOCRATIC PARTY (D),0,0,228,228
+County of Hawaii,01-12,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-12,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-12,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,01-12,Straight Party,,,REPUBLICAN PARTY (R),0,0,56,56
+County of Hawaii,01-12,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,01-12,US Representative,2,D,"HIRONO, Mazie",0,0,170,170
+County of Hawaii,01-12,US Representative,2,R,"EVANS, Roger B.",0,0,25,25
+County of Hawaii,01-12,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-12,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,176,176
+County of Hawaii,01-12,State Senate,1,R,"HONG, Ted H.S.",0,0,43,43
+County of Hawaii,01-12,State Representative,1,D,"FUJIYAMA, Ken",0,0,64,64
+County of Hawaii,01-12,State Representative,1,D,"KIM, Jo",0,0,39,39
+County of Hawaii,01-12,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,91,91
+County of Hawaii,01-12,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,8,8
+County of Hawaii,01-12,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,20,20
+County of Hawaii,01-12,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,19,19
+County of Hawaii,01-13,Straight Party,,,DEMOCRATIC PARTY (D),0,0,317,317
+County of Hawaii,01-13,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-13,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,01-13,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,01-13,Straight Party,,,REPUBLICAN PARTY (R),0,0,47,47
+County of Hawaii,01-13,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,01-13,US Representative,2,D,"HIRONO, Mazie",0,0,213,213
+County of Hawaii,01-13,US Representative,2,R,"EVANS, Roger B.",0,0,26,26
+County of Hawaii,01-13,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,01-13,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,231,231
+County of Hawaii,01-13,State Senate,1,R,"HONG, Ted H.S.",0,0,42,42
+County of Hawaii,01-13,State Representative,1,D,"FUJIYAMA, Ken",0,0,81,81
+County of Hawaii,01-13,State Representative,1,D,"KIM, Jo",0,0,63,63
+County of Hawaii,01-13,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,114,114
+County of Hawaii,01-13,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,17,17
+County of Hawaii,01-13,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,10,10
+County of Hawaii,01-13,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,14,14
+County of Hawaii,01-14,Straight Party,,,DEMOCRATIC PARTY (D),0,0,97,97
+County of Hawaii,01-14,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,01-14,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,01-14,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,01-14,Straight Party,,,REPUBLICAN PARTY (R),0,0,16,16
+County of Hawaii,01-14,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,01-14,US Representative,2,D,"HIRONO, Mazie",0,0,81,81
+County of Hawaii,01-14,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Hawaii,01-14,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,01-14,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,72,72
+County of Hawaii,01-14,State Senate,1,R,"HONG, Ted H.S.",0,0,14,14
+County of Hawaii,01-14,State Representative,1,D,"FUJIYAMA, Ken",0,0,29,29
+County of Hawaii,01-14,State Representative,1,D,"KIM, Jo",0,0,23,23
+County of Hawaii,01-14,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,16,16
+County of Hawaii,01-14,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,11,11
+County of Hawaii,01-14,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,9,9
+County of Hawaii,01-14,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,6,6
+County of Hawaii,01-15,Straight Party,,,DEMOCRATIC PARTY (D),0,0,95,95
+County of Hawaii,01-15,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Hawaii,01-15,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,01-15,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,01-15,Straight Party,,,REPUBLICAN PARTY (R),0,0,23,23
+County of Hawaii,01-15,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,01-15,US Representative,2,D,"HIRONO, Mazie",0,0,82,82
+County of Hawaii,01-15,US Representative,2,R,"EVANS, Roger B.",0,0,23,23
+County of Hawaii,01-15,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Hawaii,01-15,State Senate,3,D,"ISBELL, Virginia",0,0,14,14
+County of Hawaii,01-15,State Senate,3,D,"GREEN, Josh",0,0,73,73
+County of Hawaii,01-15,State Representative,1,D,"FUJIYAMA, Ken",0,0,7,7
+County of Hawaii,01-15,State Representative,1,D,"KIM, Jo",0,0,30,30
+County of Hawaii,01-15,State Representative,1,D,"NAKASHIMA, Mark M.",0,0,30,30
+County of Hawaii,01-15,State Representative,1,D,"NAKKIM, Lynn (Kalama)",0,0,12,12
+County of Hawaii,01-15,State Representative,1,R,"OFFENBAKER, Steven A.",0,0,7,7
+County of Hawaii,01-15,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",0,0,12,12
+County of Hawaii,02-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,683,683
+County of Hawaii,02-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+County of Hawaii,02-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,02-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,02-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,135,135
+County of Hawaii,02-01,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,02-01,US Representative,2,D,"HIRONO, Mazie",0,0,480,480
+County of Hawaii,02-01,US Representative,2,R,"EVANS, Roger B.",0,0,44,44
+County of Hawaii,02-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,02-01,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,476,476
+County of Hawaii,02-01,State Senate,1,R,"HONG, Ted H.S.",0,0,124,124
+County of Hawaii,02-01,State Representative,2,D,"CHANG, Jerry Leslie",0,0,420,420
+County of Hawaii,02-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,367,367
+County of Hawaii,02-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,02-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,02-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Hawaii,02-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,77,77
+County of Hawaii,02-02,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,02-02,US Representative,2,D,"HIRONO, Mazie",0,0,264,264
+County of Hawaii,02-02,US Representative,2,R,"EVANS, Roger B.",0,0,29,29
+County of Hawaii,02-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,02-02,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,252,252
+County of Hawaii,02-02,State Senate,1,R,"HONG, Ted H.S.",0,0,72,72
+County of Hawaii,02-02,State Representative,2,D,"CHANG, Jerry Leslie",0,0,253,253
+County of Hawaii,02-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,520,520
+County of Hawaii,02-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Hawaii,02-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,02-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Hawaii,02-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,107,107
+County of Hawaii,02-03,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Hawaii,02-03,US Representative,2,D,"HIRONO, Mazie",0,0,390,390
+County of Hawaii,02-03,US Representative,2,R,"EVANS, Roger B.",0,0,49,49
+County of Hawaii,02-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,02-03,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,367,367
+County of Hawaii,02-03,State Senate,1,R,"HONG, Ted H.S.",0,0,96,96
+County of Hawaii,02-03,State Representative,2,D,"CHANG, Jerry Leslie",0,0,352,352
+County of Hawaii,02-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,129,129
+County of Hawaii,02-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,02-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,02-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,02-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,30,30
+County of Hawaii,02-04,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,02-04,US Representative,2,D,"HIRONO, Mazie",0,0,92,92
+County of Hawaii,02-04,US Representative,2,R,"EVANS, Roger B.",0,0,17,17
+County of Hawaii,02-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,02-04,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,85,85
+County of Hawaii,02-04,State Senate,1,R,"HONG, Ted H.S.",0,0,25,25
+County of Hawaii,02-04,State Representative,2,D,"CHANG, Jerry Leslie",0,0,73,73
+County of Hawaii,02-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,224,224
+County of Hawaii,02-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,02-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+County of Hawaii,02-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,02-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,32,32
+County of Hawaii,02-05,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,02-05,US Representative,2,D,"HIRONO, Mazie",0,0,169,169
+County of Hawaii,02-05,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Hawaii,02-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+County of Hawaii,02-05,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,136,136
+County of Hawaii,02-05,State Senate,1,R,"HONG, Ted H.S.",0,0,26,26
+County of Hawaii,02-05,State Representative,2,D,"CHANG, Jerry Leslie",0,0,125,125
+County of Hawaii,02-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,335,335
+County of Hawaii,02-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+County of Hawaii,02-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,02-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,02-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,45,45
+County of Hawaii,02-06,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Hawaii,02-06,US Representative,2,D,"HIRONO, Mazie",0,0,227,227
+County of Hawaii,02-06,US Representative,2,R,"EVANS, Roger B.",0,0,19,19
+County of Hawaii,02-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,02-06,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,223,223
+County of Hawaii,02-06,State Senate,1,R,"HONG, Ted H.S.",0,0,41,41
+County of Hawaii,02-06,State Representative,2,D,"CHANG, Jerry Leslie",0,0,214,214
+County of Hawaii,02-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,148,148
+County of Hawaii,02-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,02-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,02-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,02-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,20,20
+County of Hawaii,02-07,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,02-07,US Representative,2,D,"HIRONO, Mazie",0,0,104,104
+County of Hawaii,02-07,US Representative,2,R,"EVANS, Roger B.",0,0,6,6
+County of Hawaii,02-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,02-07,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,112,112
+County of Hawaii,02-07,State Senate,1,R,"HONG, Ted H.S.",0,0,16,16
+County of Hawaii,02-07,State Representative,2,D,"CHANG, Jerry Leslie",0,0,106,106
+County of Hawaii,02-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,259,259
+County of Hawaii,02-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Hawaii,02-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,02-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,02-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,40,40
+County of Hawaii,02-08,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,02-08,US Representative,2,D,"HIRONO, Mazie",0,0,183,183
+County of Hawaii,02-08,US Representative,2,R,"EVANS, Roger B.",0,0,11,11
+County of Hawaii,02-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,02-08,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,185,185
+County of Hawaii,02-08,State Senate,1,R,"HONG, Ted H.S.",0,0,33,33
+County of Hawaii,02-08,State Representative,2,D,"CHANG, Jerry Leslie",0,0,167,167
+County of Hawaii,03-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,493,493
+County of Hawaii,03-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Hawaii,03-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,03-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Hawaii,03-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,41,41
+County of Hawaii,03-01,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,03-01,US Representative,2,D,"HIRONO, Mazie",0,0,351,351
+County of Hawaii,03-01,US Representative,2,R,"EVANS, Roger B.",0,0,27,27
+County of Hawaii,03-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,03-01,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,362,362
+County of Hawaii,03-01,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,23,23
+County of Hawaii,03-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,127,127
+County of Hawaii,03-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,03-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,03-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+County of Hawaii,03-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,13,13
+County of Hawaii,03-02,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,03-02,US Representative,2,D,"HIRONO, Mazie",0,0,91,91
+County of Hawaii,03-02,US Representative,2,R,"EVANS, Roger B.",0,0,9,9
+County of Hawaii,03-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,03-02,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,111,111
+County of Hawaii,03-02,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,8,8
+County of Hawaii,03-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,129,129
+County of Hawaii,03-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Hawaii,03-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,03-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,03-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,20,20
+County of Hawaii,03-03,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,03-03,US Representative,2,D,"HIRONO, Mazie",0,0,97,97
+County of Hawaii,03-03,US Representative,2,R,"EVANS, Roger B.",0,0,4,4
+County of Hawaii,03-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,03-03,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,101,101
+County of Hawaii,03-03,State Senate,1,R,"HONG, Ted H.S.",0,0,19,19
+County of Hawaii,03-03,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,101,101
+County of Hawaii,03-03,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,4,4
+County of Hawaii,03-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,499,499
+County of Hawaii,03-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,03-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,03-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Hawaii,03-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,46,46
+County of Hawaii,03-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,03-04,US Representative,2,D,"HIRONO, Mazie",0,0,380,380
+County of Hawaii,03-04,US Representative,2,R,"EVANS, Roger B.",0,0,32,32
+County of Hawaii,03-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,03-04,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,392,392
+County of Hawaii,03-04,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,23,23
+County of Hawaii,03-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,490,490
+County of Hawaii,03-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Hawaii,03-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,03-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,03-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,63,63
+County of Hawaii,03-05,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+County of Hawaii,03-05,US Representative,2,D,"HIRONO, Mazie",0,0,400,400
+County of Hawaii,03-05,US Representative,2,R,"EVANS, Roger B.",0,0,48,48
+County of Hawaii,03-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,03-05,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,362,362
+County of Hawaii,03-05,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,44,44
+County of Hawaii,03-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,709,709
+County of Hawaii,03-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Hawaii,03-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,03-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,15,15
+County of Hawaii,03-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,78,78
+County of Hawaii,03-06,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Hawaii,03-06,US Representative,2,D,"HIRONO, Mazie",0,0,499,499
+County of Hawaii,03-06,US Representative,2,R,"EVANS, Roger B.",0,0,30,30
+County of Hawaii,03-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,03-06,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,509,509
+County of Hawaii,03-06,State Senate,1,R,"HONG, Ted H.S.",0,0,65,65
+County of Hawaii,03-06,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,499,499
+County of Hawaii,03-06,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,28,28
+County of Hawaii,03-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,401,401
+County of Hawaii,03-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Hawaii,03-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,03-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Hawaii,03-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,37,37
+County of Hawaii,03-07,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,03-07,US Representative,2,D,"HIRONO, Mazie",0,0,316,316
+County of Hawaii,03-07,US Representative,2,R,"EVANS, Roger B.",0,0,27,27
+County of Hawaii,03-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Hawaii,03-07,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,310,310
+County of Hawaii,03-07,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,16,16
+County of Hawaii,03-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,601,601
+County of Hawaii,03-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Hawaii,03-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,03-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Hawaii,03-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,54,54
+County of Hawaii,03-08,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Hawaii,03-08,US Representative,2,D,"HIRONO, Mazie",0,0,469,469
+County of Hawaii,03-08,US Representative,2,R,"EVANS, Roger B.",0,0,35,35
+County of Hawaii,03-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Hawaii,03-08,State Representative,3,D,"TSUJI, Clifton (Clift)",0,0,447,447
+County of Hawaii,03-08,State Representative,3,R,"TAVARES, Deirdre (Moana)",0,0,38,38
+County of Hawaii,04-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,406,406
+County of Hawaii,04-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+County of Hawaii,04-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+County of Hawaii,04-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+County of Hawaii,04-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,78,78
+County of Hawaii,04-01,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+County of Hawaii,04-01,US Representative,2,D,"HIRONO, Mazie",0,0,305,305
+County of Hawaii,04-01,US Representative,2,R,"EVANS, Roger B.",0,0,49,49
+County of Hawaii,04-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+County of Hawaii,04-01,State Representative,4,D,"HANOHANO, Faye P.",0,0,184,184
+County of Hawaii,04-01,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,76,76
+County of Hawaii,04-01,State Representative,4,D,"SPARKS, Steven B.",0,0,92,92
+County of Hawaii,04-01,State Representative,4,R,"BLAS, Fred",0,0,56,56
+County of Hawaii,04-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,306,306
+County of Hawaii,04-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+County of Hawaii,04-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,04-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,8,8
+County of Hawaii,04-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,52,52
+County of Hawaii,04-02,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Hawaii,04-02,US Representative,2,D,"HIRONO, Mazie",0,0,234,234
+County of Hawaii,04-02,US Representative,2,R,"EVANS, Roger B.",0,0,38,38
+County of Hawaii,04-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,04-02,State Representative,4,D,"HANOHANO, Faye P.",0,0,144,144
+County of Hawaii,04-02,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,66,66
+County of Hawaii,04-02,State Representative,4,D,"SPARKS, Steven B.",0,0,58,58
+County of Hawaii,04-02,State Representative,4,R,"BLAS, Fred",0,0,38,38
+County of Hawaii,04-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,517,517
+County of Hawaii,04-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,12,12
+County of Hawaii,04-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,10,10
+County of Hawaii,04-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Hawaii,04-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,108,108
+County of Hawaii,04-03,US Representative,2,I,"STENSHOL, Shaun",0,0,11,11
+County of Hawaii,04-03,US Representative,2,D,"HIRONO, Mazie",0,0,354,354
+County of Hawaii,04-03,US Representative,2,R,"EVANS, Roger B.",0,0,67,67
+County of Hawaii,04-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,10,10
+County of Hawaii,04-03,State Representative,4,D,"HANOHANO, Faye P.",0,0,186,186
+County of Hawaii,04-03,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,159,159
+County of Hawaii,04-03,State Representative,4,D,"SPARKS, Steven B.",0,0,109,109
+County of Hawaii,04-03,State Representative,4,R,"BLAS, Fred",0,0,74,74
+County of Hawaii,04-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,396,396
+County of Hawaii,04-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+County of Hawaii,04-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,04-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,04-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,126,126
+County of Hawaii,04-04,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Hawaii,04-04,US Representative,2,D,"HIRONO, Mazie",0,0,284,284
+County of Hawaii,04-04,US Representative,2,R,"EVANS, Roger B.",0,0,50,50
+County of Hawaii,04-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Hawaii,04-04,State Representative,4,D,"HANOHANO, Faye P.",0,0,213,213
+County of Hawaii,04-04,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,90,90
+County of Hawaii,04-04,State Representative,4,D,"SPARKS, Steven B.",0,0,45,45
+County of Hawaii,04-04,State Representative,4,R,"BLAS, Fred",0,0,116,116
+County of Hawaii,04-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,677,677
+County of Hawaii,04-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,18,18
+County of Hawaii,04-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+County of Hawaii,04-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,10,10
+County of Hawaii,04-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,94,94
+County of Hawaii,04-05,US Representative,2,I,"STENSHOL, Shaun",0,0,14,14
+County of Hawaii,04-05,US Representative,2,D,"HIRONO, Mazie",0,0,410,410
+County of Hawaii,04-05,US Representative,2,R,"EVANS, Roger B.",0,0,52,52
+County of Hawaii,04-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,6,6
+County of Hawaii,04-05,State Representative,4,D,"HANOHANO, Faye P.",0,0,199,199
+County of Hawaii,04-05,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,264,264
+County of Hawaii,04-05,State Representative,4,D,"SPARKS, Steven B.",0,0,161,161
+County of Hawaii,04-05,State Representative,4,R,"BLAS, Fred",0,0,67,67
+County of Hawaii,04-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,421,421
+County of Hawaii,04-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,9,9
+County of Hawaii,04-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+County of Hawaii,04-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,9,9
+County of Hawaii,04-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,107,107
+County of Hawaii,04-06,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+County of Hawaii,04-06,US Representative,2,D,"HIRONO, Mazie",0,0,317,317
+County of Hawaii,04-06,US Representative,2,R,"EVANS, Roger B.",0,0,75,75
+County of Hawaii,04-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+County of Hawaii,04-06,State Representative,4,D,"HANOHANO, Faye P.",0,0,208,208
+County of Hawaii,04-06,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,105,105
+County of Hawaii,04-06,State Representative,4,D,"SPARKS, Steven B.",0,0,61,61
+County of Hawaii,04-06,State Representative,4,R,"BLAS, Fred",0,0,69,69
+County of Hawaii,04-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,166,166
+County of Hawaii,04-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,04-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,04-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,04-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,19,19
+County of Hawaii,04-07,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,04-07,US Representative,2,D,"HIRONO, Mazie",0,0,85,85
+County of Hawaii,04-07,US Representative,2,R,"EVANS, Roger B.",0,0,10,10
+County of Hawaii,04-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,04-07,State Representative,4,D,"HANOHANO, Faye P.",0,0,44,44
+County of Hawaii,04-07,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,46,46
+County of Hawaii,04-07,State Representative,4,D,"SPARKS, Steven B.",0,0,58,58
+County of Hawaii,04-07,State Representative,4,R,"BLAS, Fred",0,0,16,16
+County of Hawaii,04-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,236,236
+County of Hawaii,04-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,04-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,04-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,04-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,62,62
+County of Hawaii,04-08,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,04-08,US Representative,2,D,"HIRONO, Mazie",0,0,175,175
+County of Hawaii,04-08,US Representative,2,R,"EVANS, Roger B.",0,0,42,42
+County of Hawaii,04-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,04-08,State Representative,4,D,"HANOHANO, Faye P.",0,0,116,116
+County of Hawaii,04-08,State Representative,4,D,"MARZI, Anthony (Tony)",0,0,69,69
+County of Hawaii,04-08,State Representative,4,D,"SPARKS, Steven B.",0,0,25,25
+County of Hawaii,04-08,State Representative,4,R,"BLAS, Fred",0,0,47,47
+County of Hawaii,05-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,142,142
+County of Hawaii,05-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Hawaii,05-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,05-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Hawaii,05-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,24,24
+County of Hawaii,05-01,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+County of Hawaii,05-01,US Representative,2,D,"HIRONO, Mazie",0,0,112,112
+County of Hawaii,05-01,US Representative,2,R,"EVANS, Roger B.",0,0,23,23
+County of Hawaii,05-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Hawaii,05-01,State Representative,5,D,"HERKES, Robert (Bob)",0,0,83,83
+County of Hawaii,05-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,298,298
+County of Hawaii,05-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,16,16
+County of Hawaii,05-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,05-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,12,12
+County of Hawaii,05-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,61,61
+County of Hawaii,05-02,US Representative,2,I,"STENSHOL, Shaun",0,0,16,16
+County of Hawaii,05-02,US Representative,2,D,"HIRONO, Mazie",0,0,244,244
+County of Hawaii,05-02,US Representative,2,R,"EVANS, Roger B.",0,0,57,57
+County of Hawaii,05-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Hawaii,05-02,State Representative,5,D,"HERKES, Robert (Bob)",0,0,152,152
+County of Hawaii,05-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,469,469
+County of Hawaii,05-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,15,15
+County of Hawaii,05-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,19,19
+County of Hawaii,05-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,10,10
+County of Hawaii,05-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,101,101
+County of Hawaii,05-03,US Representative,2,I,"STENSHOL, Shaun",0,0,13,13
+County of Hawaii,05-03,US Representative,2,D,"HIRONO, Mazie",0,0,370,370
+County of Hawaii,05-03,US Representative,2,R,"EVANS, Roger B.",0,0,96,96
+County of Hawaii,05-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,19,19
+County of Hawaii,05-03,State Representative,5,D,"HERKES, Robert (Bob)",0,0,280,280
+County of Hawaii,05-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,205,205
+County of Hawaii,05-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,05-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,05-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Hawaii,05-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,11,11
+County of Hawaii,05-04,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,05-04,US Representative,2,D,"HIRONO, Mazie",0,0,169,169
+County of Hawaii,05-04,US Representative,2,R,"EVANS, Roger B.",0,0,10,10
+County of Hawaii,05-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,05-04,State Representative,5,D,"HERKES, Robert (Bob)",0,0,122,122
+County of Hawaii,05-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,267,267
+County of Hawaii,05-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,21,21
+County of Hawaii,05-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,05-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,10,10
+County of Hawaii,05-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,53,53
+County of Hawaii,05-05,US Representative,2,I,"STENSHOL, Shaun",0,0,19,19
+County of Hawaii,05-05,US Representative,2,D,"HIRONO, Mazie",0,0,203,203
+County of Hawaii,05-05,US Representative,2,R,"EVANS, Roger B.",0,0,48,48
+County of Hawaii,05-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Hawaii,05-05,State Representative,5,D,"HERKES, Robert (Bob)",0,0,171,171
+County of Hawaii,05-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,343,343
+County of Hawaii,05-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,12,12
+County of Hawaii,05-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,12,12
+County of Hawaii,05-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,12,12
+County of Hawaii,05-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,97,97
+County of Hawaii,05-06,US Representative,2,I,"STENSHOL, Shaun",0,0,10,10
+County of Hawaii,05-06,US Representative,2,D,"HIRONO, Mazie",0,0,268,268
+County of Hawaii,05-06,US Representative,2,R,"EVANS, Roger B.",0,0,94,94
+County of Hawaii,05-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,11,11
+County of Hawaii,05-06,State Representative,5,D,"HERKES, Robert (Bob)",0,0,190,190
+County of Hawaii,05-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,115,115
+County of Hawaii,05-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,05-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,05-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,05-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,11,11
+County of Hawaii,05-07,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,05-07,US Representative,2,D,"HIRONO, Mazie",0,0,67,67
+County of Hawaii,05-07,US Representative,2,R,"EVANS, Roger B.",0,0,10,10
+County of Hawaii,05-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,05-07,State Senate,3,D,"ISBELL, Virginia",0,0,30,30
+County of Hawaii,05-07,State Senate,3,D,"GREEN, Josh",0,0,77,77
+County of Hawaii,05-07,State Representative,5,D,"HERKES, Robert (Bob)",0,0,66,66
+County of Hawaii,05-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,130,130
+County of Hawaii,05-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,05-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,05-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,05-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,9,9
+County of Hawaii,05-08,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,05-08,US Representative,2,D,"HIRONO, Mazie",0,0,80,80
+County of Hawaii,05-08,US Representative,2,R,"EVANS, Roger B.",0,0,8,8
+County of Hawaii,05-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,05-08,State Senate,3,D,"ISBELL, Virginia",0,0,43,43
+County of Hawaii,05-08,State Senate,3,D,"GREEN, Josh",0,0,81,81
+County of Hawaii,05-08,State Representative,5,D,"HERKES, Robert (Bob)",0,0,68,68
+County of Hawaii,05-09,Straight Party,,,DEMOCRATIC PARTY (D),0,0,280,280
+County of Hawaii,05-09,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,05-09,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Hawaii,05-09,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,05-09,Straight Party,,,REPUBLICAN PARTY (R),0,0,15,15
+County of Hawaii,05-09,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,05-09,US Representative,2,D,"HIRONO, Mazie",0,0,177,177
+County of Hawaii,05-09,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Hawaii,05-09,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,05-09,State Senate,3,D,"ISBELL, Virginia",0,0,94,94
+County of Hawaii,05-09,State Senate,3,D,"GREEN, Josh",0,0,174,174
+County of Hawaii,05-09,State Representative,5,D,"HERKES, Robert (Bob)",0,0,160,160
+County of Hawaii,05-10,Straight Party,,,DEMOCRATIC PARTY (D),0,0,119,119
+County of Hawaii,05-10,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,05-10,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,05-10,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,05-10,Straight Party,,,REPUBLICAN PARTY (R),0,0,13,13
+County of Hawaii,05-10,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,05-10,US Representative,2,D,"HIRONO, Mazie",0,0,86,86
+County of Hawaii,05-10,US Representative,2,R,"EVANS, Roger B.",0,0,11,11
+County of Hawaii,05-10,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,05-10,State Senate,3,D,"ISBELL, Virginia",0,0,36,36
+County of Hawaii,05-10,State Senate,3,D,"GREEN, Josh",0,0,77,77
+County of Hawaii,05-10,State Representative,5,D,"HERKES, Robert (Bob)",0,0,76,76
+County of Hawaii,05-11,Straight Party,,,DEMOCRATIC PARTY (D),0,0,481,481
+County of Hawaii,05-11,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,05-11,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,05-11,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+County of Hawaii,05-11,Straight Party,,,REPUBLICAN PARTY (R),0,0,43,43
+County of Hawaii,05-11,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,05-11,US Representative,2,D,"HIRONO, Mazie",0,0,331,331
+County of Hawaii,05-11,US Representative,2,R,"EVANS, Roger B.",0,0,39,39
+County of Hawaii,05-11,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,05-11,State Senate,3,D,"ISBELL, Virginia",0,0,144,144
+County of Hawaii,05-11,State Senate,3,D,"GREEN, Josh",0,0,312,312
+County of Hawaii,05-11,State Representative,5,D,"HERKES, Robert (Bob)",0,0,267,267
+County of Hawaii,05-12,Straight Party,,,DEMOCRATIC PARTY (D),0,0,412,412
+County of Hawaii,05-12,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Hawaii,05-12,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,05-12,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,05-12,Straight Party,,,REPUBLICAN PARTY (R),0,0,60,60
+County of Hawaii,05-12,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Hawaii,05-12,US Representative,2,D,"HIRONO, Mazie",0,0,278,278
+County of Hawaii,05-12,US Representative,2,R,"EVANS, Roger B.",0,0,56,56
+County of Hawaii,05-12,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,05-12,State Senate,3,D,"ISBELL, Virginia",0,0,122,122
+County of Hawaii,05-12,State Senate,3,D,"GREEN, Josh",0,0,277,277
+County of Hawaii,05-12,State Representative,5,D,"HERKES, Robert (Bob)",0,0,255,255
+County of Hawaii,06-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,301,301
+County of Hawaii,06-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+County of Hawaii,06-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,06-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+County of Hawaii,06-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,63,63
+County of Hawaii,06-01,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,06-01,US Representative,2,D,"HIRONO, Mazie",0,0,205,205
+County of Hawaii,06-01,US Representative,2,R,"EVANS, Roger B.",0,0,33,33
+County of Hawaii,06-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,06-01,State Senate,3,D,"ISBELL, Virginia",0,0,69,69
+County of Hawaii,06-01,State Senate,3,D,"GREEN, Josh",0,0,224,224
+County of Hawaii,06-01,State Representative,6,D,"COFFMAN, Denny",0,0,101,101
+County of Hawaii,06-01,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,88,88
+County of Hawaii,06-01,State Representative,6,D,"MACGREGOR, Maegan",0,0,47,47
+County of Hawaii,06-01,State Representative,6,R,"SMITH, Andy",0,0,49,49
+County of Hawaii,06-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,554,554
+County of Hawaii,06-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+County of Hawaii,06-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,06-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,06-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,152,152
+County of Hawaii,06-02,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+County of Hawaii,06-02,US Representative,2,D,"HIRONO, Mazie",0,0,380,380
+County of Hawaii,06-02,US Representative,2,R,"EVANS, Roger B.",0,0,84,84
+County of Hawaii,06-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,06-02,State Senate,3,D,"ISBELL, Virginia",0,0,86,86
+County of Hawaii,06-02,State Senate,3,D,"GREEN, Josh",0,0,458,458
+County of Hawaii,06-02,State Representative,6,D,"COFFMAN, Denny",0,0,287,287
+County of Hawaii,06-02,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,106,106
+County of Hawaii,06-02,State Representative,6,D,"MACGREGOR, Maegan",0,0,74,74
+County of Hawaii,06-02,State Representative,6,R,"SMITH, Andy",0,0,129,129
+County of Hawaii,06-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,214,214
+County of Hawaii,06-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,06-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,06-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Hawaii,06-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,81,81
+County of Hawaii,06-03,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,06-03,US Representative,2,D,"HIRONO, Mazie",0,0,145,145
+County of Hawaii,06-03,US Representative,2,R,"EVANS, Roger B.",0,0,43,43
+County of Hawaii,06-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,06-03,State Senate,3,D,"ISBELL, Virginia",0,0,32,32
+County of Hawaii,06-03,State Senate,3,D,"GREEN, Josh",0,0,179,179
+County of Hawaii,06-03,State Representative,6,D,"COFFMAN, Denny",0,0,98,98
+County of Hawaii,06-03,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,30,30
+County of Hawaii,06-03,State Representative,6,D,"MACGREGOR, Maegan",0,0,32,32
+County of Hawaii,06-03,State Representative,6,R,"SMITH, Andy",0,0,73,73
+County of Hawaii,06-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,282,282
+County of Hawaii,06-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Hawaii,06-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,06-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,06-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,95,95
+County of Hawaii,06-04,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Hawaii,06-04,US Representative,2,D,"HIRONO, Mazie",0,0,180,180
+County of Hawaii,06-04,US Representative,2,R,"EVANS, Roger B.",0,0,57,57
+County of Hawaii,06-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,06-04,State Senate,3,D,"ISBELL, Virginia",0,0,49,49
+County of Hawaii,06-04,State Senate,3,D,"GREEN, Josh",0,0,223,223
+County of Hawaii,06-04,State Representative,6,D,"COFFMAN, Denny",0,0,74,74
+County of Hawaii,06-04,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,119,119
+County of Hawaii,06-04,State Representative,6,D,"MACGREGOR, Maegan",0,0,34,34
+County of Hawaii,06-04,State Representative,6,R,"SMITH, Andy",0,0,76,76
+County of Hawaii,06-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,286,286
+County of Hawaii,06-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Hawaii,06-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,06-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Hawaii,06-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,81,81
+County of Hawaii,06-05,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Hawaii,06-05,US Representative,2,D,"HIRONO, Mazie",0,0,187,187
+County of Hawaii,06-05,US Representative,2,R,"EVANS, Roger B.",0,0,43,43
+County of Hawaii,06-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,06-05,State Senate,3,D,"ISBELL, Virginia",0,0,65,65
+County of Hawaii,06-05,State Senate,3,D,"GREEN, Josh",0,0,210,210
+County of Hawaii,06-05,State Representative,6,D,"COFFMAN, Denny",0,0,81,81
+County of Hawaii,06-05,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,88,88
+County of Hawaii,06-05,State Representative,6,D,"MACGREGOR, Maegan",0,0,45,45
+County of Hawaii,06-05,State Representative,6,R,"SMITH, Andy",0,0,69,69
+County of Hawaii,06-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,216,216
+County of Hawaii,06-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,06-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,06-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Hawaii,06-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,67,67
+County of Hawaii,06-06,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,06-06,US Representative,2,D,"HIRONO, Mazie",0,0,162,162
+County of Hawaii,06-06,US Representative,2,R,"EVANS, Roger B.",0,0,34,34
+County of Hawaii,06-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,06-06,State Senate,3,D,"ISBELL, Virginia",0,0,51,51
+County of Hawaii,06-06,State Senate,3,D,"GREEN, Josh",0,0,153,153
+County of Hawaii,06-06,State Representative,6,D,"COFFMAN, Denny",0,0,73,73
+County of Hawaii,06-06,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,68,68
+County of Hawaii,06-06,State Representative,6,D,"MACGREGOR, Maegan",0,0,38,38
+County of Hawaii,06-06,State Representative,6,R,"SMITH, Andy",0,0,60,60
+County of Hawaii,06-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,183,183
+County of Hawaii,06-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+County of Hawaii,06-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,06-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,8,8
+County of Hawaii,06-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,54,54
+County of Hawaii,06-07,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,06-07,US Representative,2,D,"HIRONO, Mazie",0,0,129,129
+County of Hawaii,06-07,US Representative,2,R,"EVANS, Roger B.",0,0,33,33
+County of Hawaii,06-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,06-07,State Senate,3,D,"ISBELL, Virginia",0,0,24,24
+County of Hawaii,06-07,State Senate,3,D,"GREEN, Josh",0,0,155,155
+County of Hawaii,06-07,State Representative,6,D,"COFFMAN, Denny",0,0,79,79
+County of Hawaii,06-07,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,42,42
+County of Hawaii,06-07,State Representative,6,D,"MACGREGOR, Maegan",0,0,25,25
+County of Hawaii,06-07,State Representative,6,R,"SMITH, Andy",0,0,49,49
+County of Hawaii,06-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,291,291
+County of Hawaii,06-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Hawaii,06-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,06-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+County of Hawaii,06-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,51,51
+County of Hawaii,06-08,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,06-08,US Representative,2,D,"HIRONO, Mazie",0,0,206,206
+County of Hawaii,06-08,US Representative,2,R,"EVANS, Roger B.",0,0,30,30
+County of Hawaii,06-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,06-08,State Senate,3,D,"ISBELL, Virginia",0,0,75,75
+County of Hawaii,06-08,State Senate,3,D,"GREEN, Josh",0,0,200,200
+County of Hawaii,06-08,State Representative,6,D,"COFFMAN, Denny",0,0,77,77
+County of Hawaii,06-08,State Representative,6,D,"LESLIE, Gene (Bucky)",0,0,93,93
+County of Hawaii,06-08,State Representative,6,D,"MACGREGOR, Maegan",0,0,56,56
+County of Hawaii,06-08,State Representative,6,R,"SMITH, Andy",0,0,39,39
+County of Hawaii,07-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,240,240
+County of Hawaii,07-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,07-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Hawaii,07-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+County of Hawaii,07-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,57,57
+County of Hawaii,07-01,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Hawaii,07-01,US Representative,2,D,"HIRONO, Mazie",0,0,158,158
+County of Hawaii,07-01,US Representative,2,R,"EVANS, Roger B.",0,0,45,45
+County of Hawaii,07-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Hawaii,07-01,State Senate,3,D,"ISBELL, Virginia",0,0,40,40
+County of Hawaii,07-01,State Senate,3,D,"GREEN, Josh",0,0,182,182
+County of Hawaii,07-01,State Representative,7,D,"EVANS, Cindy",0,0,162,162
+County of Hawaii,07-01,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,32,32
+County of Hawaii,07-01,State Representative,7,R,"KAILIMAI, B.J.",0,0,17,17
+County of Hawaii,07-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,593,593
+County of Hawaii,07-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Hawaii,07-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,07-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,12,12
+County of Hawaii,07-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,139,139
+County of Hawaii,07-02,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Hawaii,07-02,US Representative,2,D,"HIRONO, Mazie",0,0,368,368
+County of Hawaii,07-02,US Representative,2,R,"EVANS, Roger B.",0,0,107,107
+County of Hawaii,07-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,07-02,State Senate,3,D,"ISBELL, Virginia",0,0,142,142
+County of Hawaii,07-02,State Senate,3,D,"GREEN, Josh",0,0,410,410
+County of Hawaii,07-02,State Representative,7,D,"EVANS, Cindy",0,0,379,379
+County of Hawaii,07-02,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,62,62
+County of Hawaii,07-02,State Representative,7,R,"KAILIMAI, B.J.",0,0,36,36
+County of Hawaii,07-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,498,498
+County of Hawaii,07-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,10,10
+County of Hawaii,07-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+County of Hawaii,07-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,11,11
+County of Hawaii,07-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,166,166
+County of Hawaii,07-03,US Representative,2,I,"STENSHOL, Shaun",0,0,10,10
+County of Hawaii,07-03,US Representative,2,D,"HIRONO, Mazie",0,0,346,346
+County of Hawaii,07-03,US Representative,2,R,"EVANS, Roger B.",0,0,121,121
+County of Hawaii,07-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,7,7
+County of Hawaii,07-03,State Senate,3,D,"ISBELL, Virginia",0,0,81,81
+County of Hawaii,07-03,State Senate,3,D,"GREEN, Josh",0,0,348,348
+County of Hawaii,07-03,State Representative,7,D,"EVANS, Cindy",0,0,401,401
+County of Hawaii,07-03,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,86,86
+County of Hawaii,07-03,State Representative,7,R,"KAILIMAI, B.J.",0,0,61,61
+County of Hawaii,07-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,70,70
+County of Hawaii,07-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,07-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,07-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,07-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,26,26
+County of Hawaii,07-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,07-04,US Representative,2,D,"HIRONO, Mazie",0,0,53,53
+County of Hawaii,07-04,US Representative,2,R,"EVANS, Roger B.",0,0,18,18
+County of Hawaii,07-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,07-04,State Senate,3,D,"ISBELL, Virginia",0,0,9,9
+County of Hawaii,07-04,State Senate,3,D,"GREEN, Josh",0,0,51,51
+County of Hawaii,07-04,State Representative,7,D,"EVANS, Cindy",0,0,52,52
+County of Hawaii,07-04,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,13,13
+County of Hawaii,07-04,State Representative,7,R,"KAILIMAI, B.J.",0,0,6,6
+County of Hawaii,07-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,329,329
+County of Hawaii,07-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,07-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+County of Hawaii,07-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+County of Hawaii,07-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,131,131
+County of Hawaii,07-05,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,07-05,US Representative,2,D,"HIRONO, Mazie",0,0,216,216
+County of Hawaii,07-05,US Representative,2,R,"EVANS, Roger B.",0,0,84,84
+County of Hawaii,07-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+County of Hawaii,07-05,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,223,223
+County of Hawaii,07-05,State Senate,1,R,"HONG, Ted H.S.",0,0,94,94
+County of Hawaii,07-05,State Representative,7,D,"EVANS, Cindy",0,0,210,210
+County of Hawaii,07-05,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,48,48
+County of Hawaii,07-05,State Representative,7,R,"KAILIMAI, B.J.",0,0,64,64
+County of Hawaii,07-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,319,319
+County of Hawaii,07-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,07-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,07-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+County of Hawaii,07-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,104,104
+County of Hawaii,07-06,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,07-06,US Representative,2,D,"HIRONO, Mazie",0,0,204,204
+County of Hawaii,07-06,US Representative,2,R,"EVANS, Roger B.",0,0,55,55
+County of Hawaii,07-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,07-06,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,214,214
+County of Hawaii,07-06,State Senate,1,R,"HONG, Ted H.S.",0,0,65,65
+County of Hawaii,07-06,State Representative,7,D,"EVANS, Cindy",0,0,207,207
+County of Hawaii,07-06,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,32,32
+County of Hawaii,07-06,State Representative,7,R,"KAILIMAI, B.J.",0,0,56,56
+County of Hawaii,07-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,161,161
+County of Hawaii,07-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Hawaii,07-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Hawaii,07-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Hawaii,07-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,67,67
+County of Hawaii,07-07,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Hawaii,07-07,US Representative,2,D,"HIRONO, Mazie",0,0,99,99
+County of Hawaii,07-07,US Representative,2,R,"EVANS, Roger B.",0,0,36,36
+County of Hawaii,07-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Hawaii,07-07,State Senate,1,D,"TAKAMINE, Dwight Y.",0,0,109,109
+County of Hawaii,07-07,State Senate,1,R,"HONG, Ted H.S.",0,0,43,43
+County of Hawaii,07-07,State Representative,7,D,"EVANS, Cindy",0,0,92,92
+County of Hawaii,07-07,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,19,19
+County of Hawaii,07-07,State Representative,7,R,"KAILIMAI, B.J.",0,0,38,38
+County of Hawaii,07-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,33,33
+County of Hawaii,07-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Hawaii,07-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Hawaii,07-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Hawaii,07-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,11,11
+County of Hawaii,07-08,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Hawaii,07-08,US Representative,2,D,"HIRONO, Mazie",0,0,20,20
+County of Hawaii,07-08,US Representative,2,R,"EVANS, Roger B.",0,0,8,8
+County of Hawaii,07-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Hawaii,07-08,State Senate,3,D,"ISBELL, Virginia",0,0,2,2
+County of Hawaii,07-08,State Senate,3,D,"GREEN, Josh",0,0,26,26
+County of Hawaii,07-08,State Representative,7,D,"EVANS, Cindy",0,0,25,25
+County of Hawaii,07-08,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",0,0,3,3
+County of Hawaii,07-08,State Representative,7,R,"KAILIMAI, B.J.",0,0,6,6
+County of Maui,08-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,264,264
+County of Maui,08-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,08-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,08-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,08-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,27,27
+County of Maui,08-01,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Maui,08-01,US Representative,2,D,"HIRONO, Mazie",0,0,193,193
+County of Maui,08-01,US Representative,2,R,"EVANS, Roger B.",0,0,24,24
+County of Maui,08-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,08-01,State Representative,8,D,"KAMA, Tasha",0,0,160,160
+County of Maui,08-01,State Representative,8,D,"SOUKI, Joe",0,0,93,93
+County of Maui,08-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,452,452
+County of Maui,08-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,08-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,08-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+County of Maui,08-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,44,44
+County of Maui,08-02,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Maui,08-02,US Representative,2,D,"HIRONO, Mazie",0,0,338,338
+County of Maui,08-02,US Representative,2,R,"EVANS, Roger B.",0,0,38,38
+County of Maui,08-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,08-02,State Representative,8,D,"KAMA, Tasha",0,0,234,234
+County of Maui,08-02,State Representative,8,D,"SOUKI, Joe",0,0,192,192
+County of Maui,08-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,213,213
+County of Maui,08-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Maui,08-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,08-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,08-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,26,26
+County of Maui,08-03,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,08-03,US Representative,2,D,"HIRONO, Mazie",0,0,168,168
+County of Maui,08-03,US Representative,2,R,"EVANS, Roger B.",0,0,24,24
+County of Maui,08-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,08-03,State Representative,8,D,"KAMA, Tasha",0,0,69,69
+County of Maui,08-03,State Representative,8,D,"SOUKI, Joe",0,0,127,127
+County of Maui,08-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,209,209
+County of Maui,08-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Maui,08-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,08-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+County of Maui,08-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,14,14
+County of Maui,08-04,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,08-04,US Representative,2,D,"HIRONO, Mazie",0,0,158,158
+County of Maui,08-04,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Maui,08-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,08-04,State Representative,8,D,"KAMA, Tasha",0,0,92,92
+County of Maui,08-04,State Representative,8,D,"SOUKI, Joe",0,0,95,95
+County of Maui,08-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,426,426
+County of Maui,08-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,08-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,08-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+County of Maui,08-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,70,70
+County of Maui,08-05,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,08-05,US Representative,2,D,"HIRONO, Mazie",0,0,333,333
+County of Maui,08-05,US Representative,2,R,"EVANS, Roger B.",0,0,61,61
+County of Maui,08-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,08-05,State Representative,8,D,"KAMA, Tasha",0,0,178,178
+County of Maui,08-05,State Representative,8,D,"SOUKI, Joe",0,0,216,216
+County of Maui,08-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,223,223
+County of Maui,08-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,08-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,08-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,08-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,15,15
+County of Maui,08-06,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,08-06,US Representative,2,D,"HIRONO, Mazie",0,0,181,181
+County of Maui,08-06,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Maui,08-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Maui,08-06,State Representative,8,D,"KAMA, Tasha",0,0,85,85
+County of Maui,08-06,State Representative,8,D,"SOUKI, Joe",0,0,118,118
+County of Maui,08-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,141,141
+County of Maui,08-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,08-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,08-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,08-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,11,11
+County of Maui,08-07,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,08-07,US Representative,2,D,"HIRONO, Mazie",0,0,115,115
+County of Maui,08-07,US Representative,2,R,"EVANS, Roger B.",0,0,10,10
+County of Maui,08-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,08-07,State Representative,8,D,"KAMA, Tasha",0,0,61,61
+County of Maui,08-07,State Representative,8,D,"SOUKI, Joe",0,0,71,71
+County of Maui,09-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,192,192
+County of Maui,09-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,09-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,09-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Maui,09-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,28,28
+County of Maui,09-01,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,09-01,US Representative,2,D,"HIRONO, Mazie",0,0,148,148
+County of Maui,09-01,US Representative,2,R,"EVANS, Roger B.",0,0,20,20
+County of Maui,09-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,09-01,State Representative,9,D,"NAKASONE, Bob",0,0,123,123
+County of Maui,09-01,State Representative,9,R,"KAHULA, Henry P., Jr.",0,0,21,21
+County of Maui,09-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,392,392
+County of Maui,09-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,09-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,09-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,09-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,56,56
+County of Maui,09-02,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,09-02,US Representative,2,D,"HIRONO, Mazie",0,0,337,337
+County of Maui,09-02,US Representative,2,R,"EVANS, Roger B.",0,0,31,31
+County of Maui,09-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Maui,09-02,State Representative,9,D,"NAKASONE, Bob",0,0,268,268
+County of Maui,09-02,State Representative,9,R,"KAHULA, Henry P., Jr.",0,0,34,34
+County of Maui,09-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,338,338
+County of Maui,09-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,09-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,09-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Maui,09-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,40,40
+County of Maui,09-03,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,09-03,US Representative,2,D,"HIRONO, Mazie",0,0,287,287
+County of Maui,09-03,US Representative,2,R,"EVANS, Roger B.",0,0,25,25
+County of Maui,09-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,09-03,State Representative,9,D,"NAKASONE, Bob",0,0,246,246
+County of Maui,09-03,State Representative,9,R,"KAHULA, Henry P., Jr.",0,0,24,24
+County of Maui,09-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,299,299
+County of Maui,09-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Maui,09-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,09-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,09-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,33,33
+County of Maui,09-04,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,09-04,US Representative,2,D,"HIRONO, Mazie",0,0,249,249
+County of Maui,09-04,US Representative,2,R,"EVANS, Roger B.",0,0,14,14
+County of Maui,09-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,09-04,State Representative,9,D,"NAKASONE, Bob",0,0,183,183
+County of Maui,09-04,State Representative,9,R,"KAHULA, Henry P., Jr.",0,0,24,24
+County of Maui,09-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,381,381
+County of Maui,09-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Maui,09-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,09-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,09-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,30,30
+County of Maui,09-05,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Maui,09-05,US Representative,2,D,"HIRONO, Mazie",0,0,312,312
+County of Maui,09-05,US Representative,2,R,"EVANS, Roger B.",0,0,24,24
+County of Maui,09-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,09-05,State Representative,9,D,"NAKASONE, Bob",0,0,256,256
+County of Maui,09-05,State Representative,9,R,"KAHULA, Henry P., Jr.",0,0,18,18
+County of Maui,09-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,22,22
+County of Maui,09-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,09-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,09-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,09-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,2,2
+County of Maui,09-06,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,09-06,US Representative,2,D,"HIRONO, Mazie",0,0,17,17
+County of Maui,09-06,US Representative,2,R,"EVANS, Roger B.",0,0,1,1
+County of Maui,09-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,09-06,State Representative,9,D,"NAKASONE, Bob",0,0,11,11
+County of Maui,09-06,State Representative,9,R,"KAHULA, Henry P., Jr.",0,0,1,1
+County of Maui,09-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,120,120
+County of Maui,09-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Maui,09-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Maui,09-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Maui,09-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,26,26
+County of Maui,09-07,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Maui,09-07,US Representative,2,D,"HIRONO, Mazie",0,0,98,98
+County of Maui,09-07,US Representative,2,R,"EVANS, Roger B.",0,0,12,12
+County of Maui,09-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Maui,09-07,State Representative,9,D,"NAKASONE, Bob",0,0,60,60
+County of Maui,09-07,State Representative,9,R,"KAHULA, Henry P., Jr.",0,0,19,19
+County of Maui,10-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,114,114
+County of Maui,10-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Maui,10-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,10-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,10-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,24,24
+County of Maui,10-01,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+County of Maui,10-01,US Representative,2,D,"HIRONO, Mazie",0,0,90,90
+County of Maui,10-01,US Representative,2,R,"EVANS, Roger B.",0,0,10,10
+County of Maui,10-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,10-01,State Senate,5,D,"BAKER, Roz",0,0,89,89
+County of Maui,10-01,State Senate,5,D,"MULVIHILL, Bart",0,0,13,13
+County of Maui,10-01,State Senate,5,R,"SHIELDS, Jan",0,0,17,17
+County of Maui,10-01,State Representative,10,D,"MCKELVEY, Angus",0,0,76,76
+County of Maui,10-01,State Representative,10,R,"MADDEN, Ramon K.",0,0,14,14
+County of Maui,10-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,176,176
+County of Maui,10-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,10-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,10-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,10-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,58,58
+County of Maui,10-02,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,10-02,US Representative,2,D,"HIRONO, Mazie",0,0,125,125
+County of Maui,10-02,US Representative,2,R,"EVANS, Roger B.",0,0,25,25
+County of Maui,10-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,10-02,State Senate,5,D,"BAKER, Roz",0,0,112,112
+County of Maui,10-02,State Senate,5,D,"MULVIHILL, Bart",0,0,42,42
+County of Maui,10-02,State Senate,5,R,"SHIELDS, Jan",0,0,52,52
+County of Maui,10-02,State Representative,10,D,"MCKELVEY, Angus",0,0,136,136
+County of Maui,10-02,State Representative,10,R,"MADDEN, Ramon K.",0,0,26,26
+County of Maui,10-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,246,246
+County of Maui,10-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Maui,10-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,10-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,10-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,26,26
+County of Maui,10-03,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Maui,10-03,US Representative,2,D,"HIRONO, Mazie",0,0,206,206
+County of Maui,10-03,US Representative,2,R,"EVANS, Roger B.",0,0,12,12
+County of Maui,10-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,10-03,State Senate,5,D,"BAKER, Roz",0,0,194,194
+County of Maui,10-03,State Senate,5,D,"MULVIHILL, Bart",0,0,37,37
+County of Maui,10-03,State Senate,5,R,"SHIELDS, Jan",0,0,22,22
+County of Maui,10-03,State Representative,10,D,"MCKELVEY, Angus",0,0,191,191
+County of Maui,10-03,State Representative,10,R,"MADDEN, Ramon K.",0,0,15,15
+County of Maui,10-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,176,176
+County of Maui,10-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,10-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,10-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Maui,10-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,45,45
+County of Maui,10-04,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,10-04,US Representative,2,D,"HIRONO, Mazie",0,0,145,145
+County of Maui,10-04,US Representative,2,R,"EVANS, Roger B.",0,0,17,17
+County of Maui,10-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Maui,10-04,State Senate,5,D,"BAKER, Roz",0,0,132,132
+County of Maui,10-04,State Senate,5,D,"MULVIHILL, Bart",0,0,31,31
+County of Maui,10-04,State Senate,5,R,"SHIELDS, Jan",0,0,37,37
+County of Maui,10-04,State Representative,10,D,"MCKELVEY, Angus",0,0,151,151
+County of Maui,10-04,State Representative,10,R,"MADDEN, Ramon K.",0,0,22,22
+County of Maui,10-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,162,162
+County of Maui,10-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,10-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,10-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,10-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,87,87
+County of Maui,10-05,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,10-05,US Representative,2,D,"HIRONO, Mazie",0,0,111,111
+County of Maui,10-05,US Representative,2,R,"EVANS, Roger B.",0,0,36,36
+County of Maui,10-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,10-05,State Senate,5,D,"BAKER, Roz",0,0,105,105
+County of Maui,10-05,State Senate,5,D,"MULVIHILL, Bart",0,0,46,46
+County of Maui,10-05,State Senate,5,R,"SHIELDS, Jan",0,0,74,74
+County of Maui,10-05,State Representative,10,D,"MCKELVEY, Angus",0,0,125,125
+County of Maui,10-05,State Representative,10,R,"MADDEN, Ramon K.",0,0,39,39
+County of Maui,10-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,200,200
+County of Maui,10-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Maui,10-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,10-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Maui,10-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,81,81
+County of Maui,10-06,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,10-06,US Representative,2,D,"HIRONO, Mazie",0,0,142,142
+County of Maui,10-06,US Representative,2,R,"EVANS, Roger B.",0,0,36,36
+County of Maui,10-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,10-06,State Senate,5,D,"BAKER, Roz",0,0,129,129
+County of Maui,10-06,State Senate,5,D,"MULVIHILL, Bart",0,0,52,52
+County of Maui,10-06,State Senate,5,R,"SHIELDS, Jan",0,0,74,74
+County of Maui,10-06,State Representative,10,D,"MCKELVEY, Angus",0,0,153,153
+County of Maui,10-06,State Representative,10,R,"MADDEN, Ramon K.",0,0,35,35
+County of Maui,11-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,299,299
+County of Maui,11-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Maui,11-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,11-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,11-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,67,67
+County of Maui,11-01,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+County of Maui,11-01,US Representative,2,D,"HIRONO, Mazie",0,0,239,239
+County of Maui,11-01,US Representative,2,R,"EVANS, Roger B.",0,0,26,26
+County of Maui,11-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,11-01,State Senate,5,D,"BAKER, Roz",0,0,217,217
+County of Maui,11-01,State Senate,5,D,"MULVIHILL, Bart",0,0,55,55
+County of Maui,11-01,State Senate,5,R,"SHIELDS, Jan",0,0,47,47
+County of Maui,11-01,State Representative,11,D,"GINGERICH, Michael",0,0,86,86
+County of Maui,11-01,State Representative,11,D,"BERTRAM, Joe, III",0,0,175,175
+County of Maui,11-01,State Representative,11,R,"FONTAINE, George R.",0,0,35,35
+County of Maui,11-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,462,462
+County of Maui,11-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+County of Maui,11-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,11-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Maui,11-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,159,159
+County of Maui,11-02,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Maui,11-02,US Representative,2,D,"HIRONO, Mazie",0,0,342,342
+County of Maui,11-02,US Representative,2,R,"EVANS, Roger B.",0,0,77,77
+County of Maui,11-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Maui,11-02,State Senate,5,D,"BAKER, Roz",0,0,270,270
+County of Maui,11-02,State Senate,5,D,"MULVIHILL, Bart",0,0,153,153
+County of Maui,11-02,State Senate,5,R,"SHIELDS, Jan",0,0,135,135
+County of Maui,11-02,State Representative,11,D,"GINGERICH, Michael",0,0,131,131
+County of Maui,11-02,State Representative,11,D,"BERTRAM, Joe, III",0,0,296,296
+County of Maui,11-02,State Representative,11,R,"FONTAINE, George R.",0,0,108,108
+County of Maui,11-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,272,272
+County of Maui,11-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+County of Maui,11-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,11-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Maui,11-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,116,116
+County of Maui,11-03,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Maui,11-03,US Representative,2,D,"HIRONO, Mazie",0,0,196,196
+County of Maui,11-03,US Representative,2,R,"EVANS, Roger B.",0,0,45,45
+County of Maui,11-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,11-03,State Senate,5,D,"BAKER, Roz",0,0,175,175
+County of Maui,11-03,State Senate,5,D,"MULVIHILL, Bart",0,0,84,84
+County of Maui,11-03,State Senate,5,R,"SHIELDS, Jan",0,0,97,97
+County of Maui,11-03,State Representative,11,D,"GINGERICH, Michael",0,0,61,61
+County of Maui,11-03,State Representative,11,D,"BERTRAM, Joe, III",0,0,183,183
+County of Maui,11-03,State Representative,11,R,"FONTAINE, George R.",0,0,67,67
+County of Maui,11-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,293,293
+County of Maui,11-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+County of Maui,11-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,11-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+County of Maui,11-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,112,112
+County of Maui,11-04,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Maui,11-04,US Representative,2,D,"HIRONO, Mazie",0,0,218,218
+County of Maui,11-04,US Representative,2,R,"EVANS, Roger B.",0,0,62,62
+County of Maui,11-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,11-04,State Senate,5,D,"BAKER, Roz",0,0,202,202
+County of Maui,11-04,State Senate,5,D,"MULVIHILL, Bart",0,0,73,73
+County of Maui,11-04,State Senate,5,R,"SHIELDS, Jan",0,0,85,85
+County of Maui,11-04,State Representative,11,D,"GINGERICH, Michael",0,0,81,81
+County of Maui,11-04,State Representative,11,D,"BERTRAM, Joe, III",0,0,180,180
+County of Maui,11-04,State Representative,11,R,"FONTAINE, George R.",0,0,75,75
+County of Maui,12-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,516,516
+County of Maui,12-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+County of Maui,12-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,12-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,12-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,58,58
+County of Maui,12-01,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+County of Maui,12-01,US Representative,2,D,"HIRONO, Mazie",0,0,367,367
+County of Maui,12-01,US Representative,2,R,"EVANS, Roger B.",0,0,29,29
+County of Maui,12-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Maui,12-01,State Senate,6,I,"BLUMER-BUELL, John",0,0,6,6
+County of Maui,12-01,State Senate,6,D,"ENGLISH, J. Kalani",0,0,344,344
+County of Maui,12-01,State Representative,12,D,"YAMASHITA, Kyle",0,0,300,300
+County of Maui,12-01,State Representative,12,D,"STARR, Summer",0,0,195,195
+County of Maui,12-01,State Representative,12,R,"VIERRA, Mickey",0,0,49,49
+County of Maui,12-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,403,403
+County of Maui,12-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,12-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,12-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,12-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,36,36
+County of Maui,12-02,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,12-02,US Representative,2,D,"HIRONO, Mazie",0,0,247,247
+County of Maui,12-02,US Representative,2,R,"EVANS, Roger B.",0,0,15,15
+County of Maui,12-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Maui,12-02,State Senate,6,I,"BLUMER-BUELL, John",0,0,3,3
+County of Maui,12-02,State Senate,6,D,"ENGLISH, J. Kalani",0,0,249,249
+County of Maui,12-02,State Representative,12,D,"YAMASHITA, Kyle",0,0,191,191
+County of Maui,12-02,State Representative,12,D,"STARR, Summer",0,0,203,203
+County of Maui,12-02,State Representative,12,R,"VIERRA, Mickey",0,0,27,27
+County of Maui,12-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,532,532
+County of Maui,12-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Maui,12-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,12-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Maui,12-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,63,63
+County of Maui,12-03,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,12-03,US Representative,2,D,"HIRONO, Mazie",0,0,344,344
+County of Maui,12-03,US Representative,2,R,"EVANS, Roger B.",0,0,30,30
+County of Maui,12-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,12-03,State Senate,6,I,"BLUMER-BUELL, John",0,0,2,2
+County of Maui,12-03,State Senate,6,D,"ENGLISH, J. Kalani",0,0,319,319
+County of Maui,12-03,State Representative,12,D,"YAMASHITA, Kyle",0,0,275,275
+County of Maui,12-03,State Representative,12,D,"STARR, Summer",0,0,239,239
+County of Maui,12-03,State Representative,12,R,"VIERRA, Mickey",0,0,51,51
+County of Maui,12-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,679,679
+County of Maui,12-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Maui,12-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,12-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,12-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,90,90
+County of Maui,12-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,12-04,US Representative,2,D,"HIRONO, Mazie",0,0,492,492
+County of Maui,12-04,US Representative,2,R,"EVANS, Roger B.",0,0,32,32
+County of Maui,12-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,12-04,State Senate,6,I,"BLUMER-BUELL, John",0,0,2,2
+County of Maui,12-04,State Senate,6,D,"ENGLISH, J. Kalani",0,0,448,448
+County of Maui,12-04,State Representative,12,D,"YAMASHITA, Kyle",0,0,444,444
+County of Maui,12-04,State Representative,12,D,"STARR, Summer",0,0,211,211
+County of Maui,12-04,State Representative,12,R,"VIERRA, Mickey",0,0,72,72
+County of Maui,12-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,306,306
+County of Maui,12-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Maui,12-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,12-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Maui,12-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,46,46
+County of Maui,12-05,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,12-05,US Representative,2,D,"HIRONO, Mazie",0,0,208,208
+County of Maui,12-05,US Representative,2,R,"EVANS, Roger B.",0,0,16,16
+County of Maui,12-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,12-05,State Senate,6,I,"BLUMER-BUELL, John",0,0,0,0
+County of Maui,12-05,State Senate,6,D,"ENGLISH, J. Kalani",0,0,204,204
+County of Maui,12-05,State Representative,12,D,"YAMASHITA, Kyle",0,0,149,149
+County of Maui,12-05,State Representative,12,D,"STARR, Summer",0,0,141,141
+County of Maui,12-05,State Representative,12,R,"VIERRA, Mickey",0,0,34,34
+County of Maui,12-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,524,524
+County of Maui,12-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+County of Maui,12-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Maui,12-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,12-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,61,61
+County of Maui,12-06,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,12-06,US Representative,2,D,"HIRONO, Mazie",0,0,324,324
+County of Maui,12-06,US Representative,2,R,"EVANS, Roger B.",0,0,34,34
+County of Maui,12-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Maui,12-06,State Senate,6,I,"BLUMER-BUELL, John",0,0,2,2
+County of Maui,12-06,State Senate,6,D,"ENGLISH, J. Kalani",0,0,331,331
+County of Maui,12-06,State Representative,12,D,"YAMASHITA, Kyle",0,0,220,220
+County of Maui,12-06,State Representative,12,D,"STARR, Summer",0,0,288,288
+County of Maui,12-06,State Representative,12,R,"VIERRA, Mickey",0,0,49,49
+County of Maui,12-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,33,33
+County of Maui,12-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,12-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,12-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,12-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,5,5
+County of Maui,12-07,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,12-07,US Representative,2,D,"HIRONO, Mazie",0,0,17,17
+County of Maui,12-07,US Representative,2,R,"EVANS, Roger B.",0,0,3,3
+County of Maui,12-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,12-07,State Senate,6,I,"BLUMER-BUELL, John",0,0,0,0
+County of Maui,12-07,State Senate,6,D,"ENGLISH, J. Kalani",0,0,25,25
+County of Maui,12-07,State Representative,12,D,"YAMASHITA, Kyle",0,0,6,6
+County of Maui,12-07,State Representative,12,D,"STARR, Summer",0,0,27,27
+County of Maui,12-07,State Representative,12,R,"VIERRA, Mickey",0,0,4,4
+County of Maui,13-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,151,151
+County of Maui,13-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Maui,13-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,13-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Maui,13-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,19,19
+County of Maui,13-01,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,13-01,US Representative,2,D,"HIRONO, Mazie",0,0,103,103
+County of Maui,13-01,US Representative,2,R,"EVANS, Roger B.",0,0,18,18
+County of Maui,13-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,13-01,State Senate,6,I,"BLUMER-BUELL, John",0,0,1,1
+County of Maui,13-01,State Senate,6,D,"ENGLISH, J. Kalani",0,0,104,104
+County of Maui,13-01,State Representative,13,D,"CARROLL, Mele",0,0,94,94
+County of Maui,13-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,358,358
+County of Maui,13-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,13,13
+County of Maui,13-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Maui,13-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,13-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,56,56
+County of Maui,13-02,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Maui,13-02,US Representative,2,D,"HIRONO, Mazie",0,0,208,208
+County of Maui,13-02,US Representative,2,R,"EVANS, Roger B.",0,0,54,54
+County of Maui,13-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Maui,13-02,State Senate,6,I,"BLUMER-BUELL, John",0,0,10,10
+County of Maui,13-02,State Senate,6,D,"ENGLISH, J. Kalani",0,0,230,230
+County of Maui,13-02,State Representative,13,D,"CARROLL, Mele",0,0,213,213
+County of Maui,13-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,389,389
+County of Maui,13-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,21,21
+County of Maui,13-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+County of Maui,13-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Maui,13-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,32,32
+County of Maui,13-03,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+County of Maui,13-03,US Representative,2,D,"HIRONO, Mazie",0,0,254,254
+County of Maui,13-03,US Representative,2,R,"EVANS, Roger B.",0,0,30,30
+County of Maui,13-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,6,6
+County of Maui,13-03,State Senate,6,I,"BLUMER-BUELL, John",0,0,19,19
+County of Maui,13-03,State Senate,6,D,"ENGLISH, J. Kalani",0,0,261,261
+County of Maui,13-03,State Representative,13,D,"CARROLL, Mele",0,0,253,253
+County of Maui,13-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,95,95
+County of Maui,13-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Maui,13-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,13-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,13-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,8,8
+County of Maui,13-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,13-04,US Representative,2,D,"HIRONO, Mazie",0,0,54,54
+County of Maui,13-04,US Representative,2,R,"EVANS, Roger B.",0,0,8,8
+County of Maui,13-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,13-04,State Senate,6,I,"BLUMER-BUELL, John",0,0,7,7
+County of Maui,13-04,State Senate,6,D,"ENGLISH, J. Kalani",0,0,67,67
+County of Maui,13-04,State Representative,13,D,"CARROLL, Mele",0,0,68,68
+County of Maui,13-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,19,19
+County of Maui,13-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+County of Maui,13-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,13-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,13-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,7,7
+County of Maui,13-05,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Maui,13-05,US Representative,2,D,"HIRONO, Mazie",0,0,12,12
+County of Maui,13-05,US Representative,2,R,"EVANS, Roger B.",0,0,6,6
+County of Maui,13-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,13-05,State Senate,6,I,"BLUMER-BUELL, John",0,0,5,5
+County of Maui,13-05,State Senate,6,D,"ENGLISH, J. Kalani",0,0,13,13
+County of Maui,13-05,State Representative,13,D,"CARROLL, Mele",0,0,11,11
+County of Maui,13-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,192,192
+County of Maui,13-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,23,23
+County of Maui,13-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,13-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,13-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,17,17
+County of Maui,13-06,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Maui,13-06,US Representative,2,D,"HIRONO, Mazie",0,0,109,109
+County of Maui,13-06,US Representative,2,R,"EVANS, Roger B.",0,0,15,15
+County of Maui,13-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,13-06,State Senate,6,I,"BLUMER-BUELL, John",0,0,23,23
+County of Maui,13-06,State Senate,6,D,"ENGLISH, J. Kalani",0,0,160,160
+County of Maui,13-06,State Representative,13,D,"CARROLL, Mele",0,0,108,108
+County of Maui,13-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,362,362
+County of Maui,13-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+County of Maui,13-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Maui,13-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,13-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,47,47
+County of Maui,13-07,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Maui,13-07,US Representative,2,D,"HIRONO, Mazie",0,0,259,259
+County of Maui,13-07,US Representative,2,R,"EVANS, Roger B.",0,0,43,43
+County of Maui,13-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,13-07,State Senate,6,I,"BLUMER-BUELL, John",0,0,4,4
+County of Maui,13-07,State Senate,6,D,"ENGLISH, J. Kalani",0,0,184,184
+County of Maui,13-07,State Representative,13,D,"CARROLL, Mele",0,0,177,177
+County of Maui,13-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,59,59
+County of Maui,13-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,13-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,13-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,13-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,12,12
+County of Maui,13-08,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,13-08,US Representative,2,D,"HIRONO, Mazie",0,0,32,32
+County of Maui,13-08,US Representative,2,R,"EVANS, Roger B.",0,0,10,10
+County of Maui,13-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,13-08,State Senate,6,I,"BLUMER-BUELL, John",0,0,0,0
+County of Maui,13-08,State Senate,6,D,"ENGLISH, J. Kalani",0,0,43,43
+County of Maui,13-08,State Representative,13,D,"CARROLL, Mele",0,0,37,37
+County of Maui,13-09,Straight Party,,,DEMOCRATIC PARTY (D),0,0,223,223
+County of Maui,13-09,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,13-09,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,13-09,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+County of Maui,13-09,Straight Party,,,REPUBLICAN PARTY (R),0,0,20,20
+County of Maui,13-09,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,13-09,US Representative,2,D,"HIRONO, Mazie",0,0,155,155
+County of Maui,13-09,US Representative,2,R,"EVANS, Roger B.",0,0,20,20
+County of Maui,13-09,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,13-09,State Senate,6,I,"BLUMER-BUELL, John",0,0,0,0
+County of Maui,13-09,State Senate,6,D,"ENGLISH, J. Kalani",0,0,150,150
+County of Maui,13-09,State Representative,13,D,"CARROLL, Mele",0,0,124,124
+County of Maui,13-10,Straight Party,,,DEMOCRATIC PARTY (D),0,0,25,25
+County of Maui,13-10,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,13-10,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,13-10,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,13-10,Straight Party,,,REPUBLICAN PARTY (R),0,0,9,9
+County of Maui,13-10,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,13-10,US Representative,2,D,"HIRONO, Mazie",0,0,18,18
+County of Maui,13-10,US Representative,2,R,"EVANS, Roger B.",0,0,9,9
+County of Maui,13-10,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,13-10,State Senate,6,I,"BLUMER-BUELL, John",0,0,0,0
+County of Maui,13-10,State Senate,6,D,"ENGLISH, J. Kalani",0,0,17,17
+County of Maui,13-10,State Representative,13,D,"CARROLL, Mele",0,0,16,16
+County of Maui,13-11,Straight Party,,,DEMOCRATIC PARTY (D),0,0,172,172
+County of Maui,13-11,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,13-11,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Maui,13-11,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,13-11,Straight Party,,,REPUBLICAN PARTY (R),0,0,12,12
+County of Maui,13-11,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,13-11,US Representative,2,D,"HIRONO, Mazie",0,0,109,109
+County of Maui,13-11,US Representative,2,R,"EVANS, Roger B.",0,0,11,11
+County of Maui,13-11,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Maui,13-11,State Senate,6,I,"BLUMER-BUELL, John",0,0,0,0
+County of Maui,13-11,State Senate,6,D,"ENGLISH, J. Kalani",0,0,116,116
+County of Maui,13-11,State Representative,13,D,"CARROLL, Mele",0,0,103,103
+County of Maui,13-12,Straight Party,,,DEMOCRATIC PARTY (D),0,0,0,0
+County of Maui,13-12,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Maui,13-12,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Maui,13-12,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Maui,13-12,Straight Party,,,REPUBLICAN PARTY (R),0,0,0,0
+County of Maui,13-12,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Maui,13-12,US Representative,2,D,"HIRONO, Mazie",0,0,0,0
+County of Maui,13-12,US Representative,2,R,"EVANS, Roger B.",0,0,0,0
+County of Maui,13-12,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Maui,13-12,State Senate,6,I,"BLUMER-BUELL, John",0,0,0,0
+County of Maui,13-12,State Senate,6,D,"ENGLISH, J. Kalani",0,0,0,0
+County of Maui,13-12,State Representative,13,D,"CARROLL, Mele",0,0,0,0
+County of Kauai,14-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,442,442
+County of Kauai,14-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,9,9
+County of Kauai,14-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+County of Kauai,14-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Kauai,14-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,134,134
+County of Kauai,14-01,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+County of Kauai,14-01,US Representative,2,D,"HIRONO, Mazie",0,0,232,232
+County of Kauai,14-01,US Representative,2,R,"EVANS, Roger B.",0,0,82,82
+County of Kauai,14-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,5,5
+County of Kauai,14-01,State Senate,7,D,"HOOSER, Gary L.",0,0,324,324
+County of Kauai,14-01,State Senate,7,R,"GEORGI, JoAnne S.",0,0,101,101
+County of Kauai,14-01,State Representative,14,D,"MORITA, Hermina (Mina)",0,0,323,323
+County of Kauai,14-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,525,525
+County of Kauai,14-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,14,14
+County of Kauai,14-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Kauai,14-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,10,10
+County of Kauai,14-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,88,88
+County of Kauai,14-02,US Representative,2,I,"STENSHOL, Shaun",0,0,11,11
+County of Kauai,14-02,US Representative,2,D,"HIRONO, Mazie",0,0,305,305
+County of Kauai,14-02,US Representative,2,R,"EVANS, Roger B.",0,0,54,54
+County of Kauai,14-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Kauai,14-02,State Senate,7,D,"HOOSER, Gary L.",0,0,390,390
+County of Kauai,14-02,State Senate,7,R,"GEORGI, JoAnne S.",0,0,61,61
+County of Kauai,14-02,State Representative,14,D,"MORITA, Hermina (Mina)",0,0,355,355
+County of Kauai,14-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,321,321
+County of Kauai,14-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+County of Kauai,14-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Kauai,14-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Kauai,14-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,43,43
+County of Kauai,14-03,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Kauai,14-03,US Representative,2,D,"HIRONO, Mazie",0,0,149,149
+County of Kauai,14-03,US Representative,2,R,"EVANS, Roger B.",0,0,25,25
+County of Kauai,14-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Kauai,14-03,State Senate,7,D,"HOOSER, Gary L.",0,0,197,197
+County of Kauai,14-03,State Senate,7,R,"GEORGI, JoAnne S.",0,0,27,27
+County of Kauai,14-03,State Representative,14,D,"MORITA, Hermina (Mina)",0,0,173,173
+County of Kauai,14-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,1079,1079
+County of Kauai,14-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,19,19
+County of Kauai,14-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Kauai,14-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,12,12
+County of Kauai,14-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,180,180
+County of Kauai,14-04,US Representative,2,I,"STENSHOL, Shaun",0,0,13,13
+County of Kauai,14-04,US Representative,2,D,"HIRONO, Mazie",0,0,595,595
+County of Kauai,14-04,US Representative,2,R,"EVANS, Roger B.",0,0,100,100
+County of Kauai,14-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Kauai,14-04,State Senate,7,D,"HOOSER, Gary L.",0,0,773,773
+County of Kauai,14-04,State Senate,7,R,"GEORGI, JoAnne S.",0,0,117,117
+County of Kauai,14-04,State Representative,14,D,"MORITA, Hermina (Mina)",0,0,539,539
+County of Kauai,14-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,311,311
+County of Kauai,14-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+County of Kauai,14-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Kauai,14-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+County of Kauai,14-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,53,53
+County of Kauai,14-05,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+County of Kauai,14-05,US Representative,2,D,"HIRONO, Mazie",0,0,161,161
+County of Kauai,14-05,US Representative,2,R,"EVANS, Roger B.",0,0,27,27
+County of Kauai,14-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Kauai,14-05,State Senate,7,D,"HOOSER, Gary L.",0,0,202,202
+County of Kauai,14-05,State Senate,7,R,"GEORGI, JoAnne S.",0,0,43,43
+County of Kauai,14-05,State Representative,14,D,"MORITA, Hermina (Mina)",0,0,140,140
+County of Kauai,15-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,722,722
+County of Kauai,15-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,11,11
+County of Kauai,15-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Kauai,15-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Kauai,15-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,136,136
+County of Kauai,15-01,US Representative,2,I,"STENSHOL, Shaun",0,0,8,8
+County of Kauai,15-01,US Representative,2,D,"HIRONO, Mazie",0,0,405,405
+County of Kauai,15-01,US Representative,2,R,"EVANS, Roger B.",0,0,74,74
+County of Kauai,15-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Kauai,15-01,State Senate,7,D,"HOOSER, Gary L.",0,0,529,529
+County of Kauai,15-01,State Senate,7,R,"GEORGI, JoAnne S.",0,0,96,96
+County of Kauai,15-01,State Representative,15,D,"TOKIOKA, James Kunane",0,0,366,366
+County of Kauai,15-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,463,463
+County of Kauai,15-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Kauai,15-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Kauai,15-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Kauai,15-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,44,44
+County of Kauai,15-02,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Kauai,15-02,US Representative,2,D,"HIRONO, Mazie",0,0,298,298
+County of Kauai,15-02,US Representative,2,R,"EVANS, Roger B.",0,0,21,21
+County of Kauai,15-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Kauai,15-02,State Senate,7,D,"HOOSER, Gary L.",0,0,270,270
+County of Kauai,15-02,State Senate,7,R,"GEORGI, JoAnne S.",0,0,24,24
+County of Kauai,15-02,State Representative,15,D,"TOKIOKA, James Kunane",0,0,244,244
+County of Kauai,15-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,537,537
+County of Kauai,15-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+County of Kauai,15-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+County of Kauai,15-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Kauai,15-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,78,78
+County of Kauai,15-03,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+County of Kauai,15-03,US Representative,2,D,"HIRONO, Mazie",0,0,327,327
+County of Kauai,15-03,US Representative,2,R,"EVANS, Roger B.",0,0,42,42
+County of Kauai,15-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+County of Kauai,15-03,State Senate,7,D,"HOOSER, Gary L.",0,0,323,323
+County of Kauai,15-03,State Senate,7,R,"GEORGI, JoAnne S.",0,0,56,56
+County of Kauai,15-03,State Representative,15,D,"TOKIOKA, James Kunane",0,0,302,302
+County of Kauai,15-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,624,624
+County of Kauai,15-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,9,9
+County of Kauai,15-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,6,6
+County of Kauai,15-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,9,9
+County of Kauai,15-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,101,101
+County of Kauai,15-04,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+County of Kauai,15-04,US Representative,2,D,"HIRONO, Mazie",0,0,373,373
+County of Kauai,15-04,US Representative,2,R,"EVANS, Roger B.",0,0,60,60
+County of Kauai,15-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,6,6
+County of Kauai,15-04,State Senate,7,D,"HOOSER, Gary L.",0,0,399,399
+County of Kauai,15-04,State Senate,7,R,"GEORGI, JoAnne S.",0,0,71,71
+County of Kauai,15-04,State Representative,15,D,"TOKIOKA, James Kunane",0,0,364,364
+County of Kauai,15-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,257,257
+County of Kauai,15-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,10,10
+County of Kauai,15-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Kauai,15-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+County of Kauai,15-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,50,50
+County of Kauai,15-05,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+County of Kauai,15-05,US Representative,2,D,"HIRONO, Mazie",0,0,137,137
+County of Kauai,15-05,US Representative,2,R,"EVANS, Roger B.",0,0,23,23
+County of Kauai,15-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Kauai,15-05,State Senate,7,D,"HOOSER, Gary L.",0,0,169,169
+County of Kauai,15-05,State Senate,7,R,"GEORGI, JoAnne S.",0,0,33,33
+County of Kauai,15-05,State Representative,15,D,"TOKIOKA, James Kunane",0,0,107,107
+County of Kauai,16-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,385,385
+County of Kauai,16-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Kauai,16-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+County of Kauai,16-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+County of Kauai,16-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,85,85
+County of Kauai,16-01,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+County of Kauai,16-01,US Representative,2,D,"HIRONO, Mazie",0,0,245,245
+County of Kauai,16-01,US Representative,2,R,"EVANS, Roger B.",0,0,48,48
+County of Kauai,16-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Kauai,16-01,State Senate,7,D,"HOOSER, Gary L.",0,0,253,253
+County of Kauai,16-01,State Senate,7,R,"GEORGI, JoAnne S.",0,0,60,60
+County of Kauai,16-01,State Representative,16,D,"SAGUM, Roland D., III",0,0,181,181
+County of Kauai,16-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,807,807
+County of Kauai,16-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,13,13
+County of Kauai,16-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+County of Kauai,16-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+County of Kauai,16-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,165,165
+County of Kauai,16-02,US Representative,2,I,"STENSHOL, Shaun",0,0,12,12
+County of Kauai,16-02,US Representative,2,D,"HIRONO, Mazie",0,0,448,448
+County of Kauai,16-02,US Representative,2,R,"EVANS, Roger B.",0,0,90,90
+County of Kauai,16-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+County of Kauai,16-02,State Senate,7,D,"HOOSER, Gary L.",0,0,549,549
+County of Kauai,16-02,State Senate,7,R,"GEORGI, JoAnne S.",0,0,128,128
+County of Kauai,16-02,State Representative,16,D,"SAGUM, Roland D., III",0,0,349,349
+County of Kauai,16-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,590,590
+County of Kauai,16-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,11,11
+County of Kauai,16-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Kauai,16-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,13,13
+County of Kauai,16-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,80,80
+County of Kauai,16-03,US Representative,2,I,"STENSHOL, Shaun",0,0,8,8
+County of Kauai,16-03,US Representative,2,D,"HIRONO, Mazie",0,0,377,377
+County of Kauai,16-03,US Representative,2,R,"EVANS, Roger B.",0,0,31,31
+County of Kauai,16-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Kauai,16-03,State Senate,7,D,"HOOSER, Gary L.",0,0,372,372
+County of Kauai,16-03,State Senate,7,R,"GEORGI, JoAnne S.",0,0,64,64
+County of Kauai,16-03,State Representative,16,D,"SAGUM, Roland D., III",0,0,285,285
+County of Kauai,16-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,79,79
+County of Kauai,16-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+County of Kauai,16-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Kauai,16-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Kauai,16-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,4,4
+County of Kauai,16-04,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+County of Kauai,16-04,US Representative,2,D,"HIRONO, Mazie",0,0,52,52
+County of Kauai,16-04,US Representative,2,R,"EVANS, Roger B.",0,0,3,3
+County of Kauai,16-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Kauai,16-04,State Senate,7,D,"HOOSER, Gary L.",0,0,45,45
+County of Kauai,16-04,State Senate,7,R,"GEORGI, JoAnne S.",0,0,2,2
+County of Kauai,16-04,State Representative,16,D,"SAGUM, Roland D., III",0,0,43,43
+County of Kauai,16-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,373,373
+County of Kauai,16-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+County of Kauai,16-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+County of Kauai,16-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+County of Kauai,16-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,42,42
+County of Kauai,16-05,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+County of Kauai,16-05,US Representative,2,D,"HIRONO, Mazie",0,0,256,256
+County of Kauai,16-05,US Representative,2,R,"EVANS, Roger B.",0,0,25,25
+County of Kauai,16-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+County of Kauai,16-05,State Senate,7,D,"HOOSER, Gary L.",0,0,203,203
+County of Kauai,16-05,State Senate,7,R,"GEORGI, JoAnne S.",0,0,32,32
+County of Kauai,16-05,State Representative,16,D,"SAGUM, Roland D., III",0,0,203,203
+County of Kauai,16-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,484,484
+County of Kauai,16-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,11,11
+County of Kauai,16-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+County of Kauai,16-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,13,13
+County of Kauai,16-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,68,68
+County of Kauai,16-06,US Representative,2,I,"STENSHOL, Shaun",0,0,9,9
+County of Kauai,16-06,US Representative,2,D,"HIRONO, Mazie",0,0,306,306
+County of Kauai,16-06,US Representative,2,R,"EVANS, Roger B.",0,0,36,36
+County of Kauai,16-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+County of Kauai,16-06,State Senate,7,D,"HOOSER, Gary L.",0,0,276,276
+County of Kauai,16-06,State Senate,7,R,"GEORGI, JoAnne S.",0,0,51,51
+County of Kauai,16-06,State Representative,16,D,"SAGUM, Roland D., III",0,0,240,240
+County of Kauai,16-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,24,24
+County of Kauai,16-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+County of Kauai,16-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+County of Kauai,16-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+County of Kauai,16-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,6,6
+County of Kauai,16-07,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+County of Kauai,16-07,US Representative,2,D,"HIRONO, Mazie",0,0,6,6
+County of Kauai,16-07,US Representative,2,R,"EVANS, Roger B.",0,0,2,2
+County of Kauai,16-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+County of Kauai,16-07,State Senate,7,D,"HOOSER, Gary L.",0,0,17,17
+County of Kauai,16-07,State Senate,7,R,"GEORGI, JoAnne S.",0,0,4,4
+County of Kauai,16-07,State Representative,16,D,"SAGUM, Roland D., III",0,0,1,1
+City & County of Honolulu,17-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,433,433
+City & County of Honolulu,17-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,17-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,17-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,17-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,167,167
+City & County of Honolulu,17-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,334,334
+City & County of Honolulu,17-01,US Representative,1,R,"TATAII, Steve",0,0,60,60
+City & County of Honolulu,17-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,17-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,17-01,State Representative,17,D,"MONK, Amy Yukiko",0,0,281,281
+City & County of Honolulu,17-01,State Representative,17,R,"WARD, Gene",0,0,153,153
+City & County of Honolulu,17-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,317,317
+City & County of Honolulu,17-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,17-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,17-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,17-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,80,80
+City & County of Honolulu,17-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,236,236
+City & County of Honolulu,17-02,US Representative,1,R,"TATAII, Steve",0,0,22,22
+City & County of Honolulu,17-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,17-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,17-02,State Representative,17,D,"MONK, Amy Yukiko",0,0,191,191
+City & County of Honolulu,17-02,State Representative,17,R,"WARD, Gene",0,0,79,79
+City & County of Honolulu,17-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,391,391
+City & County of Honolulu,17-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,17-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,6,6
+City & County of Honolulu,17-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,17-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,292,292
+City & County of Honolulu,17-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,273,273
+City & County of Honolulu,17-03,US Representative,1,R,"TATAII, Steve",0,0,94,94
+City & County of Honolulu,17-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,3,3
+City & County of Honolulu,17-03,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,17-03,State Representative,17,D,"MONK, Amy Yukiko",0,0,251,251
+City & County of Honolulu,17-03,State Representative,17,R,"WARD, Gene",0,0,272,272
+City & County of Honolulu,17-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,168,168
+City & County of Honolulu,17-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,17-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,17-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,17-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,132,132
+City & County of Honolulu,17-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,130,130
+City & County of Honolulu,17-04,US Representative,1,R,"TATAII, Steve",0,0,62,62
+City & County of Honolulu,17-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,17-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,17-04,State Representative,17,D,"MONK, Amy Yukiko",0,0,120,120
+City & County of Honolulu,17-04,State Representative,17,R,"WARD, Gene",0,0,130,130
+City & County of Honolulu,17-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,459,459
+City & County of Honolulu,17-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,17-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,17-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,10,10
+City & County of Honolulu,17-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,282,282
+City & County of Honolulu,17-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,359,359
+City & County of Honolulu,17-05,US Representative,1,R,"TATAII, Steve",0,0,82,82
+City & County of Honolulu,17-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,17-05,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,17-05,State Representative,17,D,"MONK, Amy Yukiko",0,0,264,264
+City & County of Honolulu,17-05,State Representative,17,R,"WARD, Gene",0,0,274,274
+City & County of Honolulu,17-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,350,350
+City & County of Honolulu,17-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,17-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,17-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,17-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,151,151
+City & County of Honolulu,17-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,258,258
+City & County of Honolulu,17-06,US Representative,1,R,"TATAII, Steve",0,0,34,34
+City & County of Honolulu,17-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,17-06,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,17-06,State Representative,17,D,"MONK, Amy Yukiko",0,0,235,235
+City & County of Honolulu,17-06,State Representative,17,R,"WARD, Gene",0,0,146,146
+City & County of Honolulu,17-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,494,494
+City & County of Honolulu,17-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,17-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,17-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,17-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,243,243
+City & County of Honolulu,17-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,382,382
+City & County of Honolulu,17-07,US Representative,1,R,"TATAII, Steve",0,0,74,74
+City & County of Honolulu,17-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,17-07,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,17-07,State Representative,17,D,"MONK, Amy Yukiko",0,0,332,332
+City & County of Honolulu,17-07,State Representative,17,R,"WARD, Gene",0,0,236,236
+City & County of Honolulu,18-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,156,156
+City & County of Honolulu,18-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,18-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,18-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,18-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,57,57
+City & County of Honolulu,18-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,120,120
+City & County of Honolulu,18-01,US Representative,1,R,"TATAII, Steve",0,0,51,51
+City & County of Honolulu,18-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,18-01,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,18-01,State Representative,18,D,"BERG, Lyla B.",0,0,112,112
+City & County of Honolulu,18-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,420,420
+City & County of Honolulu,18-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,18-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,8,8
+City & County of Honolulu,18-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,8,8
+City & County of Honolulu,18-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,133,133
+City & County of Honolulu,18-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,316,316
+City & County of Honolulu,18-02,US Representative,1,R,"TATAII, Steve",0,0,121,121
+City & County of Honolulu,18-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,5,5
+City & County of Honolulu,18-02,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,18-02,State Representative,18,D,"BERG, Lyla B.",0,0,277,277
+City & County of Honolulu,18-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,346,346
+City & County of Honolulu,18-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,18-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,18-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,18-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,98,98
+City & County of Honolulu,18-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,254,254
+City & County of Honolulu,18-03,US Representative,1,R,"TATAII, Steve",0,0,87,87
+City & County of Honolulu,18-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,18-03,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,18-03,State Representative,18,D,"BERG, Lyla B.",0,0,241,241
+City & County of Honolulu,18-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,427,427
+City & County of Honolulu,18-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,18-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+City & County of Honolulu,18-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,11,11
+City & County of Honolulu,18-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,112,112
+City & County of Honolulu,18-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,308,308
+City & County of Honolulu,18-04,US Representative,1,R,"TATAII, Steve",0,0,91,91
+City & County of Honolulu,18-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,3,3
+City & County of Honolulu,18-04,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,18-04,State Representative,18,D,"BERG, Lyla B.",0,0,325,325
+City & County of Honolulu,18-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,542,542
+City & County of Honolulu,18-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,18-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,8,8
+City & County of Honolulu,18-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,18-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,156,156
+City & County of Honolulu,18-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,414,414
+City & County of Honolulu,18-05,US Representative,1,R,"TATAII, Steve",0,0,146,146
+City & County of Honolulu,18-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,18-05,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,18-05,State Representative,18,D,"BERG, Lyla B.",0,0,368,368
+City & County of Honolulu,18-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,321,321
+City & County of Honolulu,18-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,18-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,6,6
+City & County of Honolulu,18-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,18-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,48,48
+City & County of Honolulu,18-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,236,236
+City & County of Honolulu,18-06,US Representative,1,R,"TATAII, Steve",0,0,42,42
+City & County of Honolulu,18-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,18-06,US Representative,1,L,"ZHAO, Li",0,0,5,5
+City & County of Honolulu,18-06,State Representative,18,D,"BERG, Lyla B.",0,0,230,230
+City & County of Honolulu,18-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,570,570
+City & County of Honolulu,18-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,18-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,6,6
+City & County of Honolulu,18-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,18-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,146,146
+City & County of Honolulu,18-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,417,417
+City & County of Honolulu,18-07,US Representative,1,R,"TATAII, Steve",0,0,130,130
+City & County of Honolulu,18-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,18-07,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,18-07,State Representative,18,D,"BERG, Lyla B.",0,0,356,356
+City & County of Honolulu,19-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,430,430
+City & County of Honolulu,19-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,19-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,19-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,19-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,301,301
+City & County of Honolulu,19-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,321,321
+City & County of Honolulu,19-01,US Representative,1,R,"TATAII, Steve",0,0,101,101
+City & County of Honolulu,19-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,19-01,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,19-01,State Representative,19,D,"ABE, Michael (Mike)",0,0,248,248
+City & County of Honolulu,19-01,State Representative,19,R,"MARUMOTO, Barbara C.",0,0,282,282
+City & County of Honolulu,19-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,466,466
+City & County of Honolulu,19-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,19-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,19-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,19-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,178,178
+City & County of Honolulu,19-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,363,363
+City & County of Honolulu,19-02,US Representative,1,R,"TATAII, Steve",0,0,63,63
+City & County of Honolulu,19-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,19-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,19-02,State Representative,19,D,"ABE, Michael (Mike)",0,0,251,251
+City & County of Honolulu,19-02,State Representative,19,R,"MARUMOTO, Barbara C.",0,0,170,170
+City & County of Honolulu,19-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,355,355
+City & County of Honolulu,19-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,19-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,19-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,19-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,120,120
+City & County of Honolulu,19-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,268,268
+City & County of Honolulu,19-03,US Representative,1,R,"TATAII, Steve",0,0,33,33
+City & County of Honolulu,19-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,19-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,19-03,State Representative,19,D,"ABE, Michael (Mike)",0,0,203,203
+City & County of Honolulu,19-03,State Representative,19,R,"MARUMOTO, Barbara C.",0,0,112,112
+City & County of Honolulu,19-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,603,603
+City & County of Honolulu,19-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,19-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,19-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,19-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,218,218
+City & County of Honolulu,19-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,474,474
+City & County of Honolulu,19-04,US Representative,1,R,"TATAII, Steve",0,0,68,68
+City & County of Honolulu,19-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,19-04,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,19-04,State Representative,19,D,"ABE, Michael (Mike)",0,0,332,332
+City & County of Honolulu,19-04,State Representative,19,R,"MARUMOTO, Barbara C.",0,0,209,209
+City & County of Honolulu,19-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,363,363
+City & County of Honolulu,19-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,19-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,19-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,19-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,205,205
+City & County of Honolulu,19-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,281,281
+City & County of Honolulu,19-05,US Representative,1,R,"TATAII, Steve",0,0,56,56
+City & County of Honolulu,19-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,19-05,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,19-05,State Representative,19,D,"ABE, Michael (Mike)",0,0,192,192
+City & County of Honolulu,19-05,State Representative,19,R,"MARUMOTO, Barbara C.",0,0,192,192
+City & County of Honolulu,19-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,326,326
+City & County of Honolulu,19-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,19-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,19-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,19-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,80,80
+City & County of Honolulu,19-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,257,257
+City & County of Honolulu,19-06,US Representative,1,R,"TATAII, Steve",0,0,28,28
+City & County of Honolulu,19-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,19-06,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,19-06,State Representative,19,D,"ABE, Michael (Mike)",0,0,195,195
+City & County of Honolulu,19-06,State Representative,19,R,"MARUMOTO, Barbara C.",0,0,71,71
+City & County of Honolulu,19-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,233,233
+City & County of Honolulu,19-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,19-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,19-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,19-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,61,61
+City & County of Honolulu,19-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,194,194
+City & County of Honolulu,19-07,US Representative,1,R,"TATAII, Steve",0,0,22,22
+City & County of Honolulu,19-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,19-07,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,19-07,State Representative,19,D,"ABE, Michael (Mike)",0,0,141,141
+City & County of Honolulu,19-07,State Representative,19,R,"MARUMOTO, Barbara C.",0,0,59,59
+City & County of Honolulu,20-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,332,332
+City & County of Honolulu,20-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,20-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,20-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,20-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,47,47
+City & County of Honolulu,20-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,271,271
+City & County of Honolulu,20-01,US Representative,1,R,"TATAII, Steve",0,0,26,26
+City & County of Honolulu,20-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,20-01,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,20-01,State Representative,20,D,"SAY, Calvin K. Y.",0,0,272,272
+City & County of Honolulu,20-01,State Representative,20,R,"ALLEN, Julia E.",0,0,40,40
+City & County of Honolulu,20-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,406,406
+City & County of Honolulu,20-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,20-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,20-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,20-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,81,81
+City & County of Honolulu,20-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,307,307
+City & County of Honolulu,20-02,US Representative,1,R,"TATAII, Steve",0,0,51,51
+City & County of Honolulu,20-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,20-02,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,20-02,State Representative,20,D,"SAY, Calvin K. Y.",0,0,344,344
+City & County of Honolulu,20-02,State Representative,20,R,"ALLEN, Julia E.",0,0,64,64
+City & County of Honolulu,20-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,284,284
+City & County of Honolulu,20-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,20-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,20-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,20-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,72,72
+City & County of Honolulu,20-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,212,212
+City & County of Honolulu,20-03,US Representative,1,R,"TATAII, Steve",0,0,40,40
+City & County of Honolulu,20-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,20-03,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,20-03,State Representative,20,D,"SAY, Calvin K. Y.",0,0,197,197
+City & County of Honolulu,20-03,State Representative,20,R,"ALLEN, Julia E.",0,0,57,57
+City & County of Honolulu,20-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,421,421
+City & County of Honolulu,20-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,20-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,6,6
+City & County of Honolulu,20-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,20-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,86,86
+City & County of Honolulu,20-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,346,346
+City & County of Honolulu,20-04,US Representative,1,R,"TATAII, Steve",0,0,53,53
+City & County of Honolulu,20-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,20-04,US Representative,1,L,"ZHAO, Li",0,0,6,6
+City & County of Honolulu,20-04,State Representative,20,D,"SAY, Calvin K. Y.",0,0,295,295
+City & County of Honolulu,20-04,State Representative,20,R,"ALLEN, Julia E.",0,0,68,68
+City & County of Honolulu,20-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,646,646
+City & County of Honolulu,20-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,14,14
+City & County of Honolulu,20-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+City & County of Honolulu,20-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,10,10
+City & County of Honolulu,20-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,81,81
+City & County of Honolulu,20-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,483,483
+City & County of Honolulu,20-05,US Representative,1,R,"TATAII, Steve",0,0,42,42
+City & County of Honolulu,20-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,20-05,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,20-05,State Representative,20,D,"SAY, Calvin K. Y.",0,0,561,561
+City & County of Honolulu,20-05,State Representative,20,R,"ALLEN, Julia E.",0,0,67,67
+City & County of Honolulu,20-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,569,569
+City & County of Honolulu,20-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,20-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,20-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,20-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,114,114
+City & County of Honolulu,20-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,426,426
+City & County of Honolulu,20-06,US Representative,1,R,"TATAII, Steve",0,0,65,65
+City & County of Honolulu,20-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,20-06,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,20-06,State Representative,20,D,"SAY, Calvin K. Y.",0,0,463,463
+City & County of Honolulu,20-06,State Representative,20,R,"ALLEN, Julia E.",0,0,99,99
+City & County of Honolulu,21-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,353,353
+City & County of Honolulu,21-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,21-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,21-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,21-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,44,44
+City & County of Honolulu,21-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,255,255
+City & County of Honolulu,21-01,US Representative,1,R,"TATAII, Steve",0,0,38,38
+City & County of Honolulu,21-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,21-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,21-01,State Representative,21,D,"NISHIMOTO, Scott Y.",0,0,264,264
+City & County of Honolulu,21-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,645,645
+City & County of Honolulu,21-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,21-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,21-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,12,12
+City & County of Honolulu,21-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,87,87
+City & County of Honolulu,21-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,472,472
+City & County of Honolulu,21-02,US Representative,1,R,"TATAII, Steve",0,0,78,78
+City & County of Honolulu,21-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,21-02,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,21-02,State Representative,21,D,"NISHIMOTO, Scott Y.",0,0,515,515
+City & County of Honolulu,21-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,483,483
+City & County of Honolulu,21-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,11,11
+City & County of Honolulu,21-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,10,10
+City & County of Honolulu,21-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,14,14
+City & County of Honolulu,21-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,105,105
+City & County of Honolulu,21-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,383,383
+City & County of Honolulu,21-03,US Representative,1,R,"TATAII, Steve",0,0,98,98
+City & County of Honolulu,21-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,21-03,US Representative,1,L,"ZHAO, Li",0,0,8,8
+City & County of Honolulu,21-03,State Representative,21,D,"NISHIMOTO, Scott Y.",0,0,322,322
+City & County of Honolulu,21-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,265,265
+City & County of Honolulu,21-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,21-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,21-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,21-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,98,98
+City & County of Honolulu,21-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,192,192
+City & County of Honolulu,21-04,US Representative,1,R,"TATAII, Steve",0,0,92,92
+City & County of Honolulu,21-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,3,3
+City & County of Honolulu,21-04,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,21-04,State Representative,21,D,"NISHIMOTO, Scott Y.",0,0,184,184
+City & County of Honolulu,21-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,267,267
+City & County of Honolulu,21-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,21-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,21-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,21-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,99,99
+City & County of Honolulu,21-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,216,216
+City & County of Honolulu,21-05,US Representative,1,R,"TATAII, Steve",0,0,54,54
+City & County of Honolulu,21-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,21-05,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,21-05,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,134,134
+City & County of Honolulu,21-05,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,50,50
+City & County of Honolulu,21-05,State Senate,12,R,"TRIMBLE, Gordon",0,0,92,92
+City & County of Honolulu,21-05,State Representative,21,D,"NISHIMOTO, Scott Y.",0,0,171,171
+City & County of Honolulu,21-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,252,252
+City & County of Honolulu,21-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,21-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,21-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,21-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,20,20
+City & County of Honolulu,21-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,191,191
+City & County of Honolulu,21-06,US Representative,1,R,"TATAII, Steve",0,0,18,18
+City & County of Honolulu,21-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,21-06,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,21-06,State Representative,21,D,"NISHIMOTO, Scott Y.",0,0,187,187
+City & County of Honolulu,22-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,120,120
+City & County of Honolulu,22-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,22-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,22-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,22-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,20,20
+City & County of Honolulu,22-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,91,91
+City & County of Honolulu,22-01,US Representative,1,R,"TATAII, Steve",0,0,17,17
+City & County of Honolulu,22-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,22-01,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,22-01,State Representative,22,D,"SAIKI, Scott K.",0,0,81,81
+City & County of Honolulu,22-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,236,236
+City & County of Honolulu,22-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,22-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,22-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,22-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,26,26
+City & County of Honolulu,22-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,203,203
+City & County of Honolulu,22-02,US Representative,1,R,"TATAII, Steve",0,0,25,25
+City & County of Honolulu,22-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,22-02,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,22-02,State Representative,22,D,"SAIKI, Scott K.",0,0,169,169
+City & County of Honolulu,22-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,100,100
+City & County of Honolulu,22-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,22-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,22-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,22-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,14,14
+City & County of Honolulu,22-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,81,81
+City & County of Honolulu,22-03,US Representative,1,R,"TATAII, Steve",0,0,11,11
+City & County of Honolulu,22-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,22-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,22-03,State Representative,22,D,"SAIKI, Scott K.",0,0,58,58
+City & County of Honolulu,22-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,293,293
+City & County of Honolulu,22-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,22-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+City & County of Honolulu,22-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,22-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,45,45
+City & County of Honolulu,22-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,225,225
+City & County of Honolulu,22-04,US Representative,1,R,"TATAII, Steve",0,0,42,42
+City & County of Honolulu,22-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,3,3
+City & County of Honolulu,22-04,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,22-04,State Representative,22,D,"SAIKI, Scott K.",0,0,220,220
+City & County of Honolulu,22-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,292,292
+City & County of Honolulu,22-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,22-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,8,8
+City & County of Honolulu,22-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,22-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,43,43
+City & County of Honolulu,22-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,226,226
+City & County of Honolulu,22-05,US Representative,1,R,"TATAII, Steve",0,0,40,40
+City & County of Honolulu,22-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,5,5
+City & County of Honolulu,22-05,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,22-05,State Representative,22,D,"SAIKI, Scott K.",0,0,214,214
+City & County of Honolulu,22-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,374,374
+City & County of Honolulu,22-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,22-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,22-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,22-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,48,48
+City & County of Honolulu,22-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,283,283
+City & County of Honolulu,22-06,US Representative,1,R,"TATAII, Steve",0,0,41,41
+City & County of Honolulu,22-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,22-06,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,22-06,State Representative,22,D,"SAIKI, Scott K.",0,0,243,243
+City & County of Honolulu,22-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,279,279
+City & County of Honolulu,22-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,22-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,22-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,22-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,75,75
+City & County of Honolulu,22-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,222,222
+City & County of Honolulu,22-07,US Representative,1,R,"TATAII, Steve",0,0,67,67
+City & County of Honolulu,22-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,22-07,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,22-07,State Representative,22,D,"SAIKI, Scott K.",0,0,175,175
+City & County of Honolulu,23-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,176,176
+City & County of Honolulu,23-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,23-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,23-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,23-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,81,81
+City & County of Honolulu,23-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,150,150
+City & County of Honolulu,23-01,US Representative,1,R,"TATAII, Steve",0,0,45,45
+City & County of Honolulu,23-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,23-01,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,23-01,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,96,96
+City & County of Honolulu,23-01,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,35,35
+City & County of Honolulu,23-01,State Senate,12,R,"TRIMBLE, Gordon",0,0,63,63
+City & County of Honolulu,23-01,State Representative,23,D,"BROWER, Tom",0,0,115,115
+City & County of Honolulu,23-01,State Representative,23,R,"STEVENS, Anne V.",0,0,61,61
+City & County of Honolulu,23-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,200,200
+City & County of Honolulu,23-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,23-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,23-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,23-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,105,105
+City & County of Honolulu,23-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,152,152
+City & County of Honolulu,23-02,US Representative,1,R,"TATAII, Steve",0,0,59,59
+City & County of Honolulu,23-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,23-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,23-02,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,109,109
+City & County of Honolulu,23-02,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,40,40
+City & County of Honolulu,23-02,State Senate,12,R,"TRIMBLE, Gordon",0,0,77,77
+City & County of Honolulu,23-02,State Representative,23,D,"BROWER, Tom",0,0,133,133
+City & County of Honolulu,23-02,State Representative,23,R,"STEVENS, Anne V.",0,0,77,77
+City & County of Honolulu,23-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,352,352
+City & County of Honolulu,23-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,23-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,23-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,23-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,185,185
+City & County of Honolulu,23-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,289,289
+City & County of Honolulu,23-03,US Representative,1,R,"TATAII, Steve",0,0,99,99
+City & County of Honolulu,23-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,23-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,23-03,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,202,202
+City & County of Honolulu,23-03,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,62,62
+City & County of Honolulu,23-03,State Senate,12,R,"TRIMBLE, Gordon",0,0,131,131
+City & County of Honolulu,23-03,State Representative,23,D,"BROWER, Tom",0,0,244,244
+City & County of Honolulu,23-03,State Representative,23,R,"STEVENS, Anne V.",0,0,147,147
+City & County of Honolulu,23-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,314,314
+City & County of Honolulu,23-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,23-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,23-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,23-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,146,146
+City & County of Honolulu,23-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,265,265
+City & County of Honolulu,23-04,US Representative,1,R,"TATAII, Steve",0,0,68,68
+City & County of Honolulu,23-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,23-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,23-04,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,173,173
+City & County of Honolulu,23-04,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,42,42
+City & County of Honolulu,23-04,State Senate,12,R,"TRIMBLE, Gordon",0,0,105,105
+City & County of Honolulu,23-04,State Representative,23,D,"BROWER, Tom",0,0,193,193
+City & County of Honolulu,23-04,State Representative,23,R,"STEVENS, Anne V.",0,0,111,111
+City & County of Honolulu,24-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,753,753
+City & County of Honolulu,24-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,24-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,24-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,9,9
+City & County of Honolulu,24-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,109,109
+City & County of Honolulu,24-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,558,558
+City & County of Honolulu,24-01,US Representative,1,R,"TATAII, Steve",0,0,42,42
+City & County of Honolulu,24-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,24-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,24-01,State Representative,24,D,"CHOY, Isaac W.",0,0,476,476
+City & County of Honolulu,24-01,State Representative,24,R,"JEFFRYES, Jerilyn (Jeri)",0,0,101,101
+City & County of Honolulu,24-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,414,414
+City & County of Honolulu,24-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,24-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,24-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,24-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,76,76
+City & County of Honolulu,24-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,309,309
+City & County of Honolulu,24-02,US Representative,1,R,"TATAII, Steve",0,0,38,38
+City & County of Honolulu,24-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,24-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,24-02,State Representative,24,D,"CHOY, Isaac W.",0,0,247,247
+City & County of Honolulu,24-02,State Representative,24,R,"JEFFRYES, Jerilyn (Jeri)",0,0,70,70
+City & County of Honolulu,24-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,346,346
+City & County of Honolulu,24-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,24-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,24-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,24-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,62,62
+City & County of Honolulu,24-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,280,280
+City & County of Honolulu,24-03,US Representative,1,R,"TATAII, Steve",0,0,34,34
+City & County of Honolulu,24-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,24-03,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,24-03,State Representative,24,D,"CHOY, Isaac W.",0,0,169,169
+City & County of Honolulu,24-03,State Representative,24,R,"JEFFRYES, Jerilyn (Jeri)",0,0,51,51
+City & County of Honolulu,24-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,414,414
+City & County of Honolulu,24-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,24-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,14,14
+City & County of Honolulu,24-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,24-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,91,91
+City & County of Honolulu,24-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,338,338
+City & County of Honolulu,24-04,US Representative,1,R,"TATAII, Steve",0,0,44,44
+City & County of Honolulu,24-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,5,5
+City & County of Honolulu,24-04,US Representative,1,L,"ZHAO, Li",0,0,9,9
+City & County of Honolulu,24-04,State Representative,24,D,"CHOY, Isaac W.",0,0,177,177
+City & County of Honolulu,24-04,State Representative,24,R,"JEFFRYES, Jerilyn (Jeri)",0,0,79,79
+City & County of Honolulu,24-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,565,565
+City & County of Honolulu,24-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,24-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,10,10
+City & County of Honolulu,24-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,24-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,111,111
+City & County of Honolulu,24-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,422,422
+City & County of Honolulu,24-05,US Representative,1,R,"TATAII, Steve",0,0,57,57
+City & County of Honolulu,24-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,24-05,US Representative,1,L,"ZHAO, Li",0,0,6,6
+City & County of Honolulu,24-05,State Representative,24,D,"CHOY, Isaac W.",0,0,337,337
+City & County of Honolulu,24-05,State Representative,24,R,"JEFFRYES, Jerilyn (Jeri)",0,0,93,93
+City & County of Honolulu,24-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,671,671
+City & County of Honolulu,24-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,24-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+City & County of Honolulu,24-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,24-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,115,115
+City & County of Honolulu,24-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,502,502
+City & County of Honolulu,24-06,US Representative,1,R,"TATAII, Steve",0,0,54,54
+City & County of Honolulu,24-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,6,6
+City & County of Honolulu,24-06,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,24-06,State Representative,24,D,"CHOY, Isaac W.",0,0,409,409
+City & County of Honolulu,24-06,State Representative,24,R,"JEFFRYES, Jerilyn (Jeri)",0,0,103,103
+City & County of Honolulu,25-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,375,375
+City & County of Honolulu,25-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,25-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,25-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,25-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,94,94
+City & County of Honolulu,25-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,279,279
+City & County of Honolulu,25-01,US Representative,1,R,"TATAII, Steve",0,0,86,86
+City & County of Honolulu,25-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,25-01,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,25-01,State Representative,25,D,"BELATTI, Della A.",0,0,236,236
+City & County of Honolulu,25-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,377,377
+City & County of Honolulu,25-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,25-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+City & County of Honolulu,25-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,25-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,74,74
+City & County of Honolulu,25-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,297,297
+City & County of Honolulu,25-02,US Representative,1,R,"TATAII, Steve",0,0,64,64
+City & County of Honolulu,25-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,25-02,US Representative,1,L,"ZHAO, Li",0,0,5,5
+City & County of Honolulu,25-02,State Representative,25,D,"BELATTI, Della A.",0,0,250,250
+City & County of Honolulu,25-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,31,31
+City & County of Honolulu,25-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,25-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,25-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,25-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,8,8
+City & County of Honolulu,25-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,21,21
+City & County of Honolulu,25-03,US Representative,1,R,"TATAII, Steve",0,0,7,7
+City & County of Honolulu,25-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,25-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,25-03,State Representative,25,D,"BELATTI, Della A.",0,0,19,19
+City & County of Honolulu,25-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,186,186
+City & County of Honolulu,25-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,25-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,25-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,25-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,31,31
+City & County of Honolulu,25-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,147,147
+City & County of Honolulu,25-04,US Representative,1,R,"TATAII, Steve",0,0,29,29
+City & County of Honolulu,25-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,25-04,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,25-04,State Representative,25,D,"BELATTI, Della A.",0,0,95,95
+City & County of Honolulu,25-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,394,394
+City & County of Honolulu,25-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,25-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,25-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,25-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,88,88
+City & County of Honolulu,25-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,318,318
+City & County of Honolulu,25-05,US Representative,1,R,"TATAII, Steve",0,0,82,82
+City & County of Honolulu,25-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,25-05,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,25-05,State Representative,25,D,"BELATTI, Della A.",0,0,240,240
+City & County of Honolulu,25-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,316,316
+City & County of Honolulu,25-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,25-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,25-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,25-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,65,65
+City & County of Honolulu,25-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,256,256
+City & County of Honolulu,25-06,US Representative,1,R,"TATAII, Steve",0,0,57,57
+City & County of Honolulu,25-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,25-06,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,25-06,State Representative,25,D,"BELATTI, Della A.",0,0,203,203
+City & County of Honolulu,25-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,285,285
+City & County of Honolulu,25-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,25-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,25-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,25-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,57,57
+City & County of Honolulu,25-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,225,225
+City & County of Honolulu,25-07,US Representative,1,R,"TATAII, Steve",0,0,51,51
+City & County of Honolulu,25-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,25-07,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,25-07,State Representative,25,D,"BELATTI, Della A.",0,0,172,172
+City & County of Honolulu,26-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,598,598
+City & County of Honolulu,26-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,26-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,6,6
+City & County of Honolulu,26-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,26-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,66,66
+City & County of Honolulu,26-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,463,463
+City & County of Honolulu,26-01,US Representative,1,R,"TATAII, Steve",0,0,55,55
+City & County of Honolulu,26-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,26-01,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,26-01,State Representative,26,D,"LUKE, Sylvia",0,0,480,480
+City & County of Honolulu,26-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,185,185
+City & County of Honolulu,26-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,26-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,26-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,26-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,15,15
+City & County of Honolulu,26-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,153,153
+City & County of Honolulu,26-02,US Representative,1,R,"TATAII, Steve",0,0,14,14
+City & County of Honolulu,26-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,26-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,26-02,State Representative,26,D,"LUKE, Sylvia",0,0,128,128
+City & County of Honolulu,26-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,300,300
+City & County of Honolulu,26-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,26-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,26-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,9,9
+City & County of Honolulu,26-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,68,68
+City & County of Honolulu,26-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,248,248
+City & County of Honolulu,26-03,US Representative,1,R,"TATAII, Steve",0,0,62,62
+City & County of Honolulu,26-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,26-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,26-03,State Representative,26,D,"LUKE, Sylvia",0,0,199,199
+City & County of Honolulu,26-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,207,207
+City & County of Honolulu,26-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,26-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,26-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,26-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,51,51
+City & County of Honolulu,26-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,163,163
+City & County of Honolulu,26-04,US Representative,1,R,"TATAII, Steve",0,0,48,48
+City & County of Honolulu,26-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,26-04,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,26-04,State Representative,26,D,"LUKE, Sylvia",0,0,129,129
+City & County of Honolulu,26-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,319,319
+City & County of Honolulu,26-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,26-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,6,6
+City & County of Honolulu,26-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,26-05,Straight Party,,,REPUBLICAN PARTY (R),1,0,52,53
+City & County of Honolulu,26-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,252,252
+City & County of Honolulu,26-05,US Representative,1,R,"TATAII, Steve",1,0,47,48
+City & County of Honolulu,26-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,26-05,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,26-05,State Representative,26,D,"LUKE, Sylvia",0,0,220,220
+City & County of Honolulu,26-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,575,575
+City & County of Honolulu,26-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,26-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,9,9
+City & County of Honolulu,26-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,17,17
+City & County of Honolulu,26-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,126,126
+City & County of Honolulu,26-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,454,454
+City & County of Honolulu,26-06,US Representative,1,R,"TATAII, Steve",0,0,117,117
+City & County of Honolulu,26-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,26-06,US Representative,1,L,"ZHAO, Li",0,0,7,7
+City & County of Honolulu,26-06,State Representative,26,D,"LUKE, Sylvia",0,0,418,418
+City & County of Honolulu,26-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,623,623
+City & County of Honolulu,26-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,26-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,8,8
+City & County of Honolulu,26-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,26-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,139,139
+City & County of Honolulu,26-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,451,451
+City & County of Honolulu,26-07,US Representative,1,R,"TATAII, Steve",0,0,125,125
+City & County of Honolulu,26-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,26-07,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,26-07,State Representative,26,D,"LUKE, Sylvia",0,0,485,485
+City & County of Honolulu,27-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,65,65
+City & County of Honolulu,27-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,27-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,27-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,27-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,20,20
+City & County of Honolulu,27-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,55,55
+City & County of Honolulu,27-01,US Representative,1,R,"TATAII, Steve",0,0,6,6
+City & County of Honolulu,27-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,27-01,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,27-01,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,34,34
+City & County of Honolulu,27-01,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,19,19
+City & County of Honolulu,27-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,292,292
+City & County of Honolulu,27-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,27-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,27-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,27-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,59,59
+City & County of Honolulu,27-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,240,240
+City & County of Honolulu,27-02,US Representative,1,R,"TATAII, Steve",0,0,27,27
+City & County of Honolulu,27-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,27-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,27-02,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,174,174
+City & County of Honolulu,27-02,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,56,56
+City & County of Honolulu,27-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,668,668
+City & County of Honolulu,27-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,27-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,27-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,27-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,199,199
+City & County of Honolulu,27-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,540,540
+City & County of Honolulu,27-03,US Representative,1,R,"TATAII, Steve",0,0,54,54
+City & County of Honolulu,27-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,27-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,27-03,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,406,406
+City & County of Honolulu,27-03,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,189,189
+City & County of Honolulu,27-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,122,122
+City & County of Honolulu,27-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,27-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,27-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,27-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,35,35
+City & County of Honolulu,27-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,98,98
+City & County of Honolulu,27-04,US Representative,1,R,"TATAII, Steve",0,0,11,11
+City & County of Honolulu,27-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,27-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,27-04,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,64,64
+City & County of Honolulu,27-04,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,34,34
+City & County of Honolulu,27-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,231,231
+City & County of Honolulu,27-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,27-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,27-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,27-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,51,51
+City & County of Honolulu,27-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,203,203
+City & County of Honolulu,27-05,US Representative,1,R,"TATAII, Steve",0,0,15,15
+City & County of Honolulu,27-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,3,3
+City & County of Honolulu,27-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,27-05,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,77,77
+City & County of Honolulu,27-05,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,49,49
+City & County of Honolulu,27-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,348,348
+City & County of Honolulu,27-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,27-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,27-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,27-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,93,93
+City & County of Honolulu,27-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,298,298
+City & County of Honolulu,27-06,US Representative,1,R,"TATAII, Steve",0,0,31,31
+City & County of Honolulu,27-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,27-06,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,27-06,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,161,161
+City & County of Honolulu,27-06,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,89,89
+City & County of Honolulu,27-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,112,112
+City & County of Honolulu,27-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,27-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,27-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,27-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,31,31
+City & County of Honolulu,27-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,93,93
+City & County of Honolulu,27-07,US Representative,1,R,"TATAII, Steve",0,0,11,11
+City & County of Honolulu,27-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,27-07,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,27-07,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,37,37
+City & County of Honolulu,27-07,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,27,27
+City & County of Honolulu,27-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,266,266
+City & County of Honolulu,27-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,27-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,27-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,27-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,84,84
+City & County of Honolulu,27-08,US Representative,1,D,"ABERCROMBIE, Neil",0,0,223,223
+City & County of Honolulu,27-08,US Representative,1,R,"TATAII, Steve",0,0,31,31
+City & County of Honolulu,27-08,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,27-08,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,27-08,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",0,0,137,137
+City & County of Honolulu,27-08,State Representative,27,R,"CHING, Corinne Wei Lan",0,0,79,79
+City & County of Honolulu,28-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,200,200
+City & County of Honolulu,28-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,28-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,28-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,28-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,28,28
+City & County of Honolulu,28-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,155,155
+City & County of Honolulu,28-01,US Representative,1,R,"TATAII, Steve",0,0,25,25
+City & County of Honolulu,28-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,28-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,28-01,State Representative,28,D,"RHOADS, Karl",0,0,118,118
+City & County of Honolulu,28-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,235,235
+City & County of Honolulu,28-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,28-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,28-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,28-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,53,53
+City & County of Honolulu,28-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,191,191
+City & County of Honolulu,28-02,US Representative,1,R,"TATAII, Steve",0,0,50,50
+City & County of Honolulu,28-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,3,3
+City & County of Honolulu,28-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,28-02,State Representative,28,D,"RHOADS, Karl",0,0,101,101
+City & County of Honolulu,28-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,135,135
+City & County of Honolulu,28-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,28-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,28-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,28-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,52,52
+City & County of Honolulu,28-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,110,110
+City & County of Honolulu,28-03,US Representative,1,R,"TATAII, Steve",0,0,29,29
+City & County of Honolulu,28-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,28-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,28-03,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,83,83
+City & County of Honolulu,28-03,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,18,18
+City & County of Honolulu,28-03,State Senate,12,R,"TRIMBLE, Gordon",0,0,47,47
+City & County of Honolulu,28-03,State Representative,28,D,"RHOADS, Karl",0,0,83,83
+City & County of Honolulu,28-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,176,176
+City & County of Honolulu,28-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,28-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,28-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,28-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,51,51
+City & County of Honolulu,28-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,145,145
+City & County of Honolulu,28-04,US Representative,1,R,"TATAII, Steve",0,0,34,34
+City & County of Honolulu,28-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,28-04,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,28-04,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,110,110
+City & County of Honolulu,28-04,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,29,29
+City & County of Honolulu,28-04,State Senate,12,R,"TRIMBLE, Gordon",0,0,40,40
+City & County of Honolulu,28-04,State Representative,28,D,"RHOADS, Karl",0,0,127,127
+City & County of Honolulu,28-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,521,521
+City & County of Honolulu,28-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,28-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,8,8
+City & County of Honolulu,28-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,11,11
+City & County of Honolulu,28-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,108,108
+City & County of Honolulu,28-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,386,386
+City & County of Honolulu,28-05,US Representative,1,R,"TATAII, Steve",0,0,68,68
+City & County of Honolulu,28-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,28-05,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,28-05,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,293,293
+City & County of Honolulu,28-05,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,85,85
+City & County of Honolulu,28-05,State Senate,12,R,"TRIMBLE, Gordon",0,0,94,94
+City & County of Honolulu,28-05,State Representative,28,D,"RHOADS, Karl",0,0,327,327
+City & County of Honolulu,28-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,138,138
+City & County of Honolulu,28-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,28-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,28-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,28-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,22,22
+City & County of Honolulu,28-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,115,115
+City & County of Honolulu,28-06,US Representative,1,R,"TATAII, Steve",0,0,16,16
+City & County of Honolulu,28-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,28-06,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,28-06,State Senate,12,D,"GALUTERIA, Brickwood M.",0,0,67,67
+City & County of Honolulu,28-06,State Senate,12,D,"MIDDLETON, Carlton N.",0,0,23,23
+City & County of Honolulu,28-06,State Senate,12,R,"TRIMBLE, Gordon",0,0,17,17
+City & County of Honolulu,28-06,State Representative,28,D,"RHOADS, Karl",0,0,98,98
+City & County of Honolulu,29-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,360,360
+City & County of Honolulu,29-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,29-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,29-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,29-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,50,50
+City & County of Honolulu,29-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,265,265
+City & County of Honolulu,29-01,US Representative,1,R,"TATAII, Steve",0,0,31,31
+City & County of Honolulu,29-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,29-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,29-01,State Representative,29,D,"MANAHAN, Joey",0,0,252,252
+City & County of Honolulu,29-01,State Representative,29,R,"YAW, Shane D. K.",0,0,34,34
+City & County of Honolulu,29-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,389,389
+City & County of Honolulu,29-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,29-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,29-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,29-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,45,45
+City & County of Honolulu,29-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,320,320
+City & County of Honolulu,29-02,US Representative,1,R,"TATAII, Steve",0,0,28,28
+City & County of Honolulu,29-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,29-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,29-02,State Representative,29,D,"MANAHAN, Joey",0,0,290,290
+City & County of Honolulu,29-02,State Representative,29,R,"YAW, Shane D. K.",0,0,33,33
+City & County of Honolulu,29-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,265,265
+City & County of Honolulu,29-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,29-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,29-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,29-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,23,23
+City & County of Honolulu,29-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,211,211
+City & County of Honolulu,29-03,US Representative,1,R,"TATAII, Steve",0,0,13,13
+City & County of Honolulu,29-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,29-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,29-03,State Representative,29,D,"MANAHAN, Joey",0,0,173,173
+City & County of Honolulu,29-03,State Representative,29,R,"YAW, Shane D. K.",0,0,15,15
+City & County of Honolulu,29-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,129,129
+City & County of Honolulu,29-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,29-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,29-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,29-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,32,32
+City & County of Honolulu,29-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,109,109
+City & County of Honolulu,29-04,US Representative,1,R,"TATAII, Steve",0,0,25,25
+City & County of Honolulu,29-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,29-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,29-04,State Representative,29,D,"MANAHAN, Joey",0,0,64,64
+City & County of Honolulu,29-04,State Representative,29,R,"YAW, Shane D. K.",0,0,20,20
+City & County of Honolulu,29-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,236,236
+City & County of Honolulu,29-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,29-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,29-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,29-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,17,17
+City & County of Honolulu,29-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,180,180
+City & County of Honolulu,29-05,US Representative,1,R,"TATAII, Steve",0,0,10,10
+City & County of Honolulu,29-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,29-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,29-05,State Representative,29,D,"MANAHAN, Joey",0,0,180,180
+City & County of Honolulu,29-05,State Representative,29,R,"YAW, Shane D. K.",0,0,9,9
+City & County of Honolulu,30-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,395,395
+City & County of Honolulu,30-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,30-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,30-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,30-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,70,70
+City & County of Honolulu,30-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,313,313
+City & County of Honolulu,30-01,US Representative,1,R,"TATAII, Steve",0,0,67,67
+City & County of Honolulu,30-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,30-01,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,30-01,State Representative,30,D,"MIZUNO, John",0,0,314,314
+City & County of Honolulu,30-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,339,339
+City & County of Honolulu,30-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,30-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,30-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,30-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,45,45
+City & County of Honolulu,30-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,264,264
+City & County of Honolulu,30-02,US Representative,1,R,"TATAII, Steve",0,0,42,42
+City & County of Honolulu,30-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,30-02,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,30-02,State Representative,30,D,"MIZUNO, John",0,0,242,242
+City & County of Honolulu,30-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,256,256
+City & County of Honolulu,30-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,30-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,30-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,30-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,28,28
+City & County of Honolulu,30-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,201,201
+City & County of Honolulu,30-03,US Representative,1,R,"TATAII, Steve",0,0,26,26
+City & County of Honolulu,30-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,30-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,30-03,State Representative,30,D,"MIZUNO, John",0,0,175,175
+City & County of Honolulu,30-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,175,175
+City & County of Honolulu,30-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,30-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,30-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,30-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,13,13
+City & County of Honolulu,30-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,127,127
+City & County of Honolulu,30-04,US Representative,1,R,"TATAII, Steve",0,0,12,12
+City & County of Honolulu,30-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,30-04,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,30-04,State Representative,30,D,"MIZUNO, John",0,0,147,147
+City & County of Honolulu,30-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,56,56
+City & County of Honolulu,30-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,30-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,30-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,30-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,18,18
+City & County of Honolulu,30-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,41,41
+City & County of Honolulu,30-05,US Representative,1,R,"TATAII, Steve",0,0,17,17
+City & County of Honolulu,30-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,30-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,30-05,State Representative,30,D,"MIZUNO, John",0,0,31,31
+City & County of Honolulu,30-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,470,470
+City & County of Honolulu,30-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,30-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,30-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,30-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,59,59
+City & County of Honolulu,30-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,394,394
+City & County of Honolulu,30-06,US Representative,1,R,"TATAII, Steve",0,0,57,57
+City & County of Honolulu,30-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,30-06,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,30-06,State Representative,30,D,"MIZUNO, John",0,0,345,345
+City & County of Honolulu,31-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,491,491
+City & County of Honolulu,31-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,31-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,31-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,31-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,54,54
+City & County of Honolulu,31-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,357,357
+City & County of Honolulu,31-01,US Representative,1,R,"TATAII, Steve",0,0,46,46
+City & County of Honolulu,31-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,31-01,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,31-01,State Representative,31,D,"WAKAI, Glenn",0,0,417,417
+City & County of Honolulu,31-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,515,515
+City & County of Honolulu,31-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,31-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,10,10
+City & County of Honolulu,31-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,31-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,72,72
+City & County of Honolulu,31-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,412,412
+City & County of Honolulu,31-02,US Representative,1,R,"TATAII, Steve",0,0,66,66
+City & County of Honolulu,31-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,31-02,US Representative,1,L,"ZHAO, Li",0,0,10,10
+City & County of Honolulu,31-02,State Representative,31,D,"WAKAI, Glenn",0,0,413,413
+City & County of Honolulu,31-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,333,333
+City & County of Honolulu,31-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,31-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,31-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,8,8
+City & County of Honolulu,31-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,55,55
+City & County of Honolulu,31-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,264,264
+City & County of Honolulu,31-03,US Representative,1,R,"TATAII, Steve",0,0,53,53
+City & County of Honolulu,31-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,31-03,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,31-03,State Representative,31,D,"WAKAI, Glenn",0,0,262,262
+City & County of Honolulu,31-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,347,347
+City & County of Honolulu,31-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,31-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,31-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,8,8
+City & County of Honolulu,31-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,75,75
+City & County of Honolulu,31-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,261,261
+City & County of Honolulu,31-04,US Representative,1,R,"TATAII, Steve",0,0,67,67
+City & County of Honolulu,31-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,31-04,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,31-04,State Representative,31,D,"WAKAI, Glenn",0,0,261,261
+City & County of Honolulu,31-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,634,634
+City & County of Honolulu,31-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,31-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,31-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,31-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,81,81
+City & County of Honolulu,31-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,483,483
+City & County of Honolulu,31-05,US Representative,1,R,"TATAII, Steve",0,0,74,74
+City & County of Honolulu,31-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,31-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,31-05,State Representative,31,D,"WAKAI, Glenn",0,0,515,515
+City & County of Honolulu,32-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,429,429
+City & County of Honolulu,32-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,32-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,32-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,32-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,105,105
+City & County of Honolulu,32-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,390,390
+City & County of Honolulu,32-01,US Representative,1,R,"TATAII, Steve",0,0,42,42
+City & County of Honolulu,32-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-01,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,32-01,State Representative,32,R,"FINNEGAN, Lynn",0,0,95,95
+City & County of Honolulu,32-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,42,42
+City & County of Honolulu,32-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,32-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,32-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,32-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,11,11
+City & County of Honolulu,32-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,40,40
+City & County of Honolulu,32-02,US Representative,1,R,"TATAII, Steve",0,0,3,3
+City & County of Honolulu,32-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,32-02,State Representative,32,R,"FINNEGAN, Lynn",0,0,9,9
+City & County of Honolulu,32-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,22,22
+City & County of Honolulu,32-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,32-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,32-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,32-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,19,19
+City & County of Honolulu,32-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,19,19
+City & County of Honolulu,32-03,US Representative,1,R,"TATAII, Steve",0,0,13,13
+City & County of Honolulu,32-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,32-03,State Representative,32,R,"FINNEGAN, Lynn",0,0,13,13
+City & County of Honolulu,32-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,210,210
+City & County of Honolulu,32-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,32-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,32-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,32-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,65,65
+City & County of Honolulu,32-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,201,201
+City & County of Honolulu,32-04,US Representative,1,R,"TATAII, Steve",0,0,23,23
+City & County of Honolulu,32-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,32-04,State Representative,32,R,"FINNEGAN, Lynn",0,0,61,61
+City & County of Honolulu,32-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,471,471
+City & County of Honolulu,32-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,9,9
+City & County of Honolulu,32-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,32-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,32-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,255,255
+City & County of Honolulu,32-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,429,429
+City & County of Honolulu,32-05,US Representative,1,R,"TATAII, Steve",0,0,98,98
+City & County of Honolulu,32-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,32-05,State Representative,32,R,"FINNEGAN, Lynn",0,0,235,235
+City & County of Honolulu,32-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,211,211
+City & County of Honolulu,32-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,32-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,32-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,32-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,58,58
+City & County of Honolulu,32-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,193,193
+City & County of Honolulu,32-06,US Representative,1,R,"TATAII, Steve",0,0,19,19
+City & County of Honolulu,32-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-06,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,32-06,State Representative,32,R,"FINNEGAN, Lynn",0,0,48,48
+City & County of Honolulu,32-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,145,145
+City & County of Honolulu,32-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,32-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,32-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,32-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,41,41
+City & County of Honolulu,32-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,138,138
+City & County of Honolulu,32-07,US Representative,1,R,"TATAII, Steve",0,0,13,13
+City & County of Honolulu,32-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-07,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,32-07,State Representative,32,R,"FINNEGAN, Lynn",0,0,38,38
+City & County of Honolulu,32-08,Straight Party,,,DEMOCRATIC PARTY (D),0,0,266,266
+City & County of Honolulu,32-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,32-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,32-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,32-08,Straight Party,,,REPUBLICAN PARTY (R),0,0,107,107
+City & County of Honolulu,32-08,US Representative,1,D,"ABERCROMBIE, Neil",0,0,250,250
+City & County of Honolulu,32-08,US Representative,1,R,"TATAII, Steve",0,0,44,44
+City & County of Honolulu,32-08,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,32-08,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,32-08,State Representative,32,R,"FINNEGAN, Lynn",0,0,93,93
+City & County of Honolulu,33-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,77,77
+City & County of Honolulu,33-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,33-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,33-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,33-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,21,21
+City & County of Honolulu,33-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,58,58
+City & County of Honolulu,33-01,US Representative,1,R,"TATAII, Steve",0,0,20,20
+City & County of Honolulu,33-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,33-01,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,33-01,State Representative,33,D,"OSHIRO, Blake K.",0,0,46,46
+City & County of Honolulu,33-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,205,205
+City & County of Honolulu,33-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,33-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,33-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,33-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,34,34
+City & County of Honolulu,33-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,169,169
+City & County of Honolulu,33-02,US Representative,1,R,"TATAII, Steve",0,0,32,32
+City & County of Honolulu,33-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,33-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,33-02,State Representative,33,D,"OSHIRO, Blake K.",0,0,143,143
+City & County of Honolulu,33-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,478,478
+City & County of Honolulu,33-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,33-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,33-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,33-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,55,55
+City & County of Honolulu,33-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,381,381
+City & County of Honolulu,33-03,US Representative,1,R,"TATAII, Steve",0,0,45,45
+City & County of Honolulu,33-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,33-03,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,33-03,State Representative,33,D,"OSHIRO, Blake K.",0,0,332,332
+City & County of Honolulu,33-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,775,775
+City & County of Honolulu,33-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,9,9
+City & County of Honolulu,33-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,8,8
+City & County of Honolulu,33-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,12,12
+City & County of Honolulu,33-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,149,149
+City & County of Honolulu,33-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,599,599
+City & County of Honolulu,33-04,US Representative,1,R,"TATAII, Steve",0,0,132,132
+City & County of Honolulu,33-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,3,3
+City & County of Honolulu,33-04,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,33-04,State Senate,16,D,"IGE, David Y.",0,0,436,436
+City & County of Honolulu,33-04,State Representative,33,D,"OSHIRO, Blake K.",0,0,517,517
+City & County of Honolulu,33-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,455,455
+City & County of Honolulu,33-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,33-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,33-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,10,10
+City & County of Honolulu,33-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,107,107
+City & County of Honolulu,33-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,367,367
+City & County of Honolulu,33-05,US Representative,1,R,"TATAII, Steve",0,0,100,100
+City & County of Honolulu,33-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,33-05,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,33-05,State Senate,16,D,"IGE, David Y.",0,0,284,284
+City & County of Honolulu,33-05,State Representative,33,D,"OSHIRO, Blake K.",0,0,308,308
+City & County of Honolulu,33-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,311,311
+City & County of Honolulu,33-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,33-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,33-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,33-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,55,55
+City & County of Honolulu,33-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,255,255
+City & County of Honolulu,33-06,US Representative,1,R,"TATAII, Steve",0,0,49,49
+City & County of Honolulu,33-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,33-06,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,33-06,State Senate,16,D,"IGE, David Y.",0,0,176,176
+City & County of Honolulu,33-06,State Representative,33,D,"OSHIRO, Blake K.",0,0,198,198
+City & County of Honolulu,34-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,394,394
+City & County of Honolulu,34-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,34-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,34-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,34-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,64,64
+City & County of Honolulu,34-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,299,299
+City & County of Honolulu,34-01,US Representative,1,R,"TATAII, Steve",0,0,59,59
+City & County of Honolulu,34-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,34-01,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,34-01,State Senate,16,D,"IGE, David Y.",0,0,244,244
+City & County of Honolulu,34-01,State Representative,34,D,"TAKAI, K. Mark",0,0,282,282
+City & County of Honolulu,34-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,355,355
+City & County of Honolulu,34-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,34-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,34-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,34-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,80,80
+City & County of Honolulu,34-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,272,272
+City & County of Honolulu,34-02,US Representative,1,R,"TATAII, Steve",0,0,78,78
+City & County of Honolulu,34-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,34-02,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,34-02,State Senate,16,D,"IGE, David Y.",0,0,214,214
+City & County of Honolulu,34-02,State Representative,34,D,"TAKAI, K. Mark",0,0,261,261
+City & County of Honolulu,34-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,223,223
+City & County of Honolulu,34-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,34-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,34-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,34-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,23,23
+City & County of Honolulu,34-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,179,179
+City & County of Honolulu,34-03,US Representative,1,R,"TATAII, Steve",0,0,19,19
+City & County of Honolulu,34-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,34-03,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,34-03,State Senate,16,D,"IGE, David Y.",0,0,151,151
+City & County of Honolulu,34-03,State Representative,34,D,"TAKAI, K. Mark",0,0,169,169
+City & County of Honolulu,34-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,395,395
+City & County of Honolulu,34-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,34-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,34-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,34-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,36,36
+City & County of Honolulu,34-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,305,305
+City & County of Honolulu,34-04,US Representative,1,R,"TATAII, Steve",0,0,29,29
+City & County of Honolulu,34-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,34-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,34-04,State Senate,16,D,"IGE, David Y.",0,0,244,244
+City & County of Honolulu,34-04,State Representative,34,D,"TAKAI, K. Mark",0,0,292,292
+City & County of Honolulu,34-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,238,238
+City & County of Honolulu,34-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,34-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,34-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,34-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,23,23
+City & County of Honolulu,34-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,187,187
+City & County of Honolulu,34-05,US Representative,1,R,"TATAII, Steve",0,0,21,21
+City & County of Honolulu,34-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,34-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,34-05,State Senate,16,D,"IGE, David Y.",0,0,142,142
+City & County of Honolulu,34-05,State Representative,34,D,"TAKAI, K. Mark",0,0,160,160
+City & County of Honolulu,34-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,68,68
+City & County of Honolulu,34-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,34-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,34-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,34-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,14,14
+City & County of Honolulu,34-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,61,61
+City & County of Honolulu,34-06,US Representative,1,R,"TATAII, Steve",0,0,11,11
+City & County of Honolulu,34-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,34-06,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,34-06,State Senate,18,D,"SONSON, Alex M.",0,0,27,27
+City & County of Honolulu,34-06,State Senate,18,D,"NISHIHARA, Clarence",0,0,29,29
+City & County of Honolulu,34-06,State Representative,34,D,"TAKAI, K. Mark",0,0,52,52
+City & County of Honolulu,34-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,1034,1034
+City & County of Honolulu,34-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,34-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,9,9
+City & County of Honolulu,34-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,34-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,103,103
+City & County of Honolulu,34-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,780,780
+City & County of Honolulu,34-07,US Representative,1,R,"TATAII, Steve",0,0,95,95
+City & County of Honolulu,34-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,34-07,US Representative,1,L,"ZHAO, Li",0,0,5,5
+City & County of Honolulu,34-07,State Senate,16,D,"IGE, David Y.",0,0,727,727
+City & County of Honolulu,34-07,State Representative,34,D,"TAKAI, K. Mark",0,0,809,809
+City & County of Honolulu,35-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,499,499
+City & County of Honolulu,35-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,35-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,35-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,35-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,61,61
+City & County of Honolulu,35-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,373,373
+City & County of Honolulu,35-01,US Representative,1,R,"TATAII, Steve",0,0,41,41
+City & County of Honolulu,35-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,35-01,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,35-01,State Senate,18,D,"SONSON, Alex M.",0,0,211,211
+City & County of Honolulu,35-01,State Senate,18,D,"NISHIHARA, Clarence",0,0,262,262
+City & County of Honolulu,35-01,State Representative,35,D,"AQUINO, Henry James C.",0,0,215,215
+City & County of Honolulu,35-01,State Representative,35,D,"RAHMAN, I. Perreira Padilla",0,0,178,178
+City & County of Honolulu,35-01,State Representative,35,D,"VERDADERO, Dante M.",0,0,19,19
+City & County of Honolulu,35-01,State Representative,35,D,"DOMINGO, Constante A.",0,0,21,21
+City & County of Honolulu,35-01,State Representative,35,D,"PARAYNO, Ilalo",0,0,31,31
+City & County of Honolulu,35-01,State Representative,35,R,"ANTONIO, Steven Bolosan",0,0,46,46
+City & County of Honolulu,35-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,745,745
+City & County of Honolulu,35-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,35-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,35-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,35-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,40,40
+City & County of Honolulu,35-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,572,572
+City & County of Honolulu,35-02,US Representative,1,R,"TATAII, Steve",0,0,17,17
+City & County of Honolulu,35-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,35-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,35-02,State Senate,18,D,"SONSON, Alex M.",0,0,445,445
+City & County of Honolulu,35-02,State Senate,18,D,"NISHIHARA, Clarence",0,0,268,268
+City & County of Honolulu,35-02,State Representative,35,D,"AQUINO, Henry James C.",0,0,494,494
+City & County of Honolulu,35-02,State Representative,35,D,"RAHMAN, I. Perreira Padilla",0,0,147,147
+City & County of Honolulu,35-02,State Representative,35,D,"VERDADERO, Dante M.",0,0,36,36
+City & County of Honolulu,35-02,State Representative,35,D,"DOMINGO, Constante A.",0,0,16,16
+City & County of Honolulu,35-02,State Representative,35,D,"PARAYNO, Ilalo",0,0,25,25
+City & County of Honolulu,35-02,State Representative,35,R,"ANTONIO, Steven Bolosan",0,0,32,32
+City & County of Honolulu,35-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,221,221
+City & County of Honolulu,35-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,35-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,35-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,35-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,17,17
+City & County of Honolulu,35-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,169,169
+City & County of Honolulu,35-03,US Representative,1,R,"TATAII, Steve",0,0,6,6
+City & County of Honolulu,35-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,35-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,35-03,State Senate,18,D,"SONSON, Alex M.",0,0,113,113
+City & County of Honolulu,35-03,State Senate,18,D,"NISHIHARA, Clarence",0,0,99,99
+City & County of Honolulu,35-03,State Representative,35,D,"AQUINO, Henry James C.",0,0,133,133
+City & County of Honolulu,35-03,State Representative,35,D,"RAHMAN, I. Perreira Padilla",0,0,30,30
+City & County of Honolulu,35-03,State Representative,35,D,"VERDADERO, Dante M.",0,0,17,17
+City & County of Honolulu,35-03,State Representative,35,D,"DOMINGO, Constante A.",0,0,10,10
+City & County of Honolulu,35-03,State Representative,35,D,"PARAYNO, Ilalo",0,0,12,12
+City & County of Honolulu,35-03,State Representative,35,R,"ANTONIO, Steven Bolosan",0,0,14,14
+City & County of Honolulu,35-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,330,330
+City & County of Honolulu,35-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,35-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,35-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,35-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,22,22
+City & County of Honolulu,35-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,272,272
+City & County of Honolulu,35-04,US Representative,1,R,"TATAII, Steve",0,0,15,15
+City & County of Honolulu,35-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,35-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,35-04,State Senate,18,D,"SONSON, Alex M.",0,0,163,163
+City & County of Honolulu,35-04,State Senate,18,D,"NISHIHARA, Clarence",0,0,157,157
+City & County of Honolulu,35-04,State Representative,35,D,"AQUINO, Henry James C.",0,0,192,192
+City & County of Honolulu,35-04,State Representative,35,D,"RAHMAN, I. Perreira Padilla",0,0,57,57
+City & County of Honolulu,35-04,State Representative,35,D,"VERDADERO, Dante M.",0,0,9,9
+City & County of Honolulu,35-04,State Representative,35,D,"DOMINGO, Constante A.",0,0,12,12
+City & County of Honolulu,35-04,State Representative,35,D,"PARAYNO, Ilalo",0,0,33,33
+City & County of Honolulu,35-04,State Representative,35,R,"ANTONIO, Steven Bolosan",0,0,18,18
+City & County of Honolulu,35-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,279,279
+City & County of Honolulu,35-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,35-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,35-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,35-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,13,13
+City & County of Honolulu,35-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,231,231
+City & County of Honolulu,35-05,US Representative,1,R,"TATAII, Steve",0,0,6,6
+City & County of Honolulu,35-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,35-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,35-05,State Senate,18,D,"SONSON, Alex M.",0,0,173,173
+City & County of Honolulu,35-05,State Senate,18,D,"NISHIHARA, Clarence",0,0,96,96
+City & County of Honolulu,35-05,State Representative,35,D,"AQUINO, Henry James C.",0,0,176,176
+City & County of Honolulu,35-05,State Representative,35,D,"RAHMAN, I. Perreira Padilla",0,0,36,36
+City & County of Honolulu,35-05,State Representative,35,D,"VERDADERO, Dante M.",0,0,15,15
+City & County of Honolulu,35-05,State Representative,35,D,"DOMINGO, Constante A.",0,0,12,12
+City & County of Honolulu,35-05,State Representative,35,D,"PARAYNO, Ilalo",0,0,27,27
+City & County of Honolulu,35-05,State Representative,35,R,"ANTONIO, Steven Bolosan",0,0,11,11
+City & County of Honolulu,35-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,862,862
+City & County of Honolulu,35-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,35-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,35-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,35-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,35,35
+City & County of Honolulu,35-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,705,705
+City & County of Honolulu,35-06,US Representative,1,R,"TATAII, Steve",0,0,16,16
+City & County of Honolulu,35-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,35-06,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,35-06,State Senate,18,D,"SONSON, Alex M.",0,0,515,515
+City & County of Honolulu,35-06,State Senate,18,D,"NISHIHARA, Clarence",0,0,321,321
+City & County of Honolulu,35-06,State Representative,35,D,"AQUINO, Henry James C.",0,0,580,580
+City & County of Honolulu,35-06,State Representative,35,D,"RAHMAN, I. Perreira Padilla",0,0,134,134
+City & County of Honolulu,35-06,State Representative,35,D,"VERDADERO, Dante M.",0,0,24,24
+City & County of Honolulu,35-06,State Representative,35,D,"DOMINGO, Constante A.",0,0,23,23
+City & County of Honolulu,35-06,State Representative,35,D,"PARAYNO, Ilalo",0,0,74,74
+City & County of Honolulu,35-06,State Representative,35,R,"ANTONIO, Steven Bolosan",0,0,30,30
+City & County of Honolulu,36-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,531,531
+City & County of Honolulu,36-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,36-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,36-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,36-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,51,51
+City & County of Honolulu,36-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,429,429
+City & County of Honolulu,36-01,US Representative,1,R,"TATAII, Steve",0,0,46,46
+City & County of Honolulu,36-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,36-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,36-01,State Senate,16,D,"IGE, David Y.",0,0,338,338
+City & County of Honolulu,36-01,State Representative,36,D,"TAKUMI, Roy M.",0,0,372,372
+City & County of Honolulu,36-01,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,3,3
+City & County of Honolulu,36-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,384,384
+City & County of Honolulu,36-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,36-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,36-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,16,16
+City & County of Honolulu,36-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,40,40
+City & County of Honolulu,36-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,317,317
+City & County of Honolulu,36-02,US Representative,1,R,"TATAII, Steve",0,0,36,36
+City & County of Honolulu,36-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,36-02,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,36-02,State Senate,16,D,"IGE, David Y.",0,0,239,239
+City & County of Honolulu,36-02,State Representative,36,D,"TAKUMI, Roy M.",0,0,249,249
+City & County of Honolulu,36-02,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,15,15
+City & County of Honolulu,36-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,273,273
+City & County of Honolulu,36-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,36-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,36-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,36-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,59,59
+City & County of Honolulu,36-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,226,226
+City & County of Honolulu,36-03,US Representative,1,R,"TATAII, Steve",0,0,59,59
+City & County of Honolulu,36-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,36-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,36-03,State Senate,18,D,"SONSON, Alex M.",0,0,98,98
+City & County of Honolulu,36-03,State Senate,18,D,"NISHIHARA, Clarence",0,0,135,135
+City & County of Honolulu,36-03,State Representative,36,D,"TAKUMI, Roy M.",0,0,203,203
+City & County of Honolulu,36-03,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,0,0
+City & County of Honolulu,36-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,29,29
+City & County of Honolulu,36-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,36-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,36-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,36-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,4,4
+City & County of Honolulu,36-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,26,26
+City & County of Honolulu,36-04,US Representative,1,R,"TATAII, Steve",0,0,4,4
+City & County of Honolulu,36-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,36-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,36-04,State Senate,18,D,"SONSON, Alex M.",0,0,10,10
+City & County of Honolulu,36-04,State Senate,18,D,"NISHIHARA, Clarence",0,0,15,15
+City & County of Honolulu,36-04,State Representative,36,D,"TAKUMI, Roy M.",0,0,23,23
+City & County of Honolulu,36-04,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,0,0
+City & County of Honolulu,36-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,765,765
+City & County of Honolulu,36-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,36-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,36-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,36-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,69,69
+City & County of Honolulu,36-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,614,614
+City & County of Honolulu,36-05,US Representative,1,R,"TATAII, Steve",0,0,56,56
+City & County of Honolulu,36-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,36-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,36-05,State Senate,18,D,"SONSON, Alex M.",0,0,212,212
+City & County of Honolulu,36-05,State Senate,18,D,"NISHIHARA, Clarence",0,0,496,496
+City & County of Honolulu,36-05,State Representative,36,D,"TAKUMI, Roy M.",0,0,599,599
+City & County of Honolulu,36-05,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,4,4
+City & County of Honolulu,36-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,541,541
+City & County of Honolulu,36-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,36-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,36-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,11,11
+City & County of Honolulu,36-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,97,97
+City & County of Honolulu,36-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,427,427
+City & County of Honolulu,36-06,US Representative,1,R,"TATAII, Steve",0,0,91,91
+City & County of Honolulu,36-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,36-06,US Representative,1,L,"ZHAO, Li",0,0,4,4
+City & County of Honolulu,36-06,State Senate,16,D,"IGE, David Y.",0,0,320,320
+City & County of Honolulu,36-06,State Representative,36,D,"TAKUMI, Roy M.",0,0,355,355
+City & County of Honolulu,36-06,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,8,8
+City & County of Honolulu,36-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,396,396
+City & County of Honolulu,36-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,36-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,36-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,9,9
+City & County of Honolulu,36-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,67,67
+City & County of Honolulu,36-07,US Representative,1,D,"ABERCROMBIE, Neil",0,0,310,310
+City & County of Honolulu,36-07,US Representative,1,R,"TATAII, Steve",0,0,65,65
+City & County of Honolulu,36-07,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,36-07,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,36-07,State Senate,16,D,"IGE, David Y.",0,0,228,228
+City & County of Honolulu,36-07,State Representative,36,D,"TAKUMI, Roy M.",0,0,247,247
+City & County of Honolulu,36-07,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,9,9
+City & County of Honolulu,37-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,940,940
+City & County of Honolulu,37-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,37-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,37-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,37-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,119,119
+City & County of Honolulu,37-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,753,753
+City & County of Honolulu,37-01,US Representative,1,R,"TATAII, Steve",0,0,111,111
+City & County of Honolulu,37-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,37-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,37-01,State Senate,17,D,"KIDANI, Michelle",0,0,420,420
+City & County of Honolulu,37-01,State Senate,17,D,"MENOR, Ron",0,0,295,295
+City & County of Honolulu,37-01,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,162,162
+City & County of Honolulu,37-01,State Representative,37,D,"YAMANE, Ryan I.",0,0,773,773
+City & County of Honolulu,37-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,708,708
+City & County of Honolulu,37-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,37-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,37-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,37-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,129,129
+City & County of Honolulu,37-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,567,567
+City & County of Honolulu,37-02,US Representative,1,R,"TATAII, Steve",0,0,117,117
+City & County of Honolulu,37-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,37-02,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,37-02,State Senate,17,D,"KIDANI, Michelle",0,0,306,306
+City & County of Honolulu,37-02,State Senate,17,D,"MENOR, Ron",0,0,276,276
+City & County of Honolulu,37-02,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,90,90
+City & County of Honolulu,37-02,State Representative,37,D,"YAMANE, Ryan I.",0,0,567,567
+City & County of Honolulu,37-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,880,880
+City & County of Honolulu,37-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,37-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,37-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,37-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,138,138
+City & County of Honolulu,37-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,674,674
+City & County of Honolulu,37-03,US Representative,1,R,"TATAII, Steve",0,0,133,133
+City & County of Honolulu,37-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,37-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,37-03,State Senate,17,D,"KIDANI, Michelle",0,0,354,354
+City & County of Honolulu,37-03,State Senate,17,D,"MENOR, Ron",0,0,384,384
+City & County of Honolulu,37-03,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,100,100
+City & County of Honolulu,37-03,State Representative,37,D,"YAMANE, Ryan I.",0,0,684,684
+City & County of Honolulu,37-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,738,738
+City & County of Honolulu,37-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,37-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,37-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,37-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,121,121
+City & County of Honolulu,37-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,581,581
+City & County of Honolulu,37-04,US Representative,1,R,"TATAII, Steve",0,0,111,111
+City & County of Honolulu,37-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,37-04,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,37-04,State Senate,17,D,"KIDANI, Michelle",0,0,310,310
+City & County of Honolulu,37-04,State Senate,17,D,"MENOR, Ron",0,0,309,309
+City & County of Honolulu,37-04,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,78,78
+City & County of Honolulu,37-04,State Representative,37,D,"YAMANE, Ryan I.",0,0,598,598
+City & County of Honolulu,38-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,818,818
+City & County of Honolulu,38-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,38-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+City & County of Honolulu,38-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,13,13
+City & County of Honolulu,38-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,210,210
+City & County of Honolulu,38-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,665,665
+City & County of Honolulu,38-01,US Representative,1,R,"TATAII, Steve",0,0,117,117
+City & County of Honolulu,38-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,38-01,US Representative,1,L,"ZHAO, Li",0,0,3,3
+City & County of Honolulu,38-01,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,503,503
+City & County of Honolulu,38-01,State Representative,38,D,"LEE, Marilyn B.",0,0,539,539
+City & County of Honolulu,38-01,State Representative,38,R,"APANA, Melvin K.",0,0,178,178
+City & County of Honolulu,38-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,972,972
+City & County of Honolulu,38-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,38-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,38-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,38-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,180,180
+City & County of Honolulu,38-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,770,770
+City & County of Honolulu,38-02,US Representative,1,R,"TATAII, Steve",0,0,126,126
+City & County of Honolulu,38-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,4,4
+City & County of Honolulu,38-02,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,38-02,State Senate,17,D,"KIDANI, Michelle",0,0,436,436
+City & County of Honolulu,38-02,State Senate,17,D,"MENOR, Ron",0,0,388,388
+City & County of Honolulu,38-02,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,102,102
+City & County of Honolulu,38-02,State Representative,38,D,"LEE, Marilyn B.",0,0,776,776
+City & County of Honolulu,38-02,State Representative,38,R,"APANA, Melvin K.",0,0,155,155
+City & County of Honolulu,38-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,676,676
+City & County of Honolulu,38-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,38-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,38-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,38-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,114,114
+City & County of Honolulu,38-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,521,521
+City & County of Honolulu,38-03,US Representative,1,R,"TATAII, Steve",0,0,74,74
+City & County of Honolulu,38-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,38-03,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,38-03,State Senate,17,D,"KIDANI, Michelle",0,0,258,258
+City & County of Honolulu,38-03,State Senate,17,D,"MENOR, Ron",0,0,269,269
+City & County of Honolulu,38-03,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,117,117
+City & County of Honolulu,38-03,State Representative,38,D,"LEE, Marilyn B.",0,0,515,515
+City & County of Honolulu,38-03,State Representative,38,R,"APANA, Melvin K.",0,0,90,90
+City & County of Honolulu,38-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,500,500
+City & County of Honolulu,38-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,38-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,38-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,38-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,145,145
+City & County of Honolulu,38-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,382,382
+City & County of Honolulu,38-04,US Representative,1,R,"TATAII, Steve",0,0,94,94
+City & County of Honolulu,38-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,38-04,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,38-04,State Senate,17,D,"KIDANI, Michelle",0,0,195,195
+City & County of Honolulu,38-04,State Senate,17,D,"MENOR, Ron",0,0,204,204
+City & County of Honolulu,38-04,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,77,77
+City & County of Honolulu,38-04,State Representative,38,D,"LEE, Marilyn B.",0,0,380,380
+City & County of Honolulu,38-04,State Representative,38,R,"APANA, Melvin K.",0,0,118,118
+City & County of Honolulu,38-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,569,569
+City & County of Honolulu,38-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,38-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,38-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,38-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,111,111
+City & County of Honolulu,38-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,478,478
+City & County of Honolulu,38-05,US Representative,1,R,"TATAII, Steve",0,0,80,80
+City & County of Honolulu,38-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,38-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,38-05,State Senate,17,D,"KIDANI, Michelle",0,0,181,181
+City & County of Honolulu,38-05,State Senate,17,D,"MENOR, Ron",0,0,259,259
+City & County of Honolulu,38-05,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,92,92
+City & County of Honolulu,38-05,State Representative,38,D,"LEE, Marilyn B.",0,0,426,426
+City & County of Honolulu,38-05,State Representative,38,R,"APANA, Melvin K.",0,0,88,88
+City & County of Honolulu,39-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,271,271
+City & County of Honolulu,39-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,39-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,39-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,39-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,51,51
+City & County of Honolulu,39-01,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,39-01,US Representative,2,D,"HIRONO, Mazie",0,0,183,183
+City & County of Honolulu,39-01,US Representative,2,R,"EVANS, Roger B.",0,0,48,48
+City & County of Honolulu,39-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,39-01,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,209,209
+City & County of Honolulu,39-01,State Representative,39,D,"OSHIRO, Marcus R.",0,0,171,171
+City & County of Honolulu,39-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,412,412
+City & County of Honolulu,39-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,39-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,39-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,39-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,49,49
+City & County of Honolulu,39-02,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+City & County of Honolulu,39-02,US Representative,2,D,"HIRONO, Mazie",0,0,308,308
+City & County of Honolulu,39-02,US Representative,2,R,"EVANS, Roger B.",0,0,45,45
+City & County of Honolulu,39-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,39-02,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,317,317
+City & County of Honolulu,39-02,State Representative,39,D,"OSHIRO, Marcus R.",0,0,296,296
+City & County of Honolulu,39-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,534,534
+City & County of Honolulu,39-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,39-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,39-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,39-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,83,83
+City & County of Honolulu,39-03,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+City & County of Honolulu,39-03,US Representative,2,D,"HIRONO, Mazie",0,0,364,364
+City & County of Honolulu,39-03,US Representative,2,R,"EVANS, Roger B.",0,0,76,76
+City & County of Honolulu,39-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,39-03,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,400,400
+City & County of Honolulu,39-03,State Representative,39,D,"OSHIRO, Marcus R.",0,0,373,373
+City & County of Honolulu,39-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,392,392
+City & County of Honolulu,39-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,39-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,39-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,12,12
+City & County of Honolulu,39-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,83,83
+City & County of Honolulu,39-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,39-04,US Representative,2,D,"HIRONO, Mazie",0,0,299,299
+City & County of Honolulu,39-04,US Representative,2,R,"EVANS, Roger B.",0,0,79,79
+City & County of Honolulu,39-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,39-04,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,280,280
+City & County of Honolulu,39-04,State Representative,39,D,"OSHIRO, Marcus R.",0,0,268,268
+City & County of Honolulu,39-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,121,121
+City & County of Honolulu,39-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,39-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,39-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,39-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,35,35
+City & County of Honolulu,39-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,99,99
+City & County of Honolulu,39-05,US Representative,1,R,"TATAII, Steve",0,0,35,35
+City & County of Honolulu,39-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,39-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,39-05,State Senate,17,D,"KIDANI, Michelle",0,0,49,49
+City & County of Honolulu,39-05,State Senate,17,D,"MENOR, Ron",0,0,46,46
+City & County of Honolulu,39-05,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",0,0,7,7
+City & County of Honolulu,39-05,State Representative,39,D,"OSHIRO, Marcus R.",0,0,81,81
+City & County of Honolulu,39-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,352,352
+City & County of Honolulu,39-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,39-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,39-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,39-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,42,42
+City & County of Honolulu,39-06,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,39-06,US Representative,2,D,"HIRONO, Mazie",0,0,270,270
+City & County of Honolulu,39-06,US Representative,2,R,"EVANS, Roger B.",0,0,39,39
+City & County of Honolulu,39-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,5,5
+City & County of Honolulu,39-06,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,243,243
+City & County of Honolulu,39-06,State Representative,39,D,"OSHIRO, Marcus R.",0,0,229,229
+City & County of Honolulu,40-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,231,231
+City & County of Honolulu,40-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,40-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,40-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,40-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,66,66
+City & County of Honolulu,40-01,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,40-01,US Representative,2,D,"HIRONO, Mazie",0,0,181,181
+City & County of Honolulu,40-01,US Representative,2,R,"EVANS, Roger B.",0,0,49,49
+City & County of Honolulu,40-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,40-01,State Representative,40,D,"HAR, Sharon E.",0,0,179,179
+City & County of Honolulu,40-01,State Representative,40,R,"LEGAL,  Jack M.",0,0,47,47
+City & County of Honolulu,40-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,316,316
+City & County of Honolulu,40-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,40-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,40-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,40-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,118,118
+City & County of Honolulu,40-02,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+City & County of Honolulu,40-02,US Representative,2,D,"HIRONO, Mazie",0,0,240,240
+City & County of Honolulu,40-02,US Representative,2,R,"EVANS, Roger B.",0,0,76,76
+City & County of Honolulu,40-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,40-02,State Representative,40,D,"HAR, Sharon E.",0,0,232,232
+City & County of Honolulu,40-02,State Representative,40,R,"LEGAL,  Jack M.",0,0,98,98
+City & County of Honolulu,40-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,463,463
+City & County of Honolulu,40-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,40-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,40-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,40-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,154,154
+City & County of Honolulu,40-03,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+City & County of Honolulu,40-03,US Representative,2,D,"HIRONO, Mazie",0,0,323,323
+City & County of Honolulu,40-03,US Representative,2,R,"EVANS, Roger B.",0,0,94,94
+City & County of Honolulu,40-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,40-03,State Representative,40,D,"HAR, Sharon E.",0,0,342,342
+City & County of Honolulu,40-03,State Representative,40,R,"LEGAL,  Jack M.",0,0,120,120
+City & County of Honolulu,40-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,427,427
+City & County of Honolulu,40-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,40-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,40-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,40-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,154,154
+City & County of Honolulu,40-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,40-04,US Representative,2,D,"HIRONO, Mazie",0,0,299,299
+City & County of Honolulu,40-04,US Representative,2,R,"EVANS, Roger B.",0,0,73,73
+City & County of Honolulu,40-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,40-04,State Representative,40,D,"HAR, Sharon E.",0,0,355,355
+City & County of Honolulu,40-04,State Representative,40,R,"LEGAL,  Jack M.",0,0,126,126
+City & County of Honolulu,40-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,393,393
+City & County of Honolulu,40-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,40-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,40-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,40-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,166,166
+City & County of Honolulu,40-05,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,40-05,US Representative,2,D,"HIRONO, Mazie",0,0,305,305
+City & County of Honolulu,40-05,US Representative,2,R,"EVANS, Roger B.",0,0,98,98
+City & County of Honolulu,40-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,40-05,State Representative,40,D,"HAR, Sharon E.",0,0,300,300
+City & County of Honolulu,40-05,State Representative,40,R,"LEGAL,  Jack M.",0,0,142,142
+City & County of Honolulu,40-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,222,222
+City & County of Honolulu,40-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,40-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,40-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,40-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,142,142
+City & County of Honolulu,40-06,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,40-06,US Representative,2,D,"HIRONO, Mazie",0,0,174,174
+City & County of Honolulu,40-06,US Representative,2,R,"EVANS, Roger B.",0,0,87,87
+City & County of Honolulu,40-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,40-06,State Representative,40,D,"HAR, Sharon E.",0,0,180,180
+City & County of Honolulu,40-06,State Representative,40,R,"LEGAL,  Jack M.",0,0,114,114
+City & County of Honolulu,41-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,343,343
+City & County of Honolulu,41-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,41-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,41-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,41-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,82,82
+City & County of Honolulu,41-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,293,293
+City & County of Honolulu,41-01,US Representative,1,R,"TATAII, Steve",0,0,54,54
+City & County of Honolulu,41-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,2,2
+City & County of Honolulu,41-01,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,41-01,State Representative,41,D,"CULLEN, Ty Diaz",0,0,123,123
+City & County of Honolulu,41-01,State Representative,41,D,"KARAMATSU, Jon Riki",0,0,185,185
+City & County of Honolulu,41-01,State Representative,41,R,"SANIATAN, Rito C.",0,0,62,62
+City & County of Honolulu,41-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,347,347
+City & County of Honolulu,41-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,41-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,41-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,41-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,78,78
+City & County of Honolulu,41-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,289,289
+City & County of Honolulu,41-02,US Representative,1,R,"TATAII, Steve",0,0,39,39
+City & County of Honolulu,41-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,41-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,41-02,State Representative,41,D,"CULLEN, Ty Diaz",0,0,119,119
+City & County of Honolulu,41-02,State Representative,41,D,"KARAMATSU, Jon Riki",0,0,197,197
+City & County of Honolulu,41-02,State Representative,41,R,"SANIATAN, Rito C.",0,0,68,68
+City & County of Honolulu,41-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,538,538
+City & County of Honolulu,41-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,41-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,41-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,41-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,40,40
+City & County of Honolulu,41-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,422,422
+City & County of Honolulu,41-03,US Representative,1,R,"TATAII, Steve",0,0,17,17
+City & County of Honolulu,41-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,41-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,41-03,State Senate,18,D,"SONSON, Alex M.",0,0,237,237
+City & County of Honolulu,41-03,State Senate,18,D,"NISHIHARA, Clarence",0,0,265,265
+City & County of Honolulu,41-03,State Representative,41,D,"CULLEN, Ty Diaz",0,0,242,242
+City & County of Honolulu,41-03,State Representative,41,D,"KARAMATSU, Jon Riki",0,0,232,232
+City & County of Honolulu,41-03,State Representative,41,R,"SANIATAN, Rito C.",0,0,33,33
+City & County of Honolulu,41-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,66,66
+City & County of Honolulu,41-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,41-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,41-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,41-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,22,22
+City & County of Honolulu,41-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,53,53
+City & County of Honolulu,41-04,US Representative,1,R,"TATAII, Steve",0,0,11,11
+City & County of Honolulu,41-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,41-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,41-04,State Representative,41,D,"CULLEN, Ty Diaz",0,0,38,38
+City & County of Honolulu,41-04,State Representative,41,D,"KARAMATSU, Jon Riki",0,0,17,17
+City & County of Honolulu,41-04,State Representative,41,R,"SANIATAN, Rito C.",0,0,20,20
+City & County of Honolulu,41-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,505,505
+City & County of Honolulu,41-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,41-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,41-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,41-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,131,131
+City & County of Honolulu,41-05,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,41-05,US Representative,2,D,"HIRONO, Mazie",0,0,400,400
+City & County of Honolulu,41-05,US Representative,2,R,"EVANS, Roger B.",0,0,58,58
+City & County of Honolulu,41-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,41-05,State Representative,41,D,"CULLEN, Ty Diaz",0,0,255,255
+City & County of Honolulu,41-05,State Representative,41,D,"KARAMATSU, Jon Riki",0,0,211,211
+City & County of Honolulu,41-05,State Representative,41,R,"SANIATAN, Rito C.",0,0,110,110
+City & County of Honolulu,41-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,313,313
+City & County of Honolulu,41-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,41-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,41-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,41-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,113,113
+City & County of Honolulu,41-06,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,41-06,US Representative,2,D,"HIRONO, Mazie",0,0,249,249
+City & County of Honolulu,41-06,US Representative,2,R,"EVANS, Roger B.",0,0,52,52
+City & County of Honolulu,41-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,41-06,State Representative,41,D,"CULLEN, Ty Diaz",0,0,143,143
+City & County of Honolulu,41-06,State Representative,41,D,"KARAMATSU, Jon Riki",0,0,133,133
+City & County of Honolulu,41-06,State Representative,41,R,"SANIATAN, Rito C.",0,0,90,90
+City & County of Honolulu,42-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,287,287
+City & County of Honolulu,42-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,42-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,42-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,42-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,26,26
+City & County of Honolulu,42-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,234,234
+City & County of Honolulu,42-01,US Representative,1,R,"TATAII, Steve",0,0,10,10
+City & County of Honolulu,42-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,42-01,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,42-01,State Senate,18,D,"SONSON, Alex M.",0,0,148,148
+City & County of Honolulu,42-01,State Senate,18,D,"NISHIHARA, Clarence",0,0,125,125
+City & County of Honolulu,42-01,State Representative,42,D,"RODRIGUEZ, Rey R.",0,0,23,23
+City & County of Honolulu,42-01,State Representative,42,D,"SCHULTZ, Mike P.",0,0,81,81
+City & County of Honolulu,42-01,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",0,0,158,158
+City & County of Honolulu,42-01,State Representative,42,R,"BERG, Tom",0,0,25,25
+City & County of Honolulu,42-01,State Representative,42,N,"BIMBO, Genaro Q.",0,0,0,0
+City & County of Honolulu,42-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,107,107
+City & County of Honolulu,42-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,42-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,42-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,42-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,31,31
+City & County of Honolulu,42-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,90,90
+City & County of Honolulu,42-02,US Representative,1,R,"TATAII, Steve",0,0,20,20
+City & County of Honolulu,42-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,42-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,42-02,State Representative,42,D,"RODRIGUEZ, Rey R.",0,0,10,10
+City & County of Honolulu,42-02,State Representative,42,D,"SCHULTZ, Mike P.",0,0,24,24
+City & County of Honolulu,42-02,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",0,0,53,53
+City & County of Honolulu,42-02,State Representative,42,R,"BERG, Tom",0,0,24,24
+City & County of Honolulu,42-02,State Representative,42,N,"BIMBO, Genaro Q.",0,0,0,0
+City & County of Honolulu,42-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,220,220
+City & County of Honolulu,42-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,42-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,42-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,42-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,28,28
+City & County of Honolulu,42-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,173,173
+City & County of Honolulu,42-03,US Representative,1,R,"TATAII, Steve",0,0,18,18
+City & County of Honolulu,42-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,42-03,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,42-03,State Representative,42,D,"RODRIGUEZ, Rey R.",0,0,19,19
+City & County of Honolulu,42-03,State Representative,42,D,"SCHULTZ, Mike P.",0,0,97,97
+City & County of Honolulu,42-03,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",0,0,93,93
+City & County of Honolulu,42-03,State Representative,42,R,"BERG, Tom",0,0,24,24
+City & County of Honolulu,42-03,State Representative,42,N,"BIMBO, Genaro Q.",0,0,1,1
+City & County of Honolulu,42-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,520,520
+City & County of Honolulu,42-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,42-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,42-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,42-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,58,58
+City & County of Honolulu,42-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,421,421
+City & County of Honolulu,42-04,US Representative,1,R,"TATAII, Steve",0,0,17,17
+City & County of Honolulu,42-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,42-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,42-04,State Representative,42,D,"RODRIGUEZ, Rey R.",0,0,22,22
+City & County of Honolulu,42-04,State Representative,42,D,"SCHULTZ, Mike P.",0,0,177,177
+City & County of Honolulu,42-04,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",0,0,293,293
+City & County of Honolulu,42-04,State Representative,42,R,"BERG, Tom",0,0,55,55
+City & County of Honolulu,42-04,State Representative,42,N,"BIMBO, Genaro Q.",0,0,5,5
+City & County of Honolulu,42-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,403,403
+City & County of Honolulu,42-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,42-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,42-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,42-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,117,117
+City & County of Honolulu,42-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,342,342
+City & County of Honolulu,42-05,US Representative,1,R,"TATAII, Steve",0,0,48,48
+City & County of Honolulu,42-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,42-05,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,42-05,State Representative,42,D,"RODRIGUEZ, Rey R.",0,0,18,18
+City & County of Honolulu,42-05,State Representative,42,D,"SCHULTZ, Mike P.",0,0,187,187
+City & County of Honolulu,42-05,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",0,0,155,155
+City & County of Honolulu,42-05,State Representative,42,R,"BERG, Tom",0,0,108,108
+City & County of Honolulu,42-05,State Representative,42,N,"BIMBO, Genaro Q.",0,0,3,3
+City & County of Honolulu,43-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,219,219
+City & County of Honolulu,43-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,43-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,43-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,43-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,107,107
+City & County of Honolulu,43-01,US Representative,1,D,"ABERCROMBIE, Neil",0,0,186,186
+City & County of Honolulu,43-01,US Representative,1,R,"TATAII, Steve",0,0,30,30
+City & County of Honolulu,43-01,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,43-01,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,43-01,State Representative,43,D,"FEVELLA, Kurt",0,0,83,83
+City & County of Honolulu,43-01,State Representative,43,R,"PINE, Kymberly (Marcos)",0,0,103,103
+City & County of Honolulu,43-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,411,411
+City & County of Honolulu,43-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,43-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,43-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,43-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,252,252
+City & County of Honolulu,43-02,US Representative,1,D,"ABERCROMBIE, Neil",0,0,361,361
+City & County of Honolulu,43-02,US Representative,1,R,"TATAII, Steve",0,0,105,105
+City & County of Honolulu,43-02,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,43-02,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,43-02,State Representative,43,D,"FEVELLA, Kurt",0,0,158,158
+City & County of Honolulu,43-02,State Representative,43,R,"PINE, Kymberly (Marcos)",0,0,236,236
+City & County of Honolulu,43-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,254,254
+City & County of Honolulu,43-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,43-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,43-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,43-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,113,113
+City & County of Honolulu,43-03,US Representative,1,D,"ABERCROMBIE, Neil",0,0,206,206
+City & County of Honolulu,43-03,US Representative,1,R,"TATAII, Steve",0,0,42,42
+City & County of Honolulu,43-03,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,43-03,US Representative,1,L,"ZHAO, Li",0,0,1,1
+City & County of Honolulu,43-03,State Representative,43,D,"FEVELLA, Kurt",0,0,132,132
+City & County of Honolulu,43-03,State Representative,43,R,"PINE, Kymberly (Marcos)",0,0,104,104
+City & County of Honolulu,43-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,272,272
+City & County of Honolulu,43-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,43-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,43-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,43-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,160,160
+City & County of Honolulu,43-04,US Representative,1,D,"ABERCROMBIE, Neil",0,0,230,230
+City & County of Honolulu,43-04,US Representative,1,R,"TATAII, Steve",0,0,56,56
+City & County of Honolulu,43-04,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+City & County of Honolulu,43-04,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,43-04,State Representative,43,D,"FEVELLA, Kurt",0,0,146,146
+City & County of Honolulu,43-04,State Representative,43,R,"PINE, Kymberly (Marcos)",0,0,156,156
+City & County of Honolulu,43-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,354,354
+City & County of Honolulu,43-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,43-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,43-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,43-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,136,136
+City & County of Honolulu,43-05,US Representative,1,D,"ABERCROMBIE, Neil",0,0,297,297
+City & County of Honolulu,43-05,US Representative,1,R,"TATAII, Steve",0,0,49,49
+City & County of Honolulu,43-05,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,43-05,US Representative,1,L,"ZHAO, Li",0,0,0,0
+City & County of Honolulu,43-05,State Representative,43,D,"FEVELLA, Kurt",0,0,150,150
+City & County of Honolulu,43-05,State Representative,43,R,"PINE, Kymberly (Marcos)",0,0,128,128
+City & County of Honolulu,43-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,319,319
+City & County of Honolulu,43-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,43-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,43-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,43-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,209,209
+City & County of Honolulu,43-06,US Representative,1,D,"ABERCROMBIE, Neil",0,0,275,275
+City & County of Honolulu,43-06,US Representative,1,R,"TATAII, Steve",0,0,59,59
+City & County of Honolulu,43-06,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,1,1
+City & County of Honolulu,43-06,US Representative,1,L,"ZHAO, Li",0,0,2,2
+City & County of Honolulu,43-06,State Representative,43,D,"FEVELLA, Kurt",0,0,128,128
+City & County of Honolulu,43-06,State Representative,43,R,"PINE, Kymberly (Marcos)",0,0,198,198
+City & County of Honolulu,44-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,126,126
+City & County of Honolulu,44-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,44-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,44-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,44-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,34,34
+City & County of Honolulu,44-01,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,44-01,US Representative,2,D,"HIRONO, Mazie",0,0,108,108
+City & County of Honolulu,44-01,US Representative,2,R,"EVANS, Roger B.",0,0,31,31
+City & County of Honolulu,44-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,44-01,State Representative,44,D,"AWANA, Karen Leinani",0,0,82,82
+City & County of Honolulu,44-01,State Representative,44,D,"AIPOALANI, Hanalei Y.",0,0,35,35
+City & County of Honolulu,44-01,State Representative,44,R,"KU, Tercia L.",0,0,23,23
+City & County of Honolulu,44-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,603,603
+City & County of Honolulu,44-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,44-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,44-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,44-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,33,33
+City & County of Honolulu,44-02,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,44-02,US Representative,2,D,"HIRONO, Mazie",0,0,355,355
+City & County of Honolulu,44-02,US Representative,2,R,"EVANS, Roger B.",0,0,13,13
+City & County of Honolulu,44-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,44-02,State Senate,21,D,"HANABUSA, Colleen",0,0,430,430
+City & County of Honolulu,44-02,State Senate,21,R,"JOHNSON, Dickyj",0,0,16,16
+City & County of Honolulu,44-02,State Representative,44,D,"AWANA, Karen Leinani",0,0,242,242
+City & County of Honolulu,44-02,State Representative,44,D,"AIPOALANI, Hanalei Y.",0,0,315,315
+City & County of Honolulu,44-02,State Representative,44,R,"KU, Tercia L.",0,0,21,21
+City & County of Honolulu,44-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,421,421
+City & County of Honolulu,44-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,44-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,44-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,44-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,57,57
+City & County of Honolulu,44-03,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,44-03,US Representative,2,D,"HIRONO, Mazie",0,0,300,300
+City & County of Honolulu,44-03,US Representative,2,R,"EVANS, Roger B.",0,0,35,35
+City & County of Honolulu,44-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,44-03,State Senate,21,D,"HANABUSA, Colleen",0,0,295,295
+City & County of Honolulu,44-03,State Senate,21,R,"JOHNSON, Dickyj",0,0,42,42
+City & County of Honolulu,44-03,State Representative,44,D,"AWANA, Karen Leinani",0,0,172,172
+City & County of Honolulu,44-03,State Representative,44,D,"AIPOALANI, Hanalei Y.",0,0,200,200
+City & County of Honolulu,44-03,State Representative,44,R,"KU, Tercia L.",0,0,38,38
+City & County of Honolulu,44-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,477,477
+City & County of Honolulu,44-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,44-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,44-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,44-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,90,90
+City & County of Honolulu,44-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,44-04,US Representative,2,D,"HIRONO, Mazie",0,0,300,300
+City & County of Honolulu,44-04,US Representative,2,R,"EVANS, Roger B.",0,0,57,57
+City & County of Honolulu,44-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,44-04,State Senate,21,D,"HANABUSA, Colleen",0,0,341,341
+City & County of Honolulu,44-04,State Senate,21,R,"JOHNSON, Dickyj",0,0,58,58
+City & County of Honolulu,44-04,State Representative,44,D,"AWANA, Karen Leinani",0,0,232,232
+City & County of Honolulu,44-04,State Representative,44,D,"AIPOALANI, Hanalei Y.",0,0,175,175
+City & County of Honolulu,44-04,State Representative,44,R,"KU, Tercia L.",0,0,64,64
+City & County of Honolulu,45-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,637,637
+City & County of Honolulu,45-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,45-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,45-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,45-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,101,101
+City & County of Honolulu,45-01,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,45-01,US Representative,2,D,"HIRONO, Mazie",0,0,433,433
+City & County of Honolulu,45-01,US Representative,2,R,"EVANS, Roger B.",0,0,53,53
+City & County of Honolulu,45-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,45-01,State Senate,21,D,"HANABUSA, Colleen",0,0,497,497
+City & County of Honolulu,45-01,State Senate,21,R,"JOHNSON, Dickyj",0,0,58,58
+City & County of Honolulu,45-01,State Representative,45,D,"SHIMABUKURO, Maile S. L.",0,0,471,471
+City & County of Honolulu,45-01,State Representative,45,D,"SAYLORS, Denise",0,0,85,85
+City & County of Honolulu,45-01,State Representative,45,R,"GAPOL, Derek A.",0,0,72,72
+City & County of Honolulu,45-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,312,312
+City & County of Honolulu,45-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,45-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,45-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,45-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,42,42
+City & County of Honolulu,45-02,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,45-02,US Representative,2,D,"HIRONO, Mazie",0,0,221,221
+City & County of Honolulu,45-02,US Representative,2,R,"EVANS, Roger B.",0,0,21,21
+City & County of Honolulu,45-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,45-02,State Senate,21,D,"HANABUSA, Colleen",0,0,237,237
+City & County of Honolulu,45-02,State Senate,21,R,"JOHNSON, Dickyj",0,0,20,20
+City & County of Honolulu,45-02,State Representative,45,D,"SHIMABUKURO, Maile S. L.",0,0,213,213
+City & County of Honolulu,45-02,State Representative,45,D,"SAYLORS, Denise",0,0,53,53
+City & County of Honolulu,45-02,State Representative,45,R,"GAPOL, Derek A.",0,0,28,28
+City & County of Honolulu,45-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,136,136
+City & County of Honolulu,45-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,45-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,45-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,45-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,24,24
+City & County of Honolulu,45-03,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,45-03,US Representative,2,D,"HIRONO, Mazie",0,0,88,88
+City & County of Honolulu,45-03,US Representative,2,R,"EVANS, Roger B.",0,0,11,11
+City & County of Honolulu,45-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,45-03,State Senate,21,D,"HANABUSA, Colleen",0,0,98,98
+City & County of Honolulu,45-03,State Senate,21,R,"JOHNSON, Dickyj",0,0,13,13
+City & County of Honolulu,45-03,State Representative,45,D,"SHIMABUKURO, Maile S. L.",0,0,96,96
+City & County of Honolulu,45-03,State Representative,45,D,"SAYLORS, Denise",0,0,24,24
+City & County of Honolulu,45-03,State Representative,45,R,"GAPOL, Derek A.",0,0,13,13
+City & County of Honolulu,45-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,424,424
+City & County of Honolulu,45-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,45-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,45-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,45-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,91,91
+City & County of Honolulu,45-04,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,45-04,US Representative,2,D,"HIRONO, Mazie",0,0,266,266
+City & County of Honolulu,45-04,US Representative,2,R,"EVANS, Roger B.",0,0,44,44
+City & County of Honolulu,45-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,45-04,State Senate,21,D,"HANABUSA, Colleen",0,0,291,291
+City & County of Honolulu,45-04,State Senate,21,R,"JOHNSON, Dickyj",0,0,56,56
+City & County of Honolulu,45-04,State Representative,45,D,"SHIMABUKURO, Maile S. L.",0,0,265,265
+City & County of Honolulu,45-04,State Representative,45,D,"SAYLORS, Denise",0,0,110,110
+City & County of Honolulu,45-04,State Representative,45,R,"GAPOL, Derek A.",0,0,63,63
+City & County of Honolulu,46-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,225,225
+City & County of Honolulu,46-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,46-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,46-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,46-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,164,164
+City & County of Honolulu,46-01,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,46-01,US Representative,2,D,"HIRONO, Mazie",0,0,152,152
+City & County of Honolulu,46-01,US Representative,2,R,"EVANS, Roger B.",0,0,106,106
+City & County of Honolulu,46-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,46-01,State Senate,23,D,"HEE, Clayton",0,0,162,162
+City & County of Honolulu,46-01,State Senate,23,D,"MURAKI, Noel S.",0,0,35,35
+City & County of Honolulu,46-01,State Senate,23,R,"FALE, Richard",0,0,117,117
+City & County of Honolulu,46-01,State Representative,46,D,"LUNASCO, Ollie",0,0,6,6
+City & County of Honolulu,46-01,State Representative,46,D,"MAGAOAY, Michael Y.",0,0,155,155
+City & County of Honolulu,46-01,State Representative,46,D,"WASSON, Dawn K.",0,0,50,50
+City & County of Honolulu,46-01,State Representative,46,R,"PHILIPS, Carol",0,0,102,102
+City & County of Honolulu,46-01,State Representative,46,R,"RIVIERE, Gil",0,0,49,49
+City & County of Honolulu,46-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,42,42
+City & County of Honolulu,46-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,46-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,46-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,46-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,8,8
+City & County of Honolulu,46-02,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,46-02,US Representative,2,D,"HIRONO, Mazie",0,0,33,33
+City & County of Honolulu,46-02,US Representative,2,R,"EVANS, Roger B.",0,0,5,5
+City & County of Honolulu,46-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,46-02,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,30,30
+City & County of Honolulu,46-02,State Representative,46,D,"LUNASCO, Ollie",0,0,8,8
+City & County of Honolulu,46-02,State Representative,46,D,"MAGAOAY, Michael Y.",0,0,28,28
+City & County of Honolulu,46-02,State Representative,46,D,"WASSON, Dawn K.",0,0,3,3
+City & County of Honolulu,46-02,State Representative,46,R,"PHILIPS, Carol",0,0,6,6
+City & County of Honolulu,46-02,State Representative,46,R,"RIVIERE, Gil",0,0,1,1
+City & County of Honolulu,46-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,481,481
+City & County of Honolulu,46-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,46-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,46-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,46-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,222,222
+City & County of Honolulu,46-03,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,46-03,US Representative,2,D,"HIRONO, Mazie",0,0,346,346
+City & County of Honolulu,46-03,US Representative,2,R,"EVANS, Roger B.",0,0,79,79
+City & County of Honolulu,46-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,46-03,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,352,352
+City & County of Honolulu,46-03,State Representative,46,D,"LUNASCO, Ollie",0,0,91,91
+City & County of Honolulu,46-03,State Representative,46,D,"MAGAOAY, Michael Y.",0,0,328,328
+City & County of Honolulu,46-03,State Representative,46,D,"WASSON, Dawn K.",0,0,39,39
+City & County of Honolulu,46-03,State Representative,46,R,"PHILIPS, Carol",0,0,100,100
+City & County of Honolulu,46-03,State Representative,46,R,"RIVIERE, Gil",0,0,119,119
+City & County of Honolulu,46-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,392,392
+City & County of Honolulu,46-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,46-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,46-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,46-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,208,208
+City & County of Honolulu,46-04,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,46-04,US Representative,2,D,"HIRONO, Mazie",0,0,307,307
+City & County of Honolulu,46-04,US Representative,2,R,"EVANS, Roger B.",0,0,70,70
+City & County of Honolulu,46-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,46-04,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,289,289
+City & County of Honolulu,46-04,State Representative,46,D,"LUNASCO, Ollie",0,0,57,57
+City & County of Honolulu,46-04,State Representative,46,D,"MAGAOAY, Michael Y.",0,0,289,289
+City & County of Honolulu,46-04,State Representative,46,D,"WASSON, Dawn K.",0,0,25,25
+City & County of Honolulu,46-04,State Representative,46,R,"PHILIPS, Carol",0,0,88,88
+City & County of Honolulu,46-04,State Representative,46,R,"RIVIERE, Gil",0,0,117,117
+City & County of Honolulu,46-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,254,254
+City & County of Honolulu,46-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,46-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,46-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,46-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,295,295
+City & County of Honolulu,46-05,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,46-05,US Representative,2,D,"HIRONO, Mazie",0,0,174,174
+City & County of Honolulu,46-05,US Representative,2,R,"EVANS, Roger B.",0,0,106,106
+City & County of Honolulu,46-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,46-05,State Senate,22,D,"BUNDA, Robert (Bobby)",0,0,154,154
+City & County of Honolulu,46-05,State Representative,46,D,"LUNASCO, Ollie",0,0,31,31
+City & County of Honolulu,46-05,State Representative,46,D,"MAGAOAY, Michael Y.",0,0,160,160
+City & County of Honolulu,46-05,State Representative,46,D,"WASSON, Dawn K.",0,0,35,35
+City & County of Honolulu,46-05,State Representative,46,R,"PHILIPS, Carol",0,0,108,108
+City & County of Honolulu,46-05,State Representative,46,R,"RIVIERE, Gil",0,0,186,186
+City & County of Honolulu,46-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,220,220
+City & County of Honolulu,46-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,46-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,46-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,46-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,115,115
+City & County of Honolulu,46-06,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,46-06,US Representative,2,D,"HIRONO, Mazie",0,0,177,177
+City & County of Honolulu,46-06,US Representative,2,R,"EVANS, Roger B.",0,0,51,51
+City & County of Honolulu,46-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,46-06,State Senate,23,D,"HEE, Clayton",0,0,153,153
+City & County of Honolulu,46-06,State Senate,23,D,"MURAKI, Noel S.",0,0,29,29
+City & County of Honolulu,46-06,State Senate,23,R,"FALE, Richard",0,0,66,66
+City & County of Honolulu,46-06,State Representative,46,D,"LUNASCO, Ollie",0,0,26,26
+City & County of Honolulu,46-06,State Representative,46,D,"MAGAOAY, Michael Y.",0,0,130,130
+City & County of Honolulu,46-06,State Representative,46,D,"WASSON, Dawn K.",0,0,51,51
+City & County of Honolulu,46-06,State Representative,46,R,"PHILIPS, Carol",0,0,55,55
+City & County of Honolulu,46-06,State Representative,46,R,"RIVIERE, Gil",0,0,50,50
+City & County of Honolulu,47-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,496,496
+City & County of Honolulu,47-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,47-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,47-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,47-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,258,258
+City & County of Honolulu,47-01,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,47-01,US Representative,2,D,"HIRONO, Mazie",0,0,348,348
+City & County of Honolulu,47-01,US Representative,2,R,"EVANS, Roger B.",0,0,107,107
+City & County of Honolulu,47-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,47-01,State Senate,23,D,"HEE, Clayton",0,0,309,309
+City & County of Honolulu,47-01,State Senate,23,D,"MURAKI, Noel S.",0,0,112,112
+City & County of Honolulu,47-01,State Senate,23,R,"FALE, Richard",0,0,129,129
+City & County of Honolulu,47-01,State Representative,47,D,"PACHECO, Maria",0,0,131,131
+City & County of Honolulu,47-01,State Representative,47,D,"WOOLEY, Jessica",0,0,299,299
+City & County of Honolulu,47-01,State Representative,47,R,"MEYER, Colleen",0,0,223,223
+City & County of Honolulu,47-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,383,383
+City & County of Honolulu,47-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,47-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,47-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,47-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,113,113
+City & County of Honolulu,47-02,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,47-02,US Representative,2,D,"HIRONO, Mazie",0,0,288,288
+City & County of Honolulu,47-02,US Representative,2,R,"EVANS, Roger B.",0,0,33,33
+City & County of Honolulu,47-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,47-02,State Senate,23,D,"HEE, Clayton",0,0,253,253
+City & County of Honolulu,47-02,State Senate,23,D,"MURAKI, Noel S.",0,0,81,81
+City & County of Honolulu,47-02,State Senate,23,R,"FALE, Richard",0,0,34,34
+City & County of Honolulu,47-02,State Representative,47,D,"PACHECO, Maria",0,0,74,74
+City & County of Honolulu,47-02,State Representative,47,D,"WOOLEY, Jessica",0,0,265,265
+City & County of Honolulu,47-02,State Representative,47,R,"MEYER, Colleen",0,0,109,109
+City & County of Honolulu,47-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,387,387
+City & County of Honolulu,47-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,47-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,47-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,47-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,136,136
+City & County of Honolulu,47-03,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,47-03,US Representative,2,D,"HIRONO, Mazie",0,0,310,310
+City & County of Honolulu,47-03,US Representative,2,R,"EVANS, Roger B.",0,0,63,63
+City & County of Honolulu,47-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,47-03,State Senate,23,D,"HEE, Clayton",0,0,255,255
+City & County of Honolulu,47-03,State Senate,23,D,"MURAKI, Noel S.",0,0,93,93
+City & County of Honolulu,47-03,State Senate,23,R,"FALE, Richard",0,0,60,60
+City & County of Honolulu,47-03,State Representative,47,D,"PACHECO, Maria",0,0,82,82
+City & County of Honolulu,47-03,State Representative,47,D,"WOOLEY, Jessica",0,0,270,270
+City & County of Honolulu,47-03,State Representative,47,R,"MEYER, Colleen",0,0,129,129
+City & County of Honolulu,47-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,147,147
+City & County of Honolulu,47-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,47-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,47-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,47-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,36,36
+City & County of Honolulu,47-04,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+City & County of Honolulu,47-04,US Representative,2,D,"HIRONO, Mazie",0,0,117,117
+City & County of Honolulu,47-04,US Representative,2,R,"EVANS, Roger B.",0,0,17,17
+City & County of Honolulu,47-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,47-04,State Senate,23,D,"HEE, Clayton",0,0,93,93
+City & County of Honolulu,47-04,State Senate,23,D,"MURAKI, Noel S.",0,0,33,33
+City & County of Honolulu,47-04,State Senate,23,R,"FALE, Richard",0,0,13,13
+City & County of Honolulu,47-04,State Representative,47,D,"PACHECO, Maria",0,0,22,22
+City & County of Honolulu,47-04,State Representative,47,D,"WOOLEY, Jessica",0,0,98,98
+City & County of Honolulu,47-04,State Representative,47,R,"MEYER, Colleen",0,0,34,34
+City & County of Honolulu,47-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,87,87
+City & County of Honolulu,47-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,47-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,47-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,47-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,37,37
+City & County of Honolulu,47-05,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,47-05,US Representative,2,D,"HIRONO, Mazie",0,0,73,73
+City & County of Honolulu,47-05,US Representative,2,R,"EVANS, Roger B.",0,0,19,19
+City & County of Honolulu,47-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,47-05,State Senate,23,D,"HEE, Clayton",0,0,44,44
+City & County of Honolulu,47-05,State Senate,23,D,"MURAKI, Noel S.",0,0,35,35
+City & County of Honolulu,47-05,State Senate,23,R,"FALE, Richard",0,0,20,20
+City & County of Honolulu,47-05,State Representative,47,D,"PACHECO, Maria",0,0,20,20
+City & County of Honolulu,47-05,State Representative,47,D,"WOOLEY, Jessica",0,0,55,55
+City & County of Honolulu,47-05,State Representative,47,R,"MEYER, Colleen",0,0,35,35
+City & County of Honolulu,47-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,984,984
+City & County of Honolulu,47-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,47-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,7,7
+City & County of Honolulu,47-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,47-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,240,240
+City & County of Honolulu,47-06,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+City & County of Honolulu,47-06,US Representative,2,D,"HIRONO, Mazie",0,0,730,730
+City & County of Honolulu,47-06,US Representative,2,R,"EVANS, Roger B.",0,0,90,90
+City & County of Honolulu,47-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,7,7
+City & County of Honolulu,47-06,State Senate,23,D,"HEE, Clayton",0,0,645,645
+City & County of Honolulu,47-06,State Senate,23,D,"MURAKI, Noel S.",0,0,220,220
+City & County of Honolulu,47-06,State Senate,23,R,"FALE, Richard",0,0,85,85
+City & County of Honolulu,47-06,State Representative,47,D,"PACHECO, Maria",0,0,160,160
+City & County of Honolulu,47-06,State Representative,47,D,"WOOLEY, Jessica",0,0,683,683
+City & County of Honolulu,47-06,State Representative,47,R,"MEYER, Colleen",0,0,231,231
+City & County of Honolulu,48-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,600,600
+City & County of Honolulu,48-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,48-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,48-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,48-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,112,112
+City & County of Honolulu,48-01,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,48-01,US Representative,2,D,"HIRONO, Mazie",0,0,481,481
+City & County of Honolulu,48-01,US Representative,2,R,"EVANS, Roger B.",0,0,85,85
+City & County of Honolulu,48-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,48-01,State Senate,23,D,"HEE, Clayton",0,0,356,356
+City & County of Honolulu,48-01,State Senate,23,D,"MURAKI, Noel S.",0,0,150,150
+City & County of Honolulu,48-01,State Senate,23,R,"FALE, Richard",0,0,75,75
+City & County of Honolulu,48-01,State Representative,48,D,"ITO, Ken",0,0,452,452
+City & County of Honolulu,48-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,486,486
+City & County of Honolulu,48-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,48-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,48-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,48-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,108,108
+City & County of Honolulu,48-02,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+City & County of Honolulu,48-02,US Representative,2,D,"HIRONO, Mazie",0,0,380,380
+City & County of Honolulu,48-02,US Representative,2,R,"EVANS, Roger B.",0,0,104,104
+City & County of Honolulu,48-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,48-02,State Representative,48,D,"ITO, Ken",0,0,355,355
+City & County of Honolulu,48-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,642,642
+City & County of Honolulu,48-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,48-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,48-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,11,11
+City & County of Honolulu,48-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,115,115
+City & County of Honolulu,48-03,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+City & County of Honolulu,48-03,US Representative,2,D,"HIRONO, Mazie",0,0,487,487
+City & County of Honolulu,48-03,US Representative,2,R,"EVANS, Roger B.",0,0,107,107
+City & County of Honolulu,48-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,48-03,State Representative,48,D,"ITO, Ken",0,0,493,493
+City & County of Honolulu,48-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,833,833
+City & County of Honolulu,48-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,9,9
+City & County of Honolulu,48-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,48-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,48-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,128,128
+City & County of Honolulu,48-04,US Representative,2,I,"STENSHOL, Shaun",0,0,9,9
+City & County of Honolulu,48-04,US Representative,2,D,"HIRONO, Mazie",0,0,667,667
+City & County of Honolulu,48-04,US Representative,2,R,"EVANS, Roger B.",0,0,121,121
+City & County of Honolulu,48-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,5,5
+City & County of Honolulu,48-04,State Representative,48,D,"ITO, Ken",0,0,659,659
+City & County of Honolulu,48-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,267,267
+City & County of Honolulu,48-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,48-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,48-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+City & County of Honolulu,48-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,48,48
+City & County of Honolulu,48-05,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+City & County of Honolulu,48-05,US Representative,2,D,"HIRONO, Mazie",0,0,205,205
+City & County of Honolulu,48-05,US Representative,2,R,"EVANS, Roger B.",0,0,41,41
+City & County of Honolulu,48-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,48-05,State Senate,23,D,"HEE, Clayton",0,0,150,150
+City & County of Honolulu,48-05,State Senate,23,D,"MURAKI, Noel S.",0,0,82,82
+City & County of Honolulu,48-05,State Senate,23,R,"FALE, Richard",0,0,35,35
+City & County of Honolulu,48-05,State Representative,48,D,"ITO, Ken",0,0,204,204
+City & County of Honolulu,49-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,513,513
+City & County of Honolulu,49-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,15,15
+City & County of Honolulu,49-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,49-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,49-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,192,192
+City & County of Honolulu,49-01,US Representative,2,I,"STENSHOL, Shaun",0,0,11,11
+City & County of Honolulu,49-01,US Representative,2,D,"HIRONO, Mazie",0,0,361,361
+City & County of Honolulu,49-01,US Representative,2,R,"EVANS, Roger B.",0,0,182,182
+City & County of Honolulu,49-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+City & County of Honolulu,49-01,State Representative,49,D,"CHONG, Pono",0,0,343,343
+City & County of Honolulu,49-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,283,283
+City & County of Honolulu,49-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,49-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,49-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,49-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,63,63
+City & County of Honolulu,49-02,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,49-02,US Representative,2,D,"HIRONO, Mazie",0,0,226,226
+City & County of Honolulu,49-02,US Representative,2,R,"EVANS, Roger B.",0,0,57,57
+City & County of Honolulu,49-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,49-02,State Representative,49,D,"CHONG, Pono",0,0,192,192
+City & County of Honolulu,49-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,578,578
+City & County of Honolulu,49-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,49-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,49-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,49-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,154,154
+City & County of Honolulu,49-03,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+City & County of Honolulu,49-03,US Representative,2,D,"HIRONO, Mazie",0,0,422,422
+City & County of Honolulu,49-03,US Representative,2,R,"EVANS, Roger B.",0,0,143,143
+City & County of Honolulu,49-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,5,5
+City & County of Honolulu,49-03,State Representative,49,D,"CHONG, Pono",0,0,410,410
+City & County of Honolulu,49-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,232,232
+City & County of Honolulu,49-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,49-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,49-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,49-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,75,75
+City & County of Honolulu,49-04,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,49-04,US Representative,2,D,"HIRONO, Mazie",0,0,175,175
+City & County of Honolulu,49-04,US Representative,2,R,"EVANS, Roger B.",0,0,74,74
+City & County of Honolulu,49-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,49-04,State Representative,49,D,"CHONG, Pono",0,0,149,149
+City & County of Honolulu,49-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,317,317
+City & County of Honolulu,49-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,49-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,49-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,49-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,105,105
+City & County of Honolulu,49-05,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,49-05,US Representative,2,D,"HIRONO, Mazie",0,0,235,235
+City & County of Honolulu,49-05,US Representative,2,R,"EVANS, Roger B.",0,0,103,103
+City & County of Honolulu,49-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+City & County of Honolulu,49-05,State Representative,49,D,"CHONG, Pono",0,0,212,212
+City & County of Honolulu,49-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,417,417
+City & County of Honolulu,49-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,11,11
+City & County of Honolulu,49-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,49-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,49-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,69,69
+City & County of Honolulu,49-06,US Representative,2,I,"STENSHOL, Shaun",0,0,11,11
+City & County of Honolulu,49-06,US Representative,2,D,"HIRONO, Mazie",0,0,338,338
+City & County of Honolulu,49-06,US Representative,2,R,"EVANS, Roger B.",0,0,69,69
+City & County of Honolulu,49-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,49-06,State Representative,49,D,"CHONG, Pono",0,0,251,251
+City & County of Honolulu,49-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,575,575
+City & County of Honolulu,49-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,8,8
+City & County of Honolulu,49-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,49-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,4,4
+City & County of Honolulu,49-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,143,143
+City & County of Honolulu,49-07,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+City & County of Honolulu,49-07,US Representative,2,D,"HIRONO, Mazie",0,0,463,463
+City & County of Honolulu,49-07,US Representative,2,R,"EVANS, Roger B.",0,0,117,117
+City & County of Honolulu,49-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+City & County of Honolulu,49-07,State Senate,23,D,"HEE, Clayton",0,0,319,319
+City & County of Honolulu,49-07,State Senate,23,D,"MURAKI, Noel S.",0,0,154,154
+City & County of Honolulu,49-07,State Senate,23,R,"FALE, Richard",0,0,87,87
+City & County of Honolulu,49-07,State Representative,49,D,"CHONG, Pono",0,0,430,430
+City & County of Honolulu,50-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,275,275
+City & County of Honolulu,50-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,14,14
+City & County of Honolulu,50-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,50-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,6,6
+City & County of Honolulu,50-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,202,202
+City & County of Honolulu,50-01,US Representative,2,I,"STENSHOL, Shaun",0,0,11,11
+City & County of Honolulu,50-01,US Representative,2,D,"HIRONO, Mazie",0,0,253,253
+City & County of Honolulu,50-01,US Representative,2,R,"EVANS, Roger B.",0,0,58,58
+City & County of Honolulu,50-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,50-01,State Representative,50,R,"THIELEN, Cynthia",0,0,184,184
+City & County of Honolulu,50-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,311,311
+City & County of Honolulu,50-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,15,15
+City & County of Honolulu,50-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,50-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,50-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,174,174
+City & County of Honolulu,50-02,US Representative,2,I,"STENSHOL, Shaun",0,0,15,15
+City & County of Honolulu,50-02,US Representative,2,D,"HIRONO, Mazie",0,0,286,286
+City & County of Honolulu,50-02,US Representative,2,R,"EVANS, Roger B.",0,0,54,54
+City & County of Honolulu,50-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,4,4
+City & County of Honolulu,50-02,State Representative,50,R,"THIELEN, Cynthia",0,0,155,155
+City & County of Honolulu,50-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,214,214
+City & County of Honolulu,50-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,50-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,50-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,50-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,140,140
+City & County of Honolulu,50-03,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,50-03,US Representative,2,D,"HIRONO, Mazie",0,0,201,201
+City & County of Honolulu,50-03,US Representative,2,R,"EVANS, Roger B.",0,0,39,39
+City & County of Honolulu,50-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,50-03,State Representative,50,R,"THIELEN, Cynthia",0,0,121,121
+City & County of Honolulu,50-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,319,319
+City & County of Honolulu,50-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,10,10
+City & County of Honolulu,50-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,50-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,7,7
+City & County of Honolulu,50-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,151,151
+City & County of Honolulu,50-04,US Representative,2,I,"STENSHOL, Shaun",0,0,10,10
+City & County of Honolulu,50-04,US Representative,2,D,"HIRONO, Mazie",0,0,300,300
+City & County of Honolulu,50-04,US Representative,2,R,"EVANS, Roger B.",0,0,47,47
+City & County of Honolulu,50-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,50-04,State Representative,50,R,"THIELEN, Cynthia",0,0,133,133
+City & County of Honolulu,50-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,313,313
+City & County of Honolulu,50-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,10,10
+City & County of Honolulu,50-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,50-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,5,5
+City & County of Honolulu,50-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,270,270
+City & County of Honolulu,50-05,US Representative,2,I,"STENSHOL, Shaun",0,0,8,8
+City & County of Honolulu,50-05,US Representative,2,D,"HIRONO, Mazie",0,0,296,296
+City & County of Honolulu,50-05,US Representative,2,R,"EVANS, Roger B.",0,0,83,83
+City & County of Honolulu,50-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,50-05,State Representative,50,R,"THIELEN, Cynthia",0,0,244,244
+City & County of Honolulu,50-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,293,293
+City & County of Honolulu,50-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,7,7
+City & County of Honolulu,50-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,50-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,11,11
+City & County of Honolulu,50-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,282,282
+City & County of Honolulu,50-06,US Representative,2,I,"STENSHOL, Shaun",0,0,7,7
+City & County of Honolulu,50-06,US Representative,2,D,"HIRONO, Mazie",0,0,265,265
+City & County of Honolulu,50-06,US Representative,2,R,"EVANS, Roger B.",0,0,76,76
+City & County of Honolulu,50-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,50-06,State Representative,50,R,"THIELEN, Cynthia",0,0,248,248
+City & County of Honolulu,50-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,117,117
+City & County of Honolulu,50-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,5,5
+City & County of Honolulu,50-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,2,2
+City & County of Honolulu,50-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,50-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,137,137
+City & County of Honolulu,50-07,US Representative,2,I,"STENSHOL, Shaun",0,0,5,5
+City & County of Honolulu,50-07,US Representative,2,D,"HIRONO, Mazie",0,0,106,106
+City & County of Honolulu,50-07,US Representative,2,R,"EVANS, Roger B.",0,0,42,42
+City & County of Honolulu,50-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,2,2
+City & County of Honolulu,50-07,State Representative,50,R,"THIELEN, Cynthia",0,0,129,129
+City & County of Honolulu,51-01,Straight Party,,,DEMOCRATIC PARTY (D),0,0,327,327
+City & County of Honolulu,51-01,Straight Party,,,INDEPENDENT PARTY (I),0,0,6,6
+City & County of Honolulu,51-01,Straight Party,,,LIBERTARIAN PARTY (L),0,0,4,4
+City & County of Honolulu,51-01,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,51-01,Straight Party,,,REPUBLICAN PARTY (R),0,0,161,161
+City & County of Honolulu,51-01,US Representative,2,I,"STENSHOL, Shaun",0,0,6,6
+City & County of Honolulu,51-01,US Representative,2,D,"HIRONO, Mazie",0,0,195,195
+City & County of Honolulu,51-01,US Representative,2,R,"EVANS, Roger B.",0,0,65,65
+City & County of Honolulu,51-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,51-01,State Representative,51,D,"ANDERSON, J. Ikaika",0,0,82,82
+City & County of Honolulu,51-01,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",0,0,12,12
+City & County of Honolulu,51-01,State Representative,51,D,"LEE, Chris Kalani",0,0,210,210
+City & County of Honolulu,51-01,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",0,0,149,149
+City & County of Honolulu,51-02,Straight Party,,,DEMOCRATIC PARTY (D),0,0,567,567
+City & County of Honolulu,51-02,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,51-02,Straight Party,,,LIBERTARIAN PARTY (L),0,0,5,5
+City & County of Honolulu,51-02,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,51-02,Straight Party,,,REPUBLICAN PARTY (R),0,0,92,92
+City & County of Honolulu,51-02,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,51-02,US Representative,2,D,"HIRONO, Mazie",0,0,381,381
+City & County of Honolulu,51-02,US Representative,2,R,"EVANS, Roger B.",0,0,42,42
+City & County of Honolulu,51-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,5,5
+City & County of Honolulu,51-02,State Representative,51,D,"ANDERSON, J. Ikaika",0,0,304,304
+City & County of Honolulu,51-02,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",0,0,12,12
+City & County of Honolulu,51-02,State Representative,51,D,"LEE, Chris Kalani",0,0,225,225
+City & County of Honolulu,51-02,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",0,0,85,85
+City & County of Honolulu,51-03,Straight Party,,,DEMOCRATIC PARTY (D),0,0,663,663
+City & County of Honolulu,51-03,Straight Party,,,INDEPENDENT PARTY (I),0,0,1,1
+City & County of Honolulu,51-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,51-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,1,1
+City & County of Honolulu,51-03,Straight Party,,,REPUBLICAN PARTY (R),0,0,82,82
+City & County of Honolulu,51-03,US Representative,2,I,"STENSHOL, Shaun",0,0,1,1
+City & County of Honolulu,51-03,US Representative,2,D,"HIRONO, Mazie",0,0,423,423
+City & County of Honolulu,51-03,US Representative,2,R,"EVANS, Roger B.",0,0,27,27
+City & County of Honolulu,51-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,51-03,State Representative,51,D,"ANDERSON, J. Ikaika",0,0,340,340
+City & County of Honolulu,51-03,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",0,0,21,21
+City & County of Honolulu,51-03,State Representative,51,D,"LEE, Chris Kalani",0,0,285,285
+City & County of Honolulu,51-03,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",0,0,78,78
+City & County of Honolulu,51-04,Straight Party,,,DEMOCRATIC PARTY (D),0,0,132,132
+City & County of Honolulu,51-04,Straight Party,,,INDEPENDENT PARTY (I),0,0,2,2
+City & County of Honolulu,51-04,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+City & County of Honolulu,51-04,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,51-04,Straight Party,,,REPUBLICAN PARTY (R),0,0,34,34
+City & County of Honolulu,51-04,US Representative,2,I,"STENSHOL, Shaun",0,0,2,2
+City & County of Honolulu,51-04,US Representative,2,D,"HIRONO, Mazie",0,0,102,102
+City & County of Honolulu,51-04,US Representative,2,R,"EVANS, Roger B.",0,0,13,13
+City & County of Honolulu,51-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+City & County of Honolulu,51-04,State Representative,51,D,"ANDERSON, J. Ikaika",0,0,35,35
+City & County of Honolulu,51-04,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",0,0,7,7
+City & County of Honolulu,51-04,State Representative,51,D,"LEE, Chris Kalani",0,0,87,87
+City & County of Honolulu,51-04,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",0,0,32,32
+City & County of Honolulu,51-05,Straight Party,,,DEMOCRATIC PARTY (D),0,0,706,706
+City & County of Honolulu,51-05,Straight Party,,,INDEPENDENT PARTY (I),0,0,4,4
+City & County of Honolulu,51-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,51-05,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,51-05,Straight Party,,,REPUBLICAN PARTY (R),0,0,176,176
+City & County of Honolulu,51-05,US Representative,2,I,"STENSHOL, Shaun",0,0,4,4
+City & County of Honolulu,51-05,US Representative,2,D,"HIRONO, Mazie",0,0,467,467
+City & County of Honolulu,51-05,US Representative,2,R,"EVANS, Roger B.",0,0,62,62
+City & County of Honolulu,51-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,51-05,State Representative,51,D,"ANDERSON, J. Ikaika",0,0,241,241
+City & County of Honolulu,51-05,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",0,0,21,21
+City & County of Honolulu,51-05,State Representative,51,D,"LEE, Chris Kalani",0,0,414,414
+City & County of Honolulu,51-05,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",0,0,170,170
+City & County of Honolulu,51-06,Straight Party,,,DEMOCRATIC PARTY (D),0,0,360,360
+City & County of Honolulu,51-06,Straight Party,,,INDEPENDENT PARTY (I),0,0,3,3
+City & County of Honolulu,51-06,Straight Party,,,LIBERTARIAN PARTY (L),0,0,3,3
+City & County of Honolulu,51-06,Straight Party,,,NONPARTISAN BALLOT (N),0,0,2,2
+City & County of Honolulu,51-06,Straight Party,,,REPUBLICAN PARTY (R),0,0,137,137
+City & County of Honolulu,51-06,US Representative,2,I,"STENSHOL, Shaun",0,0,3,3
+City & County of Honolulu,51-06,US Representative,2,D,"HIRONO, Mazie",0,0,224,224
+City & County of Honolulu,51-06,US Representative,2,R,"EVANS, Roger B.",0,0,60,60
+City & County of Honolulu,51-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,3,3
+City & County of Honolulu,51-06,State Representative,51,D,"ANDERSON, J. Ikaika",0,0,85,85
+City & County of Honolulu,51-06,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",0,0,26,26
+City & County of Honolulu,51-06,State Representative,51,D,"LEE, Chris Kalani",0,0,229,229
+City & County of Honolulu,51-06,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",0,0,129,129
+City & County of Honolulu,51-07,Straight Party,,,DEMOCRATIC PARTY (D),0,0,162,162
+City & County of Honolulu,51-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+City & County of Honolulu,51-07,Straight Party,,,LIBERTARIAN PARTY (L),0,0,1,1
+City & County of Honolulu,51-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,3,3
+City & County of Honolulu,51-07,Straight Party,,,REPUBLICAN PARTY (R),0,0,83,83
+City & County of Honolulu,51-07,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+City & County of Honolulu,51-07,US Representative,2,D,"HIRONO, Mazie",0,0,106,106
+City & County of Honolulu,51-07,US Representative,2,R,"EVANS, Roger B.",0,0,34,34
+City & County of Honolulu,51-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,1,1
+City & County of Honolulu,51-07,State Representative,51,D,"ANDERSON, J. Ikaika",0,0,29,29
+City & County of Honolulu,51-07,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",0,0,6,6
+City & County of Honolulu,51-07,State Representative,51,D,"LEE, Chris Kalani",0,0,109,109
+City & County of Honolulu,51-07,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",0,0,69,69
+,AB-01,Straight Party,,,DEMOCRATIC PARTY (D),174,312,0,486
+,AB-01,Straight Party,,,INDEPENDENT PARTY (I),0,1,0,1
+,AB-01,Straight Party,,,LIBERTARIAN PARTY (L),1,1,0,2
+,AB-01,Straight Party,,,NONPARTISAN BALLOT (N),4,3,0,7
+,AB-01,Straight Party,,,REPUBLICAN PARTY (R),27,27,0,54
+,AB-01,US Representative,2,I,"STENSHOL, Shaun",0,1,0,1
+,AB-01,US Representative,2,D,"HIRONO, Mazie",146,242,0,388
+,AB-01,US Representative,2,R,"EVANS, Roger B.",22,17,0,39
+,AB-01,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,1,0,2
+,AB-01,State Senate,3,D,"ISBELL, Virginia",30,31,0,61
+,AB-01,State Senate,3,D,"GREEN, Josh",137,264,0,401
+,AB-01,State Representative,1,D,"FUJIYAMA, Ken",12,49,0,61
+,AB-01,State Representative,1,D,"KIM, Jo",44,70,0,114
+,AB-01,State Representative,1,D,"NAKASHIMA, Mark M.",84,146,0,230
+,AB-01,State Representative,1,D,"NAKKIM, Lynn (Kalama)",16,11,0,27
+,AB-01,State Representative,1,R,"OFFENBAKER, Steven A.",14,11,0,25
+,AB-01,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",8,8,0,16
+,AB-02,Straight Party,,,DEMOCRATIC PARTY (D),721,460,0,1181
+,AB-02,Straight Party,,,INDEPENDENT PARTY (I),2,2,0,4
+,AB-02,Straight Party,,,LIBERTARIAN PARTY (L),2,1,0,3
+,AB-02,Straight Party,,,NONPARTISAN BALLOT (N),1,5,0,6
+,AB-02,Straight Party,,,REPUBLICAN PARTY (R),75,67,0,142
+,AB-02,US Representative,2,I,"STENSHOL, Shaun",2,2,0,4
+,AB-02,US Representative,2,D,"HIRONO, Mazie",574,360,0,934
+,AB-02,US Representative,2,R,"EVANS, Roger B.",45,44,0,89
+,AB-02,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",2,0,0,2
+,AB-02,State Senate,1,D,"TAKAMINE, Dwight Y.",627,380,0,1007
+,AB-02,State Senate,1,R,"HONG, Ted H.S.",58,62,0,120
+,AB-02,State Representative,1,D,"FUJIYAMA, Ken",75,59,0,134
+,AB-02,State Representative,1,D,"KIM, Jo",144,115,0,259
+,AB-02,State Representative,1,D,"NAKASHIMA, Mark M.",437,230,0,667
+,AB-02,State Representative,1,D,"NAKKIM, Lynn (Kalama)",16,17,0,33
+,AB-02,State Representative,1,R,"OFFENBAKER, Steven A.",37,41,0,78
+,AB-02,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",15,10,0,25
+,AB-03,Straight Party,,,DEMOCRATIC PARTY (D),23,34,0,57
+,AB-03,Straight Party,,,INDEPENDENT PARTY (I),0,1,0,1
+,AB-03,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-03,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-03,Straight Party,,,REPUBLICAN PARTY (R),12,10,0,22
+,AB-03,US Representative,2,I,"STENSHOL, Shaun",0,1,0,1
+,AB-03,US Representative,2,D,"HIRONO, Mazie",20,25,0,45
+,AB-03,US Representative,2,R,"EVANS, Roger B.",8,9,0,17
+,AB-03,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-03,State Senate,1,D,"TAKAMINE, Dwight Y.",17,23,0,40
+,AB-03,State Senate,1,R,"HONG, Ted H.S.",10,9,0,19
+,AB-03,State Representative,1,D,"FUJIYAMA, Ken",3,7,0,10
+,AB-03,State Representative,1,D,"KIM, Jo",3,12,0,15
+,AB-03,State Representative,1,D,"NAKASHIMA, Mark M.",10,8,0,18
+,AB-03,State Representative,1,D,"NAKKIM, Lynn (Kalama)",1,0,0,1
+,AB-03,State Representative,1,R,"OFFENBAKER, Steven A.",6,6,0,12
+,AB-03,State Representative,1,R,"WEINERT, Eric, Jr. (Drake)",5,1,0,6
+,AB-04,Straight Party,,,DEMOCRATIC PARTY (D),726,830,0,1556
+,AB-04,Straight Party,,,INDEPENDENT PARTY (I),5,7,0,12
+,AB-04,Straight Party,,,LIBERTARIAN PARTY (L),3,0,0,3
+,AB-04,Straight Party,,,NONPARTISAN BALLOT (N),7,9,0,16
+,AB-04,Straight Party,,,REPUBLICAN PARTY (R),145,126,0,271
+,AB-04,US Representative,2,I,"STENSHOL, Shaun",3,6,0,9
+,AB-04,US Representative,2,D,"HIRONO, Mazie",575,593,0,1168
+,AB-04,US Representative,2,R,"EVANS, Roger B.",86,57,0,143
+,AB-04,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",2,0,0,2
+,AB-04,State Senate,1,D,"TAKAMINE, Dwight Y.",568,596,0,1164
+,AB-04,State Senate,1,R,"HONG, Ted H.S.",132,118,0,250
+,AB-04,State Representative,2,D,"CHANG, Jerry Leslie",554,603,0,1157
+,AB-05,Straight Party,,,DEMOCRATIC PARTY (D),283,349,0,632
+,AB-05,Straight Party,,,INDEPENDENT PARTY (I),1,6,0,7
+,AB-05,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-05,Straight Party,,,NONPARTISAN BALLOT (N),3,3,0,6
+,AB-05,Straight Party,,,REPUBLICAN PARTY (R),39,52,0,91
+,AB-05,US Representative,2,I,"STENSHOL, Shaun",1,4,0,5
+,AB-05,US Representative,2,D,"HIRONO, Mazie",243,252,0,495
+,AB-05,US Representative,2,R,"EVANS, Roger B.",17,32,0,49
+,AB-05,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-05,State Senate,1,D,"TAKAMINE, Dwight Y.",215,248,0,463
+,AB-05,State Senate,1,R,"HONG, Ted H.S.",36,48,0,84
+,AB-05,State Representative,2,D,"CHANG, Jerry Leslie",215,248,0,463
+,AB-06,Straight Party,,,DEMOCRATIC PARTY (D),854,874,0,1728
+,AB-06,Straight Party,,,INDEPENDENT PARTY (I),5,3,0,8
+,AB-06,Straight Party,,,LIBERTARIAN PARTY (L),3,2,0,5
+,AB-06,Straight Party,,,NONPARTISAN BALLOT (N),5,8,0,13
+,AB-06,Straight Party,,,REPUBLICAN PARTY (R),74,67,0,141
+,AB-06,US Representative,2,I,"STENSHOL, Shaun",5,2,0,7
+,AB-06,US Representative,2,D,"HIRONO, Mazie",725,710,0,1435
+,AB-06,US Representative,2,R,"EVANS, Roger B.",53,48,0,101
+,AB-06,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",3,2,0,5
+,AB-06,State Representative,3,D,"TSUJI, Clifton (Clift)",713,737,0,1450
+,AB-06,State Representative,3,R,"TAVARES, Deirdre (Moana)",54,45,0,99
+,AB-07,Straight Party,,,DEMOCRATIC PARTY (D),67,68,0,135
+,AB-07,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-07,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-07,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-07,Straight Party,,,REPUBLICAN PARTY (R),6,3,0,9
+,AB-07,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+,AB-07,US Representative,2,D,"HIRONO, Mazie",59,57,0,116
+,AB-07,US Representative,2,R,"EVANS, Roger B.",4,2,0,6
+,AB-07,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,0,0,1
+,AB-07,State Representative,3,D,"TSUJI, Clifton (Clift)",55,61,0,116
+,AB-07,State Representative,3,R,"TAVARES, Deirdre (Moana)",5,3,0,8
+,AB-08,Straight Party,,,DEMOCRATIC PARTY (D),61,69,0,130
+,AB-08,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-08,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-08,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-08,Straight Party,,,REPUBLICAN PARTY (R),2,12,0,14
+,AB-08,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+,AB-08,US Representative,2,D,"HIRONO, Mazie",52,56,0,108
+,AB-08,US Representative,2,R,"EVANS, Roger B.",1,7,0,8
+,AB-08,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-08,State Senate,1,D,"TAKAMINE, Dwight Y.",51,47,0,98
+,AB-08,State Senate,1,R,"HONG, Ted H.S.",2,7,0,9
+,AB-08,State Representative,3,D,"TSUJI, Clifton (Clift)",51,57,0,108
+,AB-08,State Representative,3,R,"TAVARES, Deirdre (Moana)",1,5,0,6
+,AB-09,Straight Party,,,DEMOCRATIC PARTY (D),273,361,0,634
+,AB-09,Straight Party,,,INDEPENDENT PARTY (I),1,3,0,4
+,AB-09,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-09,Straight Party,,,NONPARTISAN BALLOT (N),1,6,0,7
+,AB-09,Straight Party,,,REPUBLICAN PARTY (R),38,32,0,70
+,AB-09,US Representative,2,I,"STENSHOL, Shaun",1,3,0,4
+,AB-09,US Representative,2,D,"HIRONO, Mazie",226,282,0,508
+,AB-09,US Representative,2,R,"EVANS, Roger B.",21,16,0,37
+,AB-09,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-09,State Senate,1,D,"TAKAMINE, Dwight Y.",219,276,0,495
+,AB-09,State Senate,1,R,"HONG, Ted H.S.",33,26,0,59
+,AB-09,State Representative,3,D,"TSUJI, Clifton (Clift)",214,283,0,497
+,AB-09,State Representative,3,R,"TAVARES, Deirdre (Moana)",15,14,0,29
+,AB-10,Straight Party,,,DEMOCRATIC PARTY (D),180,225,0,405
+,AB-10,Straight Party,,,INDEPENDENT PARTY (I),2,0,0,2
+,AB-10,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-10,Straight Party,,,NONPARTISAN BALLOT (N),0,4,0,4
+,AB-10,Straight Party,,,REPUBLICAN PARTY (R),15,12,0,27
+,AB-10,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+,AB-10,US Representative,2,D,"HIRONO, Mazie",152,180,0,332
+,AB-10,US Representative,2,R,"EVANS, Roger B.",11,7,0,18
+,AB-10,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,0,0,1
+,AB-10,State Representative,3,D,"TSUJI, Clifton (Clift)",156,170,0,326
+,AB-10,State Representative,3,R,"TAVARES, Deirdre (Moana)",7,6,0,13
+,AB-11,Straight Party,,,DEMOCRATIC PARTY (D),59,89,0,148
+,AB-11,Straight Party,,,INDEPENDENT PARTY (I),1,3,0,4
+,AB-11,Straight Party,,,LIBERTARIAN PARTY (L),0,1,0,1
+,AB-11,Straight Party,,,NONPARTISAN BALLOT (N),6,4,0,10
+,AB-11,Straight Party,,,REPUBLICAN PARTY (R),10,17,0,27
+,AB-11,US Representative,2,I,"STENSHOL, Shaun",1,3,0,4
+,AB-11,US Representative,2,D,"HIRONO, Mazie",47,78,0,125
+,AB-11,US Representative,2,R,"EVANS, Roger B.",8,10,0,18
+,AB-11,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,1,0,1
+,AB-11,State Representative,4,D,"HANOHANO, Faye P.",28,37,0,65
+,AB-11,State Representative,4,D,"MARZI, Anthony (Tony)",10,17,0,27
+,AB-11,State Representative,4,D,"SPARKS, Steven B.",7,27,0,34
+,AB-11,State Representative,4,R,"BLAS, Fred",9,12,0,21
+,AB-12,Straight Party,,,DEMOCRATIC PARTY (D),73,73,0,146
+,AB-12,Straight Party,,,INDEPENDENT PARTY (I),1,2,0,3
+,AB-12,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-12,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-12,Straight Party,,,REPUBLICAN PARTY (R),15,13,0,28
+,AB-12,US Representative,2,I,"STENSHOL, Shaun",1,2,0,3
+,AB-12,US Representative,2,D,"HIRONO, Mazie",60,59,0,119
+,AB-12,US Representative,2,R,"EVANS, Roger B.",13,9,0,22
+,AB-12,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,0,0,1
+,AB-12,State Representative,4,D,"HANOHANO, Faye P.",30,41,0,71
+,AB-12,State Representative,4,D,"MARZI, Anthony (Tony)",13,14,0,27
+,AB-12,State Representative,4,D,"SPARKS, Steven B.",19,5,0,24
+,AB-12,State Representative,4,R,"BLAS, Fred",14,11,0,25
+,AB-13,Straight Party,,,DEMOCRATIC PARTY (D),472,637,0,1109
+,AB-13,Straight Party,,,INDEPENDENT PARTY (I),8,11,0,19
+,AB-13,Straight Party,,,LIBERTARIAN PARTY (L),1,2,0,3
+,AB-13,Straight Party,,,NONPARTISAN BALLOT (N),6,12,0,18
+,AB-13,Straight Party,,,REPUBLICAN PARTY (R),125,145,0,270
+,AB-13,US Representative,2,I,"STENSHOL, Shaun",8,9,0,17
+,AB-13,US Representative,2,D,"HIRONO, Mazie",356,460,0,816
+,AB-13,US Representative,2,R,"EVANS, Roger B.",84,78,0,162
+,AB-13,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,2,0,3
+,AB-13,State Representative,4,D,"HANOHANO, Faye P.",226,278,0,504
+,AB-13,State Representative,4,D,"MARZI, Anthony (Tony)",140,211,0,351
+,AB-13,State Representative,4,D,"SPARKS, Steven B.",60,100,0,160
+,AB-13,State Representative,4,R,"BLAS, Fred",93,114,0,207
+,AB-14,Straight Party,,,DEMOCRATIC PARTY (D),31,27,0,58
+,AB-14,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-14,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-14,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-14,Straight Party,,,REPUBLICAN PARTY (R),7,8,0,15
+,AB-14,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+,AB-14,US Representative,2,D,"HIRONO, Mazie",26,23,0,49
+,AB-14,US Representative,2,R,"EVANS, Roger B.",7,7,0,14
+,AB-14,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-14,State Representative,5,D,"HERKES, Robert (Bob)",24,19,0,43
+,AB-15,Straight Party,,,DEMOCRATIC PARTY (D),337,439,0,776
+,AB-15,Straight Party,,,INDEPENDENT PARTY (I),13,11,0,24
+,AB-15,Straight Party,,,LIBERTARIAN PARTY (L),6,3,0,9
+,AB-15,Straight Party,,,NONPARTISAN BALLOT (N),7,12,0,19
+,AB-15,Straight Party,,,REPUBLICAN PARTY (R),37,71,0,108
+,AB-15,US Representative,2,I,"STENSHOL, Shaun",11,9,0,20
+,AB-15,US Representative,2,D,"HIRONO, Mazie",280,356,0,636
+,AB-15,US Representative,2,R,"EVANS, Roger B.",34,65,0,99
+,AB-15,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",6,3,0,9
+,AB-15,State Representative,5,D,"HERKES, Robert (Bob)",233,287,0,520
+,AB-16,Straight Party,,,DEMOCRATIC PARTY (D),110,64,0,174
+,AB-16,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-16,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-16,Straight Party,,,NONPARTISAN BALLOT (N),7,0,0,7
+,AB-16,Straight Party,,,REPUBLICAN PARTY (R),12,1,0,13
+,AB-16,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+,AB-16,US Representative,2,D,"HIRONO, Mazie",82,49,0,131
+,AB-16,US Representative,2,R,"EVANS, Roger B.",11,1,0,12
+,AB-16,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-16,State Senate,3,D,"ISBELL, Virginia",29,19,0,48
+,AB-16,State Senate,3,D,"GREEN, Josh",78,43,0,121
+,AB-16,State Representative,5,D,"HERKES, Robert (Bob)",73,41,0,114
+,AB-17,Straight Party,,,DEMOCRATIC PARTY (D),256,203,0,459
+,AB-17,Straight Party,,,INDEPENDENT PARTY (I),5,2,0,7
+,AB-17,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-17,Straight Party,,,NONPARTISAN BALLOT (N),2,2,0,4
+,AB-17,Straight Party,,,REPUBLICAN PARTY (R),23,27,0,50
+,AB-17,US Representative,2,I,"STENSHOL, Shaun",4,1,0,5
+,AB-17,US Representative,2,D,"HIRONO, Mazie",201,156,0,357
+,AB-17,US Representative,2,R,"EVANS, Roger B.",21,23,0,44
+,AB-17,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-17,State Senate,3,D,"ISBELL, Virginia",89,63,0,152
+,AB-17,State Senate,3,D,"GREEN, Josh",153,129,0,282
+,AB-17,State Representative,5,D,"HERKES, Robert (Bob)",174,134,0,308
+,AB-18,Straight Party,,,DEMOCRATIC PARTY (D),274,471,0,745
+,AB-18,Straight Party,,,INDEPENDENT PARTY (I),3,4,0,7
+,AB-18,Straight Party,,,LIBERTARIAN PARTY (L),0,2,0,2
+,AB-18,Straight Party,,,NONPARTISAN BALLOT (N),4,10,0,14
+,AB-18,Straight Party,,,REPUBLICAN PARTY (R),107,122,0,229
+,AB-18,US Representative,2,I,"STENSHOL, Shaun",2,3,0,5
+,AB-18,US Representative,2,D,"HIRONO, Mazie",189,345,0,534
+,AB-18,US Representative,2,R,"EVANS, Roger B.",74,70,0,144
+,AB-18,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,2,0,2
+,AB-18,State Senate,3,D,"ISBELL, Virginia",46,49,0,95
+,AB-18,State Senate,3,D,"GREEN, Josh",220,408,0,628
+,AB-18,State Representative,6,D,"COFFMAN, Denny",102,232,0,334
+,AB-18,State Representative,6,D,"LESLIE, Gene (Bucky)",80,108,0,188
+,AB-18,State Representative,6,D,"MACGREGOR, Maegan",37,63,0,100
+,AB-18,State Representative,6,R,"SMITH, Andy",100,108,0,208
+,AB-19,Straight Party,,,DEMOCRATIC PARTY (D),215,351,0,566
+,AB-19,Straight Party,,,INDEPENDENT PARTY (I),0,2,0,2
+,AB-19,Straight Party,,,LIBERTARIAN PARTY (L),1,1,0,2
+,AB-19,Straight Party,,,NONPARTISAN BALLOT (N),0,9,0,9
+,AB-19,Straight Party,,,REPUBLICAN PARTY (R),81,91,0,172
+,AB-19,US Representative,2,I,"STENSHOL, Shaun",0,2,0,2
+,AB-19,US Representative,2,D,"HIRONO, Mazie",150,267,0,417
+,AB-19,US Representative,2,R,"EVANS, Roger B.",54,61,0,115
+,AB-19,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,1,0,2
+,AB-19,State Senate,3,D,"ISBELL, Virginia",48,63,0,111
+,AB-19,State Senate,3,D,"GREEN, Josh",161,276,0,437
+,AB-19,State Representative,6,D,"COFFMAN, Denny",69,153,0,222
+,AB-19,State Representative,6,D,"LESLIE, Gene (Bucky)",40,95,0,135
+,AB-19,State Representative,6,D,"MACGREGOR, Maegan",45,52,0,97
+,AB-19,State Representative,6,R,"SMITH, Andy",74,81,0,155
+,AB-20,Straight Party,,,DEMOCRATIC PARTY (D),183,307,0,490
+,AB-20,Straight Party,,,INDEPENDENT PARTY (I),2,0,0,2
+,AB-20,Straight Party,,,LIBERTARIAN PARTY (L),1,1,0,2
+,AB-20,Straight Party,,,NONPARTISAN BALLOT (N),4,3,0,7
+,AB-20,Straight Party,,,REPUBLICAN PARTY (R),50,56,0,106
+,AB-20,US Representative,2,I,"STENSHOL, Shaun",2,0,0,2
+,AB-20,US Representative,2,D,"HIRONO, Mazie",121,222,0,343
+,AB-20,US Representative,2,R,"EVANS, Roger B.",48,43,0,91
+,AB-20,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,1,0,2
+,AB-20,State Senate,3,D,"ISBELL, Virginia",34,62,0,96
+,AB-20,State Senate,3,D,"GREEN, Josh",136,234,0,370
+,AB-20,State Representative,7,D,"EVANS, Cindy",117,238,0,355
+,AB-20,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",27,24,0,51
+,AB-20,State Representative,7,R,"KAILIMAI, B.J.",10,21,0,31
+,AB-21,Straight Party,,,DEMOCRATIC PARTY (D),107,90,0,197
+,AB-21,Straight Party,,,INDEPENDENT PARTY (I),2,0,0,2
+,AB-21,Straight Party,,,LIBERTARIAN PARTY (L),3,1,0,4
+,AB-21,Straight Party,,,NONPARTISAN BALLOT (N),3,0,0,3
+,AB-21,Straight Party,,,REPUBLICAN PARTY (R),35,24,0,59
+,AB-21,US Representative,2,I,"STENSHOL, Shaun",2,0,0,2
+,AB-21,US Representative,2,D,"HIRONO, Mazie",75,73,0,148
+,AB-21,US Representative,2,R,"EVANS, Roger B.",32,19,0,51
+,AB-21,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",3,1,0,4
+,AB-21,State Senate,3,D,"ISBELL, Virginia",22,27,0,49
+,AB-21,State Senate,3,D,"GREEN, Josh",74,60,0,134
+,AB-21,State Representative,7,D,"EVANS, Cindy",89,78,0,167
+,AB-21,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",22,13,0,35
+,AB-21,State Representative,7,R,"KAILIMAI, B.J.",5,9,0,14
+,AB-22,Straight Party,,,DEMOCRATIC PARTY (D),125,452,0,577
+,AB-22,Straight Party,,,INDEPENDENT PARTY (I),4,1,0,5
+,AB-22,Straight Party,,,LIBERTARIAN PARTY (L),0,2,0,2
+,AB-22,Straight Party,,,NONPARTISAN BALLOT (N),1,2,0,3
+,AB-22,Straight Party,,,REPUBLICAN PARTY (R),37,131,0,168
+,AB-22,US Representative,2,I,"STENSHOL, Shaun",4,0,0,4
+,AB-22,US Representative,2,D,"HIRONO, Mazie",98,331,0,429
+,AB-22,US Representative,2,R,"EVANS, Roger B.",23,86,0,109
+,AB-22,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,2,0,2
+,AB-22,State Senate,1,D,"TAKAMINE, Dwight Y.",103,345,0,448
+,AB-22,State Senate,1,R,"HONG, Ted H.S.",33,104,0,137
+,AB-22,State Representative,7,D,"EVANS, Cindy",95,322,0,417
+,AB-22,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",17,63,0,80
+,AB-22,State Representative,7,R,"KAILIMAI, B.J.",11,51,0,62
+,AB-23,Straight Party,,,DEMOCRATIC PARTY (D),33,85,0,118
+,AB-23,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-23,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-23,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-23,Straight Party,,,REPUBLICAN PARTY (R),18,19,0,37
+,AB-23,US Representative,2,I,"STENSHOL, Shaun",0,0,0,0
+,AB-23,US Representative,2,D,"HIRONO, Mazie",24,61,0,85
+,AB-23,US Representative,2,R,"EVANS, Roger B.",10,12,0,22
+,AB-23,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-23,State Senate,1,D,"TAKAMINE, Dwight Y.",28,64,0,92
+,AB-23,State Senate,1,R,"HONG, Ted H.S.",13,11,0,24
+,AB-23,State Representative,7,D,"EVANS, Cindy",22,61,0,83
+,AB-23,State Representative,7,R,"DELA CRUZ, Ronald (Makaula)",5,12,0,17
+,AB-23,State Representative,7,R,"KAILIMAI, B.J.",7,3,0,10
+,AB-24,Straight Party,,,DEMOCRATIC PARTY (D),1077,560,0,1637
+,AB-24,Straight Party,,,INDEPENDENT PARTY (I),7,9,0,16
+,AB-24,Straight Party,,,LIBERTARIAN PARTY (L),3,1,0,4
+,AB-24,Straight Party,,,NONPARTISAN BALLOT (N),6,3,0,9
+,AB-24,Straight Party,,,REPUBLICAN PARTY (R),82,62,0,144
+,AB-24,US Representative,2,I,"STENSHOL, Shaun",7,8,0,15
+,AB-24,US Representative,2,D,"HIRONO, Mazie",888,470,0,1358
+,AB-24,US Representative,2,R,"EVANS, Roger B.",75,56,0,131
+,AB-24,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",3,1,0,4
+,AB-24,State Representative,8,D,"KAMA, Tasha",360,200,0,560
+,AB-24,State Representative,8,D,"SOUKI, Joe",648,331,0,979
+,AB-25,Straight Party,,,DEMOCRATIC PARTY (D),1034,367,0,1401
+,AB-25,Straight Party,,,INDEPENDENT PARTY (I),6,2,0,8
+,AB-25,Straight Party,,,LIBERTARIAN PARTY (L),3,0,0,3
+,AB-25,Straight Party,,,NONPARTISAN BALLOT (N),4,1,0,5
+,AB-25,Straight Party,,,REPUBLICAN PARTY (R),84,47,0,131
+,AB-25,US Representative,2,I,"STENSHOL, Shaun",4,1,0,5
+,AB-25,US Representative,2,D,"HIRONO, Mazie",925,318,0,1243
+,AB-25,US Representative,2,R,"EVANS, Roger B.",57,31,0,88
+,AB-25,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",3,0,0,3
+,AB-25,State Representative,9,D,"NAKASONE, Bob",799,288,0,1087
+,AB-25,State Representative,9,R,"KAHULA, Henry P., Jr.",55,36,0,91
+,AB-26,Straight Party,,,DEMOCRATIC PARTY (D),332,234,0,566
+,AB-26,Straight Party,,,INDEPENDENT PARTY (I),9,4,0,13
+,AB-26,Straight Party,,,LIBERTARIAN PARTY (L),2,0,0,2
+,AB-26,Straight Party,,,NONPARTISAN BALLOT (N),4,2,0,6
+,AB-26,Straight Party,,,REPUBLICAN PARTY (R),104,63,0,167
+,AB-26,US Representative,2,I,"STENSHOL, Shaun",7,3,0,10
+,AB-26,US Representative,2,D,"HIRONO, Mazie",272,167,0,439
+,AB-26,US Representative,2,R,"EVANS, Roger B.",50,42,0,92
+,AB-26,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,0,0,1
+,AB-26,State Senate,5,D,"BAKER, Roz",253,157,0,410
+,AB-26,State Senate,5,D,"MULVIHILL, Bart",63,63,0,126
+,AB-26,State Senate,5,R,"SHIELDS, Jan",93,56,0,149
+,AB-26,State Representative,10,D,"MCKELVEY, Angus",260,194,0,454
+,AB-26,State Representative,10,R,"MADDEN, Ramon K.",51,45,0,96
+,AB-27,Straight Party,,,DEMOCRATIC PARTY (D),366,159,0,525
+,AB-27,Straight Party,,,INDEPENDENT PARTY (I),11,2,0,13
+,AB-27,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-27,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-27,Straight Party,,,REPUBLICAN PARTY (R),214,56,0,270
+,AB-27,US Representative,2,I,"STENSHOL, Shaun",8,1,0,9
+,AB-27,US Representative,2,D,"HIRONO, Mazie",287,113,0,400
+,AB-27,US Representative,2,R,"EVANS, Roger B.",134,24,0,158
+,AB-27,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,0,0,1
+,AB-27,State Senate,5,D,"BAKER, Roz",218,93,0,311
+,AB-27,State Senate,5,D,"MULVIHILL, Bart",110,53,0,163
+,AB-27,State Senate,5,R,"SHIELDS, Jan",183,44,0,227
+,AB-27,State Representative,11,D,"GINGERICH, Michael",97,46,0,143
+,AB-27,State Representative,11,D,"BERTRAM, Joe, III",234,100,0,334
+,AB-27,State Representative,11,R,"FONTAINE, George R.",164,33,0,197
+,AB-28,Straight Party,,,DEMOCRATIC PARTY (D),1051,381,0,1432
+,AB-28,Straight Party,,,INDEPENDENT PARTY (I),9,5,0,14
+,AB-28,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-28,Straight Party,,,NONPARTISAN BALLOT (N),7,1,0,8
+,AB-28,Straight Party,,,REPUBLICAN PARTY (R),150,37,0,187
+,AB-28,US Representative,2,I,"STENSHOL, Shaun",3,3,0,6
+,AB-28,US Representative,2,D,"HIRONO, Mazie",820,292,0,1112
+,AB-28,US Representative,2,R,"EVANS, Roger B.",79,15,0,94
+,AB-28,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-28,State Senate,6,I,"BLUMER-BUELL, John",6,2,0,8
+,AB-28,State Senate,6,D,"ENGLISH, J. Kalani",755,272,0,1027
+,AB-28,State Representative,12,D,"YAMASHITA, Kyle",770,250,0,1020
+,AB-28,State Representative,12,D,"STARR, Summer",235,118,0,353
+,AB-28,State Representative,12,R,"VIERRA, Mickey",127,25,0,152
+,AB-29,Straight Party,,,DEMOCRATIC PARTY (D),488,438,0,926
+,AB-29,Straight Party,,,INDEPENDENT PARTY (I),23,10,0,33
+,AB-29,Straight Party,,,LIBERTARIAN PARTY (L),0,1,0,1
+,AB-29,Straight Party,,,NONPARTISAN BALLOT (N),9,4,0,13
+,AB-29,Straight Party,,,REPUBLICAN PARTY (R),65,60,0,125
+,AB-29,US Representative,2,I,"STENSHOL, Shaun",9,5,0,14
+,AB-29,US Representative,2,D,"HIRONO, Mazie",379,340,0,719
+,AB-29,US Representative,2,R,"EVANS, Roger B.",57,57,0,114
+,AB-29,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,1,0,1
+,AB-29,State Senate,6,I,"BLUMER-BUELL, John",20,9,0,29
+,AB-29,State Senate,6,D,"ENGLISH, J. Kalani",340,333,0,673
+,AB-29,State Representative,13,D,"CARROLL, Mele",352,334,0,686
+,AB-30,Straight Party,,,DEMOCRATIC PARTY (D),13,0,0,13
+,AB-30,Straight Party,,,INDEPENDENT PARTY (I),2,0,0,2
+,AB-30,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-30,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-30,Straight Party,,,REPUBLICAN PARTY (R),3,0,0,3
+,AB-30,US Representative,2,I,"STENSHOL, Shaun",2,0,0,2
+,AB-30,US Representative,2,D,"HIRONO, Mazie",11,0,0,11
+,AB-30,US Representative,2,R,"EVANS, Roger B.",3,0,0,3
+,AB-30,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-30,State Senate,6,I,"BLUMER-BUELL, John",2,0,0,2
+,AB-30,State Senate,6,D,"ENGLISH, J. Kalani",9,0,0,9
+,AB-30,State Representative,13,D,"CARROLL, Mele",8,0,0,8
+,AB-31,Straight Party,,,DEMOCRATIC PARTY (D),1291,610,0,1901
+,AB-31,Straight Party,,,INDEPENDENT PARTY (I),15,4,0,19
+,AB-31,Straight Party,,,LIBERTARIAN PARTY (L),8,1,0,9
+,AB-31,Straight Party,,,NONPARTISAN BALLOT (N),20,6,0,26
+,AB-31,Straight Party,,,REPUBLICAN PARTY (R),212,86,0,298
+,AB-31,US Representative,2,I,"STENSHOL, Shaun",11,2,0,13
+,AB-31,US Representative,2,D,"HIRONO, Mazie",942,408,0,1350
+,AB-31,US Representative,2,R,"EVANS, Roger B.",146,51,0,197
+,AB-31,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",8,1,0,9
+,AB-31,State Senate,7,D,"HOOSER, Gary L.",901,424,0,1325
+,AB-31,State Senate,7,R,"GEORGI, JoAnne S.",171,63,0,234
+,AB-31,State Representative,14,D,"MORITA, Hermina (Mina)",838,368,0,1206
+,AB-32,Straight Party,,,DEMOCRATIC PARTY (D),1692,1167,0,2859
+,AB-32,Straight Party,,,INDEPENDENT PARTY (I),13,12,0,25
+,AB-32,Straight Party,,,LIBERTARIAN PARTY (L),7,6,0,13
+,AB-32,Straight Party,,,NONPARTISAN BALLOT (N),25,13,0,38
+,AB-32,Straight Party,,,REPUBLICAN PARTY (R),260,133,0,393
+,AB-32,US Representative,2,I,"STENSHOL, Shaun",10,4,0,14
+,AB-32,US Representative,2,D,"HIRONO, Mazie",1260,826,0,2086
+,AB-32,US Representative,2,R,"EVANS, Roger B.",178,64,0,242
+,AB-32,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",7,6,0,13
+,AB-32,State Senate,7,D,"HOOSER, Gary L.",1146,784,0,1930
+,AB-32,State Senate,7,R,"GEORGI, JoAnne S.",210,85,0,295
+,AB-32,State Representative,15,D,"TOKIOKA, James Kunane",1083,737,0,1820
+,AB-33,Straight Party,,,DEMOCRATIC PARTY (D),1327,583,0,1910
+,AB-33,Straight Party,,,INDEPENDENT PARTY (I),14,8,0,22
+,AB-33,Straight Party,,,LIBERTARIAN PARTY (L),2,3,0,5
+,AB-33,Straight Party,,,NONPARTISAN BALLOT (N),16,5,0,21
+,AB-33,Straight Party,,,REPUBLICAN PARTY (R),178,84,0,262
+,AB-33,US Representative,2,I,"STENSHOL, Shaun",9,5,0,14
+,AB-33,US Representative,2,D,"HIRONO, Mazie",954,400,0,1354
+,AB-33,US Representative,2,R,"EVANS, Roger B.",124,35,0,159
+,AB-33,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",2,3,0,5
+,AB-33,State Senate,7,D,"HOOSER, Gary L.",826,362,0,1188
+,AB-33,State Senate,7,R,"GEORGI, JoAnne S.",138,59,0,197
+,AB-33,State Representative,16,D,"SAGUM, Roland D., III",778,351,0,1129
+,AB-34,Straight Party,,,DEMOCRATIC PARTY (D),1624,305,0,1929
+,AB-34,Straight Party,,,INDEPENDENT PARTY (I),20,4,0,24
+,AB-34,Straight Party,,,LIBERTARIAN PARTY (L),9,1,0,10
+,AB-34,Straight Party,,,NONPARTISAN BALLOT (N),21,4,0,25
+,AB-34,Straight Party,,,REPUBLICAN PARTY (R),787,99,0,886
+,AB-34,US Representative,1,D,"ABERCROMBIE, Neil",1304,246,0,1550
+,AB-34,US Representative,1,R,"TATAII, Steve",318,49,0,367
+,AB-34,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",3,1,0,4
+,AB-34,US Representative,1,L,"ZHAO, Li",6,0,0,6
+,AB-34,State Representative,17,D,"MONK, Amy Yukiko",1030,223,0,1253
+,AB-34,State Representative,17,R,"WARD, Gene",754,97,0,851
+,AB-35,Straight Party,,,DEMOCRATIC PARTY (D),1606,289,0,1895
+,AB-35,Straight Party,,,INDEPENDENT PARTY (I),21,5,0,26
+,AB-35,Straight Party,,,LIBERTARIAN PARTY (L),13,1,0,14
+,AB-35,Straight Party,,,NONPARTISAN BALLOT (N),30,3,0,33
+,AB-35,Straight Party,,,REPUBLICAN PARTY (R),422,61,0,483
+,AB-35,US Representative,1,D,"ABERCROMBIE, Neil",1239,227,0,1466
+,AB-35,US Representative,1,R,"TATAII, Steve",370,55,0,425
+,AB-35,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",4,0,0,4
+,AB-35,US Representative,1,L,"ZHAO, Li",9,1,0,10
+,AB-35,State Representative,18,D,"BERG, Lyla B.",1137,212,0,1349
+,AB-36,Straight Party,,,DEMOCRATIC PARTY (D),1357,257,0,1614
+,AB-36,Straight Party,,,INDEPENDENT PARTY (I),7,0,0,7
+,AB-36,Straight Party,,,LIBERTARIAN PARTY (L),8,3,0,11
+,AB-36,Straight Party,,,NONPARTISAN BALLOT (N),18,2,0,20
+,AB-36,Straight Party,,,REPUBLICAN PARTY (R),664,76,0,740
+,AB-36,US Representative,1,D,"ABERCROMBIE, Neil",1095,212,0,1307
+,AB-36,US Representative,1,R,"TATAII, Steve",226,24,0,250
+,AB-36,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",2,2,0,4
+,AB-36,US Representative,1,L,"ZHAO, Li",5,1,0,6
+,AB-36,State Representative,19,D,"ABE, Michael (Mike)",836,155,0,991
+,AB-36,State Representative,19,R,"MARUMOTO, Barbara C.",638,68,0,706
+,AB-37,Straight Party,,,DEMOCRATIC PARTY (D),163,19,0,182
+,AB-37,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-37,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-37,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-37,Straight Party,,,REPUBLICAN PARTY (R),51,10,0,61
+,AB-37,US Representative,1,D,"ABERCROMBIE, Neil",128,16,0,144
+,AB-37,US Representative,1,R,"TATAII, Steve",15,4,0,19
+,AB-37,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-37,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-37,State Representative,19,D,"ABE, Michael (Mike)",105,11,0,116
+,AB-37,State Representative,19,R,"MARUMOTO, Barbara C.",49,8,0,57
+,AB-38,Straight Party,,,DEMOCRATIC PARTY (D),1112,218,0,1330
+,AB-38,Straight Party,,,INDEPENDENT PARTY (I),4,0,0,4
+,AB-38,Straight Party,,,LIBERTARIAN PARTY (L),6,1,0,7
+,AB-38,Straight Party,,,NONPARTISAN BALLOT (N),12,2,0,14
+,AB-38,Straight Party,,,REPUBLICAN PARTY (R),148,30,0,178
+,AB-38,US Representative,1,D,"ABERCROMBIE, Neil",901,169,0,1070
+,AB-38,US Representative,1,R,"TATAII, Steve",103,25,0,128
+,AB-38,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",2,1,0,3
+,AB-38,US Representative,1,L,"ZHAO, Li",4,0,0,4
+,AB-38,State Representative,20,D,"SAY, Calvin K. Y.",976,189,0,1165
+,AB-38,State Representative,20,R,"ALLEN, Julia E.",131,26,0,157
+,AB-39,Straight Party,,,DEMOCRATIC PARTY (D),420,79,0,499
+,AB-39,Straight Party,,,INDEPENDENT PARTY (I),2,2,0,4
+,AB-39,Straight Party,,,LIBERTARIAN PARTY (L),4,1,0,5
+,AB-39,Straight Party,,,NONPARTISAN BALLOT (N),3,3,0,6
+,AB-39,Straight Party,,,REPUBLICAN PARTY (R),89,20,0,109
+,AB-39,US Representative,1,D,"ABERCROMBIE, Neil",345,65,0,410
+,AB-39,US Representative,1,R,"TATAII, Steve",53,14,0,67
+,AB-39,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",3,0,0,3
+,AB-39,US Representative,1,L,"ZHAO, Li",0,1,0,1
+,AB-39,State Representative,20,D,"SAY, Calvin K. Y.",315,64,0,379
+,AB-39,State Representative,20,R,"ALLEN, Julia E.",76,17,0,93
+,AB-40,Straight Party,,,DEMOCRATIC PARTY (D),936,202,0,1138
+,AB-40,Straight Party,,,INDEPENDENT PARTY (I),5,2,0,7
+,AB-40,Straight Party,,,LIBERTARIAN PARTY (L),8,1,0,9
+,AB-40,Straight Party,,,NONPARTISAN BALLOT (N),8,1,0,9
+,AB-40,Straight Party,,,REPUBLICAN PARTY (R),125,30,0,155
+,AB-40,US Representative,1,D,"ABERCROMBIE, Neil",735,160,0,895
+,AB-40,US Representative,1,R,"TATAII, Steve",113,28,0,141
+,AB-40,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",3,0,0,3
+,AB-40,US Representative,1,L,"ZHAO, Li",5,1,0,6
+,AB-40,State Representative,21,D,"NISHIMOTO, Scott Y.",773,168,0,941
+,AB-41,Straight Party,,,DEMOCRATIC PARTY (D),98,17,0,115
+,AB-41,Straight Party,,,INDEPENDENT PARTY (I),1,1,0,2
+,AB-41,Straight Party,,,LIBERTARIAN PARTY (L),6,1,0,7
+,AB-41,Straight Party,,,NONPARTISAN BALLOT (N),2,1,0,3
+,AB-41,Straight Party,,,REPUBLICAN PARTY (R),60,5,0,65
+,AB-41,US Representative,1,D,"ABERCROMBIE, Neil",69,14,0,83
+,AB-41,US Representative,1,R,"TATAII, Steve",55,5,0,60
+,AB-41,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",6,0,0,6
+,AB-41,US Representative,1,L,"ZHAO, Li",0,1,0,1
+,AB-41,State Representative,21,D,"NISHIMOTO, Scott Y.",64,13,0,77
+,AB-42,Straight Party,,,DEMOCRATIC PARTY (D),128,36,0,164
+,AB-42,Straight Party,,,INDEPENDENT PARTY (I),3,1,0,4
+,AB-42,Straight Party,,,LIBERTARIAN PARTY (L),4,0,0,4
+,AB-42,Straight Party,,,NONPARTISAN BALLOT (N),3,0,0,3
+,AB-42,Straight Party,,,REPUBLICAN PARTY (R),62,15,0,77
+,AB-42,US Representative,1,D,"ABERCROMBIE, Neil",113,32,0,145
+,AB-42,US Representative,1,R,"TATAII, Steve",43,13,0,56
+,AB-42,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-42,US Representative,1,L,"ZHAO, Li",3,0,0,3
+,AB-42,State Senate,12,D,"GALUTERIA, Brickwood M.",76,16,0,92
+,AB-42,State Senate,12,D,"MIDDLETON, Carlton N.",30,14,0,44
+,AB-42,State Senate,12,R,"TRIMBLE, Gordon",58,13,0,71
+,AB-42,State Representative,21,D,"NISHIMOTO, Scott Y.",103,32,0,135
+,AB-43,Straight Party,,,DEMOCRATIC PARTY (D),1042,239,0,1281
+,AB-43,Straight Party,,,INDEPENDENT PARTY (I),11,4,0,15
+,AB-43,Straight Party,,,LIBERTARIAN PARTY (L),11,0,0,11
+,AB-43,Straight Party,,,NONPARTISAN BALLOT (N),12,2,0,14
+,AB-43,Straight Party,,,REPUBLICAN PARTY (R),189,30,0,219
+,AB-43,US Representative,1,D,"ABERCROMBIE, Neil",861,185,0,1046
+,AB-43,US Representative,1,R,"TATAII, Steve",171,24,0,195
+,AB-43,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",4,0,0,4
+,AB-43,US Representative,1,L,"ZHAO, Li",6,0,0,6
+,AB-43,State Representative,22,D,"SAIKI, Scott K.",787,173,0,960
+,AB-44,Straight Party,,,DEMOCRATIC PARTY (D),909,300,0,1209
+,AB-44,Straight Party,,,INDEPENDENT PARTY (I),29,1,0,30
+,AB-44,Straight Party,,,LIBERTARIAN PARTY (L),17,1,0,18
+,AB-44,Straight Party,,,NONPARTISAN BALLOT (N),22,3,0,25
+,AB-44,Straight Party,,,REPUBLICAN PARTY (R),467,107,0,574
+,AB-44,US Representative,1,D,"ABERCROMBIE, Neil",792,245,0,1037
+,AB-44,US Representative,1,R,"TATAII, Steve",299,57,0,356
+,AB-44,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",6,1,0,7
+,AB-44,US Representative,1,L,"ZHAO, Li",9,0,0,9
+,AB-44,State Senate,12,D,"GALUTERIA, Brickwood M.",490,184,0,674
+,AB-44,State Senate,12,D,"MIDDLETON, Carlton N.",194,51,0,245
+,AB-44,State Senate,12,R,"TRIMBLE, Gordon",373,86,0,459
+,AB-44,State Representative,23,D,"BROWER, Tom",635,198,0,833
+,AB-44,State Representative,23,R,"STEVENS, Anne V.",389,81,0,470
+,AB-45,Straight Party,,,DEMOCRATIC PARTY (D),1705,375,0,2080
+,AB-45,Straight Party,,,INDEPENDENT PARTY (I),10,3,0,13
+,AB-45,Straight Party,,,LIBERTARIAN PARTY (L),16,2,0,18
+,AB-45,Straight Party,,,NONPARTISAN BALLOT (N),23,5,0,28
+,AB-45,Straight Party,,,REPUBLICAN PARTY (R),333,65,0,398
+,AB-45,US Representative,1,D,"ABERCROMBIE, Neil",1430,312,0,1742
+,AB-45,US Representative,1,R,"TATAII, Steve",202,30,0,232
+,AB-45,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",6,0,0,6
+,AB-45,US Representative,1,L,"ZHAO, Li",10,2,0,12
+,AB-45,State Representative,24,D,"CHOY, Isaac W.",950,256,0,1206
+,AB-45,State Representative,24,R,"JEFFRYES, Jerilyn (Jeri)",270,52,0,322
+,AB-46,Straight Party,,,DEMOCRATIC PARTY (D),808,230,0,1038
+,AB-46,Straight Party,,,INDEPENDENT PARTY (I),11,3,0,14
+,AB-46,Straight Party,,,LIBERTARIAN PARTY (L),16,5,0,21
+,AB-46,Straight Party,,,NONPARTISAN BALLOT (N),9,3,0,12
+,AB-46,Straight Party,,,REPUBLICAN PARTY (R),163,52,0,215
+,AB-46,US Representative,1,D,"ABERCROMBIE, Neil",648,181,0,829
+,AB-46,US Representative,1,R,"TATAII, Steve",151,43,0,194
+,AB-46,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",9,4,0,13
+,AB-46,US Representative,1,L,"ZHAO, Li",7,1,0,8
+,AB-46,State Representative,25,D,"BELATTI, Della A.",553,152,0,705
+,AB-47,Straight Party,,,DEMOCRATIC PARTY (D),593,120,0,713
+,AB-47,Straight Party,,,INDEPENDENT PARTY (I),8,2,0,10
+,AB-47,Straight Party,,,LIBERTARIAN PARTY (L),6,4,0,10
+,AB-47,Straight Party,,,NONPARTISAN BALLOT (N),9,0,0,9
+,AB-47,Straight Party,,,REPUBLICAN PARTY (R),105,21,0,126
+,AB-47,US Representative,1,D,"ABERCROMBIE, Neil",485,98,0,583
+,AB-47,US Representative,1,R,"TATAII, Steve",95,18,0,113
+,AB-47,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",2,3,0,5
+,AB-47,US Representative,1,L,"ZHAO, Li",4,1,0,5
+,AB-47,State Representative,25,D,"BELATTI, Della A.",346,77,0,423
+,AB-48,Straight Party,,,DEMOCRATIC PARTY (D),1546,434,0,1980
+,AB-48,Straight Party,,,INDEPENDENT PARTY (I),21,8,0,29
+,AB-48,Straight Party,,,LIBERTARIAN PARTY (L),17,6,0,23
+,AB-48,Straight Party,,,NONPARTISAN BALLOT (N),19,7,0,26
+,AB-48,Straight Party,,,REPUBLICAN PARTY (R),275,67,0,342
+,AB-48,US Representative,1,D,"ABERCROMBIE, Neil",1259,355,0,1614
+,AB-48,US Representative,1,R,"TATAII, Steve",248,55,0,303
+,AB-48,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",10,1,0,11
+,AB-48,US Representative,1,L,"ZHAO, Li",7,4,0,11
+,AB-48,State Representative,26,D,"LUKE, Sylvia",1140,341,0,1481
+,AB-49,Straight Party,,,DEMOCRATIC PARTY (D),1059,238,0,1297
+,AB-49,Straight Party,,,INDEPENDENT PARTY (I),2,1,0,3
+,AB-49,Straight Party,,,LIBERTARIAN PARTY (L),5,0,0,5
+,AB-49,Straight Party,,,NONPARTISAN BALLOT (N),13,4,0,17
+,AB-49,Straight Party,,,REPUBLICAN PARTY (R),313,65,0,378
+,AB-49,US Representative,1,D,"ABERCROMBIE, Neil",904,195,0,1099
+,AB-49,US Representative,1,R,"TATAII, Steve",128,33,0,161
+,AB-49,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",3,0,0,3
+,AB-49,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-49,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",577,140,0,717
+,AB-49,State Representative,27,R,"CHING, Corinne Wei Lan",296,58,0,354
+,AB-50,Straight Party,,,DEMOCRATIC PARTY (D),68,15,0,83
+,AB-50,Straight Party,,,INDEPENDENT PARTY (I),1,0,0,1
+,AB-50,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-50,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-50,Straight Party,,,REPUBLICAN PARTY (R),31,4,0,35
+,AB-50,US Representative,1,D,"ABERCROMBIE, Neil",57,12,0,69
+,AB-50,US Representative,1,R,"TATAII, Steve",18,1,0,19
+,AB-50,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-50,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-50,State Representative,27,D,"MOEPONO, Sesnita Der-Ling",35,8,0,43
+,AB-50,State Representative,27,R,"CHING, Corinne Wei Lan",29,4,0,33
+,AB-51,Straight Party,,,DEMOCRATIC PARTY (D),133,41,0,174
+,AB-51,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-51,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-51,Straight Party,,,NONPARTISAN BALLOT (N),0,1,0,1
+,AB-51,Straight Party,,,REPUBLICAN PARTY (R),18,6,0,24
+,AB-51,US Representative,1,D,"ABERCROMBIE, Neil",101,38,0,139
+,AB-51,US Representative,1,R,"TATAII, Steve",9,5,0,14
+,AB-51,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-51,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-51,State Representative,28,D,"RHOADS, Karl",89,20,0,109
+,AB-52,Straight Party,,,DEMOCRATIC PARTY (D),158,33,0,191
+,AB-52,Straight Party,,,INDEPENDENT PARTY (I),3,1,0,4
+,AB-52,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-52,Straight Party,,,NONPARTISAN BALLOT (N),3,5,0,8
+,AB-52,Straight Party,,,REPUBLICAN PARTY (R),18,5,0,23
+,AB-52,US Representative,1,D,"ABERCROMBIE, Neil",134,27,0,161
+,AB-52,US Representative,1,R,"TATAII, Steve",15,5,0,20
+,AB-52,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-52,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-52,State Representative,28,D,"RHOADS, Karl",90,20,0,110
+,AB-53,Straight Party,,,DEMOCRATIC PARTY (D),545,207,0,752
+,AB-53,Straight Party,,,INDEPENDENT PARTY (I),8,1,0,9
+,AB-53,Straight Party,,,LIBERTARIAN PARTY (L),10,0,0,10
+,AB-53,Straight Party,,,NONPARTISAN BALLOT (N),11,4,0,15
+,AB-53,Straight Party,,,REPUBLICAN PARTY (R),163,59,0,222
+,AB-53,US Representative,1,D,"ABERCROMBIE, Neil",446,166,0,612
+,AB-53,US Representative,1,R,"TATAII, Steve",112,36,0,148
+,AB-53,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",3,0,0,3
+,AB-53,US Representative,1,L,"ZHAO, Li",7,0,0,7
+,AB-53,State Senate,12,D,"GALUTERIA, Brickwood M.",302,133,0,435
+,AB-53,State Senate,12,D,"MIDDLETON, Carlton N.",116,32,0,148
+,AB-53,State Senate,12,R,"TRIMBLE, Gordon",150,55,0,205
+,AB-53,State Representative,28,D,"RHOADS, Karl",403,160,0,563
+,AB-54,Straight Party,,,DEMOCRATIC PARTY (D),177,40,0,217
+,AB-54,Straight Party,,,INDEPENDENT PARTY (I),0,2,0,2
+,AB-54,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-54,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-54,Straight Party,,,REPUBLICAN PARTY (R),38,11,0,49
+,AB-54,US Representative,1,D,"ABERCROMBIE, Neil",152,34,0,186
+,AB-54,US Representative,1,R,"TATAII, Steve",28,4,0,32
+,AB-54,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-54,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-54,State Senate,12,D,"GALUTERIA, Brickwood M.",121,22,0,143
+,AB-54,State Senate,12,D,"MIDDLETON, Carlton N.",34,9,0,43
+,AB-54,State Senate,12,R,"TRIMBLE, Gordon",33,10,0,43
+,AB-54,State Representative,28,D,"RHOADS, Karl",143,33,0,176
+,AB-55,Straight Party,,,DEMOCRATIC PARTY (D),714,126,0,840
+,AB-55,Straight Party,,,INDEPENDENT PARTY (I),2,3,0,5
+,AB-55,Straight Party,,,LIBERTARIAN PARTY (L),6,0,0,6
+,AB-55,Straight Party,,,NONPARTISAN BALLOT (N),6,0,0,6
+,AB-55,Straight Party,,,REPUBLICAN PARTY (R),100,23,0,123
+,AB-55,US Representative,1,D,"ABERCROMBIE, Neil",603,106,0,709
+,AB-55,US Representative,1,R,"TATAII, Steve",71,17,0,88
+,AB-55,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-55,US Representative,1,L,"ZHAO, Li",5,0,0,5
+,AB-55,State Representative,29,D,"MANAHAN, Joey",558,84,0,642
+,AB-55,State Representative,29,R,"YAW, Shane D. K.",81,16,0,97
+,AB-56,Straight Party,,,DEMOCRATIC PARTY (D),567,122,0,689
+,AB-56,Straight Party,,,INDEPENDENT PARTY (I),7,1,0,8
+,AB-56,Straight Party,,,LIBERTARIAN PARTY (L),4,1,0,5
+,AB-56,Straight Party,,,NONPARTISAN BALLOT (N),6,1,0,7
+,AB-56,Straight Party,,,REPUBLICAN PARTY (R),74,18,0,92
+,AB-56,US Representative,1,D,"ABERCROMBIE, Neil",476,102,0,578
+,AB-56,US Representative,1,R,"TATAII, Steve",61,17,0,78
+,AB-56,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-56,US Representative,1,L,"ZHAO, Li",4,1,0,5
+,AB-56,State Representative,30,D,"MIZUNO, John",460,87,0,547
+,AB-57,Straight Party,,,DEMOCRATIC PARTY (D),257,47,0,304
+,AB-57,Straight Party,,,INDEPENDENT PARTY (I),1,0,0,1
+,AB-57,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-57,Straight Party,,,NONPARTISAN BALLOT (N),2,0,0,2
+,AB-57,Straight Party,,,REPUBLICAN PARTY (R),17,8,0,25
+,AB-57,US Representative,1,D,"ABERCROMBIE, Neil",235,35,0,270
+,AB-57,US Representative,1,R,"TATAII, Steve",12,5,0,17
+,AB-57,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-57,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-57,State Representative,30,D,"MIZUNO, John",203,39,0,242
+,AB-58,Straight Party,,,DEMOCRATIC PARTY (D),295,71,0,366
+,AB-58,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-58,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-58,Straight Party,,,NONPARTISAN BALLOT (N),2,0,0,2
+,AB-58,Straight Party,,,REPUBLICAN PARTY (R),22,10,0,32
+,AB-58,US Representative,1,D,"ABERCROMBIE, Neil",241,59,0,300
+,AB-58,US Representative,1,R,"TATAII, Steve",18,6,0,24
+,AB-58,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-58,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-58,State Representative,31,D,"WAKAI, Glenn",260,59,0,319
+,AB-59,Straight Party,,,DEMOCRATIC PARTY (D),982,213,0,1195
+,AB-59,Straight Party,,,INDEPENDENT PARTY (I),9,2,0,11
+,AB-59,Straight Party,,,LIBERTARIAN PARTY (L),14,1,0,15
+,AB-59,Straight Party,,,NONPARTISAN BALLOT (N),13,2,0,15
+,AB-59,Straight Party,,,REPUBLICAN PARTY (R),186,31,0,217
+,AB-59,US Representative,1,D,"ABERCROMBIE, Neil",807,168,0,975
+,AB-59,US Representative,1,R,"TATAII, Steve",176,23,0,199
+,AB-59,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",6,1,0,7
+,AB-59,US Representative,1,L,"ZHAO, Li",8,0,0,8
+,AB-59,State Representative,31,D,"WAKAI, Glenn",792,159,0,951
+,AB-60,Straight Party,,,DEMOCRATIC PARTY (D),418,114,0,532
+,AB-60,Straight Party,,,INDEPENDENT PARTY (I),3,1,0,4
+,AB-60,Straight Party,,,LIBERTARIAN PARTY (L),3,1,0,4
+,AB-60,Straight Party,,,NONPARTISAN BALLOT (N),6,0,0,6
+,AB-60,Straight Party,,,REPUBLICAN PARTY (R),124,28,0,152
+,AB-60,US Representative,1,D,"ABERCROMBIE, Neil",387,102,0,489
+,AB-60,US Representative,1,R,"TATAII, Steve",55,12,0,67
+,AB-60,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,1,0,2
+,AB-60,US Representative,1,L,"ZHAO, Li",2,0,0,2
+,AB-60,State Representative,32,R,"FINNEGAN, Lynn",115,24,0,139
+,AB-61,Straight Party,,,DEMOCRATIC PARTY (D),327,93,0,420
+,AB-61,Straight Party,,,INDEPENDENT PARTY (I),6,2,0,8
+,AB-61,Straight Party,,,LIBERTARIAN PARTY (L),3,0,0,3
+,AB-61,Straight Party,,,NONPARTISAN BALLOT (N),3,0,0,3
+,AB-61,Straight Party,,,REPUBLICAN PARTY (R),204,20,0,224
+,AB-61,US Representative,1,D,"ABERCROMBIE, Neil",302,86,0,388
+,AB-61,US Representative,1,R,"TATAII, Steve",101,4,0,105
+,AB-61,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-61,US Representative,1,L,"ZHAO, Li",2,0,0,2
+,AB-61,State Representative,32,R,"FINNEGAN, Lynn",197,19,0,216
+,AB-62,Straight Party,,,DEMOCRATIC PARTY (D),437,161,0,598
+,AB-62,Straight Party,,,INDEPENDENT PARTY (I),3,1,0,4
+,AB-62,Straight Party,,,LIBERTARIAN PARTY (L),5,2,0,7
+,AB-62,Straight Party,,,NONPARTISAN BALLOT (N),4,2,0,6
+,AB-62,Straight Party,,,REPUBLICAN PARTY (R),62,19,0,81
+,AB-62,US Representative,1,D,"ABERCROMBIE, Neil",364,130,0,494
+,AB-62,US Representative,1,R,"TATAII, Steve",51,13,0,64
+,AB-62,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",2,0,0,2
+,AB-62,US Representative,1,L,"ZHAO, Li",3,1,0,4
+,AB-62,State Representative,33,D,"OSHIRO, Blake K.",333,119,0,452
+,AB-63,Straight Party,,,DEMOCRATIC PARTY (D),927,385,0,1312
+,AB-63,Straight Party,,,INDEPENDENT PARTY (I),7,4,0,11
+,AB-63,Straight Party,,,LIBERTARIAN PARTY (L),10,1,0,11
+,AB-63,Straight Party,,,NONPARTISAN BALLOT (N),10,2,0,12
+,AB-63,Straight Party,,,REPUBLICAN PARTY (R),162,53,0,215
+,AB-63,US Representative,1,D,"ABERCROMBIE, Neil",750,309,0,1059
+,AB-63,US Representative,1,R,"TATAII, Steve",155,36,0,191
+,AB-63,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",2,0,0,2
+,AB-63,US Representative,1,L,"ZHAO, Li",8,0,0,8
+,AB-63,State Senate,16,D,"IGE, David Y.",593,265,0,858
+,AB-63,State Representative,33,D,"OSHIRO, Blake K.",655,297,0,952
+,AB-64,Straight Party,,,DEMOCRATIC PARTY (D),1681,458,0,2139
+,AB-64,Straight Party,,,INDEPENDENT PARTY (I),8,2,0,10
+,AB-64,Straight Party,,,LIBERTARIAN PARTY (L),10,1,0,11
+,AB-64,Straight Party,,,NONPARTISAN BALLOT (N),15,1,0,16
+,AB-64,Straight Party,,,REPUBLICAN PARTY (R),205,44,0,249
+,AB-64,US Representative,1,D,"ABERCROMBIE, Neil",1354,372,0,1726
+,AB-64,US Representative,1,R,"TATAII, Steve",182,37,0,219
+,AB-64,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",7,0,0,7
+,AB-64,US Representative,1,L,"ZHAO, Li",3,1,0,4
+,AB-64,State Senate,16,D,"IGE, David Y.",1236,349,0,1585
+,AB-64,State Representative,34,D,"TAKAI, K. Mark",1376,374,0,1750
+,AB-65,Straight Party,,,DEMOCRATIC PARTY (D),78,10,0,88
+,AB-65,Straight Party,,,INDEPENDENT PARTY (I),0,1,0,1
+,AB-65,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-65,Straight Party,,,NONPARTISAN BALLOT (N),1,1,0,2
+,AB-65,Straight Party,,,REPUBLICAN PARTY (R),13,1,0,14
+,AB-65,US Representative,1,D,"ABERCROMBIE, Neil",63,9,0,72
+,AB-65,US Representative,1,R,"TATAII, Steve",13,0,0,13
+,AB-65,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-65,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-65,State Senate,18,D,"SONSON, Alex M.",37,5,0,42
+,AB-65,State Senate,18,D,"NISHIHARA, Clarence",34,4,0,38
+,AB-65,State Representative,34,D,"TAKAI, K. Mark",63,7,0,70
+,AB-66,Straight Party,,,DEMOCRATIC PARTY (D),230,43,0,273
+,AB-66,Straight Party,,,INDEPENDENT PARTY (I),1,1,0,2
+,AB-66,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-66,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-66,Straight Party,,,REPUBLICAN PARTY (R),16,11,0,27
+,AB-66,US Representative,1,D,"ABERCROMBIE, Neil",186,37,0,223
+,AB-66,US Representative,1,R,"TATAII, Steve",9,7,0,16
+,AB-66,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-66,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-66,State Senate,18,D,"SONSON, Alex M.",74,19,0,93
+,AB-66,State Senate,18,D,"NISHIHARA, Clarence",147,23,0,170
+,AB-66,State Representative,35,D,"AQUINO, Henry James C.",98,21,0,119
+,AB-66,State Representative,35,D,"RAHMAN, I. Perreira Padilla",77,13,0,90
+,AB-66,State Representative,35,D,"VERDADERO, Dante M.",3,1,0,4
+,AB-66,State Representative,35,D,"DOMINGO, Constante A.",9,2,0,11
+,AB-66,State Representative,35,D,"PARAYNO, Ilalo",18,1,0,19
+,AB-66,State Representative,35,R,"ANTONIO, Steven Bolosan",15,7,0,22
+,AB-67,Straight Party,,,DEMOCRATIC PARTY (D),1020,141,0,1161
+,AB-67,Straight Party,,,INDEPENDENT PARTY (I),3,0,0,3
+,AB-67,Straight Party,,,LIBERTARIAN PARTY (L),2,0,0,2
+,AB-67,Straight Party,,,NONPARTISAN BALLOT (N),2,0,0,2
+,AB-67,Straight Party,,,REPUBLICAN PARTY (R),56,11,0,67
+,AB-67,US Representative,1,D,"ABERCROMBIE, Neil",865,123,0,988
+,AB-67,US Representative,1,R,"TATAII, Steve",37,7,0,44
+,AB-67,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-67,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-67,State Senate,18,D,"SONSON, Alex M.",593,61,0,654
+,AB-67,State Senate,18,D,"NISHIHARA, Clarence",397,73,0,470
+,AB-67,State Representative,35,D,"AQUINO, Henry James C.",571,79,0,650
+,AB-67,State Representative,35,D,"RAHMAN, I. Perreira Padilla",233,21,0,254
+,AB-67,State Representative,35,D,"VERDADERO, Dante M.",54,10,0,64
+,AB-67,State Representative,35,D,"DOMINGO, Constante A.",66,8,0,74
+,AB-67,State Representative,35,D,"PARAYNO, Ilalo",46,12,0,58
+,AB-67,State Representative,35,R,"ANTONIO, Steven Bolosan",48,10,0,58
+,AB-68,Straight Party,,,DEMOCRATIC PARTY (D),952,220,0,1172
+,AB-68,Straight Party,,,INDEPENDENT PARTY (I),5,2,0,7
+,AB-68,Straight Party,,,LIBERTARIAN PARTY (L),2,0,0,2
+,AB-68,Straight Party,,,NONPARTISAN BALLOT (N),18,2,0,20
+,AB-68,Straight Party,,,REPUBLICAN PARTY (R),89,17,0,106
+,AB-68,US Representative,1,D,"ABERCROMBIE, Neil",764,182,0,946
+,AB-68,US Representative,1,R,"TATAII, Steve",75,14,0,89
+,AB-68,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-68,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-68,State Senate,16,D,"IGE, David Y.",681,164,0,845
+,AB-68,State Representative,36,D,"TAKUMI, Roy M.",702,171,0,873
+,AB-68,State Representative,36,N,"LUM LEE, Christopher-Travis",15,1,0,16
+,AB-69,Straight Party,,,DEMOCRATIC PARTY (D),563,107,0,670
+,AB-69,Straight Party,,,INDEPENDENT PARTY (I),4,3,0,7
+,AB-69,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-69,Straight Party,,,NONPARTISAN BALLOT (N),4,2,0,6
+,AB-69,Straight Party,,,REPUBLICAN PARTY (R),42,10,0,52
+,AB-69,US Representative,1,D,"ABERCROMBIE, Neil",464,80,0,544
+,AB-69,US Representative,1,R,"TATAII, Steve",38,6,0,44
+,AB-69,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-69,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-69,State Senate,18,D,"SONSON, Alex M.",146,26,0,172
+,AB-69,State Senate,18,D,"NISHIHARA, Clarence",371,72,0,443
+,AB-69,State Representative,36,D,"TAKUMI, Roy M.",456,88,0,544
+,AB-69,State Representative,36,N,"LUM LEE, Christopher-Travis",2,2,0,4
+,AB-70,Straight Party,,,DEMOCRATIC PARTY (D),12,5,0,17
+,AB-70,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-70,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-70,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-70,Straight Party,,,REPUBLICAN PARTY (R),2,0,0,2
+,AB-70,US Representative,1,D,"ABERCROMBIE, Neil",11,5,0,16
+,AB-70,US Representative,1,R,"TATAII, Steve",2,0,0,2
+,AB-70,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-70,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-70,State Senate,18,D,"SONSON, Alex M.",1,1,0,2
+,AB-70,State Senate,18,D,"NISHIHARA, Clarence",11,3,0,14
+,AB-70,State Representative,36,D,"TAKUMI, Roy M.",12,4,0,16
+,AB-70,State Representative,36,N,"LUM LEE, Christopher-Travis",0,0,0,0
+,AB-71,Straight Party,,,DEMOCRATIC PARTY (D),400,84,0,484
+,AB-71,Straight Party,,,INDEPENDENT PARTY (I),3,2,0,5
+,AB-71,Straight Party,,,LIBERTARIAN PARTY (L),2,0,0,2
+,AB-71,Straight Party,,,NONPARTISAN BALLOT (N),0,1,0,1
+,AB-71,Straight Party,,,REPUBLICAN PARTY (R),56,9,0,65
+,AB-71,US Representative,1,D,"ABERCROMBIE, Neil",341,77,0,418
+,AB-71,US Representative,1,R,"TATAII, Steve",50,7,0,57
+,AB-71,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-71,US Representative,1,L,"ZHAO, Li",2,0,0,2
+,AB-71,State Senate,17,D,"KIDANI, Michelle",162,42,0,204
+,AB-71,State Senate,17,D,"MENOR, Ron",151,30,0,181
+,AB-71,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",52,8,0,60
+,AB-71,State Representative,37,D,"YAMANE, Ryan I.",339,75,0,414
+,AB-72,Straight Party,,,DEMOCRATIC PARTY (D),1004,201,0,1205
+,AB-72,Straight Party,,,INDEPENDENT PARTY (I),1,1,0,2
+,AB-72,Straight Party,,,LIBERTARIAN PARTY (L),4,0,0,4
+,AB-72,Straight Party,,,NONPARTISAN BALLOT (N),1,2,0,3
+,AB-72,Straight Party,,,REPUBLICAN PARTY (R),116,18,0,134
+,AB-72,US Representative,1,D,"ABERCROMBIE, Neil",784,165,0,949
+,AB-72,US Representative,1,R,"TATAII, Steve",107,14,0,121
+,AB-72,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",4,0,0,4
+,AB-72,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-72,State Senate,17,D,"KIDANI, Michelle",427,82,0,509
+,AB-72,State Senate,17,D,"MENOR, Ron",431,83,0,514
+,AB-72,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",105,28,0,133
+,AB-72,State Representative,37,D,"YAMANE, Ryan I.",825,171,0,996
+,AB-73,Straight Party,,,DEMOCRATIC PARTY (D),447,90,0,537
+,AB-73,Straight Party,,,INDEPENDENT PARTY (I),3,1,0,4
+,AB-73,Straight Party,,,LIBERTARIAN PARTY (L),6,0,0,6
+,AB-73,Straight Party,,,NONPARTISAN BALLOT (N),9,1,0,10
+,AB-73,Straight Party,,,REPUBLICAN PARTY (R),74,14,0,88
+,AB-73,US Representative,1,D,"ABERCROMBIE, Neil",372,70,0,442
+,AB-73,US Representative,1,R,"TATAII, Steve",51,9,0,60
+,AB-73,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-73,US Representative,1,L,"ZHAO, Li",5,0,0,5
+,AB-73,State Senate,22,D,"BUNDA, Robert (Bobby)",283,64,0,347
+,AB-73,State Representative,38,D,"LEE, Marilyn B.",315,70,0,385
+,AB-73,State Representative,38,R,"APANA, Melvin K.",65,13,0,78
+,AB-74,Straight Party,,,DEMOCRATIC PARTY (D),513,85,0,598
+,AB-74,Straight Party,,,INDEPENDENT PARTY (I),2,0,0,2
+,AB-74,Straight Party,,,LIBERTARIAN PARTY (L),1,1,0,2
+,AB-74,Straight Party,,,NONPARTISAN BALLOT (N),3,0,0,3
+,AB-74,Straight Party,,,REPUBLICAN PARTY (R),57,11,0,68
+,AB-74,US Representative,1,D,"ABERCROMBIE, Neil",413,76,0,489
+,AB-74,US Representative,1,R,"TATAII, Steve",42,7,0,49
+,AB-74,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-74,US Representative,1,L,"ZHAO, Li",1,1,0,2
+,AB-74,State Senate,17,D,"KIDANI, Michelle",227,33,0,260
+,AB-74,State Senate,17,D,"MENOR, Ron",193,36,0,229
+,AB-74,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",58,9,0,67
+,AB-74,State Representative,38,D,"LEE, Marilyn B.",412,67,0,479
+,AB-74,State Representative,38,R,"APANA, Melvin K.",48,8,0,56
+,AB-75,Straight Party,,,DEMOCRATIC PARTY (D),829,170,0,999
+,AB-75,Straight Party,,,INDEPENDENT PARTY (I),5,1,0,6
+,AB-75,Straight Party,,,LIBERTARIAN PARTY (L),4,1,0,5
+,AB-75,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-75,Straight Party,,,REPUBLICAN PARTY (R),113,20,0,133
+,AB-75,US Representative,1,D,"ABERCROMBIE, Neil",666,134,0,800
+,AB-75,US Representative,1,R,"TATAII, Steve",87,17,0,104
+,AB-75,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,1,0,2
+,AB-75,US Representative,1,L,"ZHAO, Li",3,0,0,3
+,AB-75,State Senate,17,D,"KIDANI, Michelle",320,61,0,381
+,AB-75,State Senate,17,D,"MENOR, Ron",337,68,0,405
+,AB-75,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",131,30,0,161
+,AB-75,State Representative,38,D,"LEE, Marilyn B.",657,140,0,797
+,AB-75,State Representative,38,R,"APANA, Melvin K.",101,16,0,117
+,AB-76,Straight Party,,,DEMOCRATIC PARTY (D),859,89,0,948
+,AB-76,Straight Party,,,INDEPENDENT PARTY (I),9,0,0,9
+,AB-76,Straight Party,,,LIBERTARIAN PARTY (L),1,1,0,2
+,AB-76,Straight Party,,,NONPARTISAN BALLOT (N),15,1,0,16
+,AB-76,Straight Party,,,REPUBLICAN PARTY (R),132,14,0,146
+,AB-76,US Representative,2,I,"STENSHOL, Shaun",7,0,0,7
+,AB-76,US Representative,2,D,"HIRONO, Mazie",706,71,0,777
+,AB-76,US Representative,2,R,"EVANS, Roger B.",122,12,0,134
+,AB-76,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,1,0,1
+,AB-76,State Senate,22,D,"BUNDA, Robert (Bobby)",634,71,0,705
+,AB-76,State Representative,39,D,"OSHIRO, Marcus R.",641,74,0,715
+,AB-77,Straight Party,,,DEMOCRATIC PARTY (D),48,8,0,56
+,AB-77,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-77,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-77,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-77,Straight Party,,,REPUBLICAN PARTY (R),16,2,0,18
+,AB-77,US Representative,1,D,"ABERCROMBIE, Neil",33,7,0,40
+,AB-77,US Representative,1,R,"TATAII, Steve",16,1,0,17
+,AB-77,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-77,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-77,State Senate,17,D,"KIDANI, Michelle",19,6,0,25
+,AB-77,State Senate,17,D,"MENOR, Ron",22,0,0,22
+,AB-77,State Senate,17,D,"TSUNEYOSHI, Resa R. K.",4,1,0,5
+,AB-77,State Representative,39,D,"OSHIRO, Marcus R.",29,6,0,35
+,AB-78,Straight Party,,,DEMOCRATIC PARTY (D),512,243,0,755
+,AB-78,Straight Party,,,INDEPENDENT PARTY (I),8,3,0,11
+,AB-78,Straight Party,,,LIBERTARIAN PARTY (L),3,1,0,4
+,AB-78,Straight Party,,,NONPARTISAN BALLOT (N),10,3,0,13
+,AB-78,Straight Party,,,REPUBLICAN PARTY (R),184,57,0,241
+,AB-78,US Representative,2,I,"STENSHOL, Shaun",6,1,0,7
+,AB-78,US Representative,2,D,"HIRONO, Mazie",379,200,0,579
+,AB-78,US Representative,2,R,"EVANS, Roger B.",136,44,0,180
+,AB-78,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",3,0,0,3
+,AB-78,State Representative,40,D,"HAR, Sharon E.",435,212,0,647
+,AB-78,State Representative,40,R,"LEGAL,  Jack M.",166,52,0,218
+,AB-79,Straight Party,,,DEMOCRATIC PARTY (D),301,128,0,429
+,AB-79,Straight Party,,,INDEPENDENT PARTY (I),4,0,0,4
+,AB-79,Straight Party,,,LIBERTARIAN PARTY (L),2,0,0,2
+,AB-79,Straight Party,,,NONPARTISAN BALLOT (N),3,0,0,3
+,AB-79,Straight Party,,,REPUBLICAN PARTY (R),97,40,0,137
+,AB-79,US Representative,2,I,"STENSHOL, Shaun",3,0,0,3
+,AB-79,US Representative,2,D,"HIRONO, Mazie",242,99,0,341
+,AB-79,US Representative,2,R,"EVANS, Roger B.",75,28,0,103
+,AB-79,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,0,0,1
+,AB-79,State Representative,40,D,"HAR, Sharon E.",232,109,0,341
+,AB-79,State Representative,40,R,"LEGAL,  Jack M.",84,32,0,116
+,AB-80,Straight Party,,,DEMOCRATIC PARTY (D),351,89,0,440
+,AB-80,Straight Party,,,INDEPENDENT PARTY (I),4,2,0,6
+,AB-80,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-80,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-80,Straight Party,,,REPUBLICAN PARTY (R),75,7,0,82
+,AB-80,US Representative,1,D,"ABERCROMBIE, Neil",287,80,0,367
+,AB-80,US Representative,1,R,"TATAII, Steve",48,5,0,53
+,AB-80,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-80,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-80,State Representative,41,D,"CULLEN, Ty Diaz",83,26,0,109
+,AB-80,State Representative,41,D,"KARAMATSU, Jon Riki",225,58,0,283
+,AB-80,State Representative,41,R,"SANIATAN, Rito C.",63,6,0,69
+,AB-81,Straight Party,,,DEMOCRATIC PARTY (D),174,27,0,201
+,AB-81,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-81,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-81,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-81,Straight Party,,,REPUBLICAN PARTY (R),17,0,0,17
+,AB-81,US Representative,1,D,"ABERCROMBIE, Neil",158,21,0,179
+,AB-81,US Representative,1,R,"TATAII, Steve",8,0,0,8
+,AB-81,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-81,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-81,State Senate,18,D,"SONSON, Alex M.",57,7,0,64
+,AB-81,State Senate,18,D,"NISHIHARA, Clarence",113,19,0,132
+,AB-81,State Representative,41,D,"CULLEN, Ty Diaz",58,10,0,68
+,AB-81,State Representative,41,D,"KARAMATSU, Jon Riki",113,15,0,128
+,AB-81,State Representative,41,R,"SANIATAN, Rito C.",13,0,0,13
+,AB-82,Straight Party,,,DEMOCRATIC PARTY (D),311,79,0,390
+,AB-82,Straight Party,,,INDEPENDENT PARTY (I),1,0,0,1
+,AB-82,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-82,Straight Party,,,NONPARTISAN BALLOT (N),3,0,0,3
+,AB-82,Straight Party,,,REPUBLICAN PARTY (R),91,12,0,103
+,AB-82,US Representative,2,I,"STENSHOL, Shaun",1,0,0,1
+,AB-82,US Representative,2,D,"HIRONO, Mazie",270,66,0,336
+,AB-82,US Representative,2,R,"EVANS, Roger B.",60,5,0,65
+,AB-82,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-82,State Representative,41,D,"CULLEN, Ty Diaz",114,27,0,141
+,AB-82,State Representative,41,D,"KARAMATSU, Jon Riki",167,48,0,215
+,AB-82,State Representative,41,R,"SANIATAN, Rito C.",79,7,0,86
+,AB-83,Straight Party,,,DEMOCRATIC PARTY (D),148,13,0,161
+,AB-83,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-83,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-83,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-83,Straight Party,,,REPUBLICAN PARTY (R),5,0,0,5
+,AB-83,US Representative,1,D,"ABERCROMBIE, Neil",120,7,0,127
+,AB-83,US Representative,1,R,"TATAII, Steve",2,0,0,2
+,AB-83,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-83,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-83,State Senate,18,D,"SONSON, Alex M.",55,4,0,59
+,AB-83,State Senate,18,D,"NISHIHARA, Clarence",88,8,0,96
+,AB-83,State Representative,42,D,"RODRIGUEZ, Rey R.",11,1,0,12
+,AB-83,State Representative,42,D,"SCHULTZ, Mike P.",52,7,0,59
+,AB-83,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",73,4,0,77
+,AB-83,State Representative,42,R,"BERG, Tom",4,0,0,4
+,AB-83,State Representative,42,N,"BIMBO, Genaro Q.",0,0,0,0
+,AB-84,Straight Party,,,DEMOCRATIC PARTY (D),31,8,0,39
+,AB-84,Straight Party,,,INDEPENDENT PARTY (I),0,0,0,0
+,AB-84,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-84,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-84,Straight Party,,,REPUBLICAN PARTY (R),1,1,0,2
+,AB-84,US Representative,1,D,"ABERCROMBIE, Neil",28,6,0,34
+,AB-84,US Representative,1,R,"TATAII, Steve",1,0,0,1
+,AB-84,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",0,0,0,0
+,AB-84,US Representative,1,L,"ZHAO, Li",0,0,0,0
+,AB-84,State Representative,42,D,"RODRIGUEZ, Rey R.",4,1,0,5
+,AB-84,State Representative,42,D,"SCHULTZ, Mike P.",12,2,0,14
+,AB-84,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",11,4,0,15
+,AB-84,State Representative,42,R,"BERG, Tom",1,1,0,2
+,AB-84,State Representative,42,N,"BIMBO, Genaro Q.",0,0,0,0
+,AB-85,Straight Party,,,DEMOCRATIC PARTY (D),499,115,0,614
+,AB-85,Straight Party,,,INDEPENDENT PARTY (I),2,1,0,3
+,AB-85,Straight Party,,,LIBERTARIAN PARTY (L),2,0,0,2
+,AB-85,Straight Party,,,NONPARTISAN BALLOT (N),4,0,0,4
+,AB-85,Straight Party,,,REPUBLICAN PARTY (R),86,21,0,107
+,AB-85,US Representative,1,D,"ABERCROMBIE, Neil",433,98,0,531
+,AB-85,US Representative,1,R,"TATAII, Steve",47,16,0,63
+,AB-85,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-85,US Representative,1,L,"ZHAO, Li",1,0,0,1
+,AB-85,State Representative,42,D,"RODRIGUEZ, Rey R.",34,14,0,48
+,AB-85,State Representative,42,D,"SCHULTZ, Mike P.",216,48,0,264
+,AB-85,State Representative,42,D,"CABANILLA ARAKAWA, Rida T. R.",217,48,0,265
+,AB-85,State Representative,42,R,"BERG, Tom",76,21,0,97
+,AB-85,State Representative,42,N,"BIMBO, Genaro Q.",3,0,0,3
+,AB-86,Straight Party,,,DEMOCRATIC PARTY (D),660,165,0,825
+,AB-86,Straight Party,,,INDEPENDENT PARTY (I),12,5,0,17
+,AB-86,Straight Party,,,LIBERTARIAN PARTY (L),2,1,0,3
+,AB-86,Straight Party,,,NONPARTISAN BALLOT (N),8,2,0,10
+,AB-86,Straight Party,,,REPUBLICAN PARTY (R),385,84,0,469
+,AB-86,US Representative,1,D,"ABERCROMBIE, Neil",606,145,0,751
+,AB-86,US Representative,1,R,"TATAII, Steve",154,47,0,201
+,AB-86,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,AB-86,US Representative,1,L,"ZHAO, Li",1,1,0,2
+,AB-86,State Representative,43,D,"FEVELLA, Kurt",317,108,0,425
+,AB-86,State Representative,43,R,"PINE, Kymberly (Marcos)",368,79,0,447
+,AB-87,Straight Party,,,DEMOCRATIC PARTY (D),36,11,0,47
+,AB-87,Straight Party,,,INDEPENDENT PARTY (I),1,0,0,1
+,AB-87,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-87,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,AB-87,Straight Party,,,REPUBLICAN PARTY (R),13,4,0,17
+,AB-87,US Representative,2,I,"STENSHOL, Shaun",1,0,0,1
+,AB-87,US Representative,2,D,"HIRONO, Mazie",35,9,0,44
+,AB-87,US Representative,2,R,"EVANS, Roger B.",11,4,0,15
+,AB-87,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-87,State Representative,44,D,"AWANA, Karen Leinani",18,8,0,26
+,AB-87,State Representative,44,D,"AIPOALANI, Hanalei Y.",9,2,0,11
+,AB-87,State Representative,44,R,"KU, Tercia L.",9,3,0,12
+,AB-88,Straight Party,,,DEMOCRATIC PARTY (D),480,164,0,644
+,AB-88,Straight Party,,,INDEPENDENT PARTY (I),5,2,0,7
+,AB-88,Straight Party,,,LIBERTARIAN PARTY (L),3,0,0,3
+,AB-88,Straight Party,,,NONPARTISAN BALLOT (N),3,1,0,4
+,AB-88,Straight Party,,,REPUBLICAN PARTY (R),92,28,0,120
+,AB-88,US Representative,2,I,"STENSHOL, Shaun",5,2,0,7
+,AB-88,US Representative,2,D,"HIRONO, Mazie",373,131,0,504
+,AB-88,US Representative,2,R,"EVANS, Roger B.",65,24,0,89
+,AB-88,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",3,0,0,3
+,AB-88,State Senate,21,D,"HANABUSA, Colleen",379,131,0,510
+,AB-88,State Senate,21,R,"JOHNSON, Dickyj",65,19,0,84
+,AB-88,State Representative,44,D,"AWANA, Karen Leinani",243,75,0,318
+,AB-88,State Representative,44,D,"AIPOALANI, Hanalei Y.",198,78,0,276
+,AB-88,State Representative,44,R,"KU, Tercia L.",71,20,0,91
+,AB-89,Straight Party,,,DEMOCRATIC PARTY (D),562,135,0,697
+,AB-89,Straight Party,,,INDEPENDENT PARTY (I),9,1,0,10
+,AB-89,Straight Party,,,LIBERTARIAN PARTY (L),1,2,0,3
+,AB-89,Straight Party,,,NONPARTISAN BALLOT (N),2,1,0,3
+,AB-89,Straight Party,,,REPUBLICAN PARTY (R),95,21,0,116
+,AB-89,US Representative,2,I,"STENSHOL, Shaun",5,1,0,6
+,AB-89,US Representative,2,D,"HIRONO, Mazie",441,109,0,550
+,AB-89,US Representative,2,R,"EVANS, Roger B.",65,14,0,79
+,AB-89,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,2,0,3
+,AB-89,State Senate,21,D,"HANABUSA, Colleen",451,113,0,564
+,AB-89,State Senate,21,R,"JOHNSON, Dickyj",66,14,0,80
+,AB-89,State Representative,45,D,"SHIMABUKURO, Maile S. L.",432,99,0,531
+,AB-89,State Representative,45,D,"SAYLORS, Denise",94,30,0,124
+,AB-89,State Representative,45,R,"GAPOL, Derek A.",73,13,0,86
+,AB-90,Straight Party,,,DEMOCRATIC PARTY (D),58,21,0,79
+,AB-90,Straight Party,,,INDEPENDENT PARTY (I),2,0,0,2
+,AB-90,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-90,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-90,Straight Party,,,REPUBLICAN PARTY (R),36,15,0,51
+,AB-90,US Representative,2,I,"STENSHOL, Shaun",2,0,0,2
+,AB-90,US Representative,2,D,"HIRONO, Mazie",51,12,0,63
+,AB-90,US Representative,2,R,"EVANS, Roger B.",25,11,0,36
+,AB-90,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-90,State Senate,23,D,"HEE, Clayton",39,14,0,53
+,AB-90,State Senate,23,D,"MURAKI, Noel S.",16,5,0,21
+,AB-90,State Senate,23,R,"FALE, Richard",26,13,0,39
+,AB-90,State Representative,46,D,"LUNASCO, Ollie",5,6,0,11
+,AB-90,State Representative,46,D,"MAGAOAY, Michael Y.",35,11,0,46
+,AB-90,State Representative,46,D,"WASSON, Dawn K.",12,4,0,16
+,AB-90,State Representative,46,R,"PHILIPS, Carol",20,9,0,29
+,AB-90,State Representative,46,R,"RIVIERE, Gil",16,4,0,20
+,AB-91,Straight Party,,,DEMOCRATIC PARTY (D),479,51,0,530
+,AB-91,Straight Party,,,INDEPENDENT PARTY (I),5,1,0,6
+,AB-91,Straight Party,,,LIBERTARIAN PARTY (L),4,0,0,4
+,AB-91,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-91,Straight Party,,,REPUBLICAN PARTY (R),193,16,0,209
+,AB-91,US Representative,2,I,"STENSHOL, Shaun",5,1,0,6
+,AB-91,US Representative,2,D,"HIRONO, Mazie",383,40,0,423
+,AB-91,US Representative,2,R,"EVANS, Roger B.",93,9,0,102
+,AB-91,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",4,0,0,4
+,AB-91,State Senate,22,D,"BUNDA, Robert (Bobby)",380,36,0,416
+,AB-91,State Representative,46,D,"LUNASCO, Ollie",90,11,0,101
+,AB-91,State Representative,46,D,"MAGAOAY, Michael Y.",309,33,0,342
+,AB-91,State Representative,46,D,"WASSON, Dawn K.",55,4,0,59
+,AB-91,State Representative,46,R,"PHILIPS, Carol",95,3,0,98
+,AB-91,State Representative,46,R,"RIVIERE, Gil",92,13,0,105
+,AB-92,Straight Party,,,DEMOCRATIC PARTY (D),891,497,0,1388
+,AB-92,Straight Party,,,INDEPENDENT PARTY (I),12,2,0,14
+,AB-92,Straight Party,,,LIBERTARIAN PARTY (L),4,0,0,4
+,AB-92,Straight Party,,,NONPARTISAN BALLOT (N),3,2,0,5
+,AB-92,Straight Party,,,REPUBLICAN PARTY (R),260,140,0,400
+,AB-92,US Representative,2,I,"STENSHOL, Shaun",10,2,0,12
+,AB-92,US Representative,2,D,"HIRONO, Mazie",714,404,0,1118
+,AB-92,US Representative,2,R,"EVANS, Roger B.",128,64,0,192
+,AB-92,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",3,0,0,3
+,AB-92,State Senate,23,D,"HEE, Clayton",562,314,0,876
+,AB-92,State Senate,23,D,"MURAKI, Noel S.",256,148,0,404
+,AB-92,State Senate,23,R,"FALE, Richard",126,62,0,188
+,AB-92,State Representative,47,D,"PACHECO, Maria",162,97,0,259
+,AB-92,State Representative,47,D,"WOOLEY, Jessica",601,352,0,953
+,AB-92,State Representative,47,R,"MEYER, Colleen",236,132,0,368
+,AB-93,Straight Party,,,DEMOCRATIC PARTY (D),51,55,0,106
+,AB-93,Straight Party,,,INDEPENDENT PARTY (I),0,1,0,1
+,AB-93,Straight Party,,,LIBERTARIAN PARTY (L),0,0,0,0
+,AB-93,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,AB-93,Straight Party,,,REPUBLICAN PARTY (R),21,10,0,31
+,AB-93,US Representative,2,I,"STENSHOL, Shaun",0,1,0,1
+,AB-93,US Representative,2,D,"HIRONO, Mazie",45,49,0,94
+,AB-93,US Representative,2,R,"EVANS, Roger B.",15,2,0,17
+,AB-93,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",0,0,0,0
+,AB-93,State Senate,23,D,"HEE, Clayton",36,24,0,60
+,AB-93,State Senate,23,D,"MURAKI, Noel S.",10,23,0,33
+,AB-93,State Senate,23,R,"FALE, Richard",16,2,0,18
+,AB-93,State Representative,47,D,"PACHECO, Maria",4,11,0,15
+,AB-93,State Representative,47,D,"WOOLEY, Jessica",37,35,0,72
+,AB-93,State Representative,47,R,"MEYER, Colleen",21,8,0,29
+,AB-94,Straight Party,,,DEMOCRATIC PARTY (D),345,218,0,563
+,AB-94,Straight Party,,,INDEPENDENT PARTY (I),4,1,0,5
+,AB-94,Straight Party,,,LIBERTARIAN PARTY (L),1,0,0,1
+,AB-94,Straight Party,,,NONPARTISAN BALLOT (N),4,3,0,7
+,AB-94,Straight Party,,,REPUBLICAN PARTY (R),50,35,0,85
+,AB-94,US Representative,2,I,"STENSHOL, Shaun",4,1,0,5
+,AB-94,US Representative,2,D,"HIRONO, Mazie",292,185,0,477
+,AB-94,US Representative,2,R,"EVANS, Roger B.",44,30,0,74
+,AB-94,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,0,0,1
+,AB-94,State Senate,23,D,"HEE, Clayton",200,125,0,325
+,AB-94,State Senate,23,D,"MURAKI, Noel S.",107,59,0,166
+,AB-94,State Senate,23,R,"FALE, Richard",41,23,0,64
+,AB-94,State Representative,48,D,"ITO, Ken",296,190,0,486
+,AB-95,Straight Party,,,DEMOCRATIC PARTY (D),1164,573,0,1737
+,AB-95,Straight Party,,,INDEPENDENT PARTY (I),10,3,0,13
+,AB-95,Straight Party,,,LIBERTARIAN PARTY (L),5,2,0,7
+,AB-95,Straight Party,,,NONPARTISAN BALLOT (N),12,3,0,15
+,AB-95,Straight Party,,,REPUBLICAN PARTY (R),170,65,0,235
+,AB-95,US Representative,2,I,"STENSHOL, Shaun",8,1,0,9
+,AB-95,US Representative,2,D,"HIRONO, Mazie",990,486,0,1476
+,AB-95,US Representative,2,R,"EVANS, Roger B.",160,60,0,220
+,AB-95,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",5,2,0,7
+,AB-95,State Representative,48,D,"ITO, Ken",928,451,0,1379
+,AB-96,Straight Party,,,DEMOCRATIC PARTY (D),909,318,0,1227
+,AB-96,Straight Party,,,INDEPENDENT PARTY (I),11,5,0,16
+,AB-96,Straight Party,,,LIBERTARIAN PARTY (L),4,0,0,4
+,AB-96,Straight Party,,,NONPARTISAN BALLOT (N),14,6,0,20
+,AB-96,Straight Party,,,REPUBLICAN PARTY (R),226,65,0,291
+,AB-96,US Representative,2,I,"STENSHOL, Shaun",11,4,0,15
+,AB-96,US Representative,2,D,"HIRONO, Mazie",758,258,0,1016
+,AB-96,US Representative,2,R,"EVANS, Roger B.",214,60,0,274
+,AB-96,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",4,0,0,4
+,AB-96,State Representative,49,D,"CHONG, Pono",653,226,0,879
+,AB-97,Straight Party,,,DEMOCRATIC PARTY (D),286,180,0,466
+,AB-97,Straight Party,,,INDEPENDENT PARTY (I),3,2,0,5
+,AB-97,Straight Party,,,LIBERTARIAN PARTY (L),1,1,0,2
+,AB-97,Straight Party,,,NONPARTISAN BALLOT (N),5,4,0,9
+,AB-97,Straight Party,,,REPUBLICAN PARTY (R),73,56,0,129
+,AB-97,US Representative,2,I,"STENSHOL, Shaun",3,2,0,5
+,AB-97,US Representative,2,D,"HIRONO, Mazie",237,144,0,381
+,AB-97,US Representative,2,R,"EVANS, Roger B.",63,45,0,108
+,AB-97,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",1,1,0,2
+,AB-97,State Senate,23,D,"HEE, Clayton",160,96,0,256
+,AB-97,State Senate,23,D,"MURAKI, Noel S.",81,62,0,143
+,AB-97,State Senate,23,R,"FALE, Richard",61,42,0,103
+,AB-97,State Representative,49,D,"CHONG, Pono",233,140,0,373
+,AB-98,Straight Party,,,DEMOCRATIC PARTY (D),628,292,0,920
+,AB-98,Straight Party,,,INDEPENDENT PARTY (I),17,5,0,22
+,AB-98,Straight Party,,,LIBERTARIAN PARTY (L),8,2,0,10
+,AB-98,Straight Party,,,NONPARTISAN BALLOT (N),11,1,0,12
+,AB-98,Straight Party,,,REPUBLICAN PARTY (R),554,138,0,692
+,AB-98,US Representative,2,I,"STENSHOL, Shaun",13,2,0,15
+,AB-98,US Representative,2,D,"HIRONO, Mazie",583,263,0,846
+,AB-98,US Representative,2,R,"EVANS, Roger B.",218,58,0,276
+,AB-98,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",8,2,0,10
+,AB-98,State Representative,50,R,"THIELEN, Cynthia",511,122,0,633
+,AB-99,Straight Party,,,DEMOCRATIC PARTY (D),985,338,0,1323
+,AB-99,Straight Party,,,INDEPENDENT PARTY (I),10,3,0,13
+,AB-99,Straight Party,,,LIBERTARIAN PARTY (L),2,0,0,2
+,AB-99,Straight Party,,,NONPARTISAN BALLOT (N),4,1,0,5
+,AB-99,Straight Party,,,REPUBLICAN PARTY (R),237,71,0,308
+,AB-99,US Representative,2,I,"STENSHOL, Shaun",7,2,0,9
+,AB-99,US Representative,2,D,"HIRONO, Mazie",753,265,0,1018
+,AB-99,US Representative,2,R,"EVANS, Roger B.",118,32,0,150
+,AB-99,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",2,0,0,2
+,AB-99,State Representative,51,D,"ANDERSON, J. Ikaika",326,135,0,461
+,AB-99,State Representative,51,D,"CHRISTENSEN, Shawn Aukai",27,6,0,33
+,AB-99,State Representative,51,D,"LEE, Chris Kalani",563,170,0,733
+,AB-99,State Representative,51,R,"KAWANANAKOA, Quentin Kuhio",229,57,0,286
+,Overseas 100,Straight Party,,,DEMOCRATIC PARTY (D),97,0,0,97
+,Overseas 100,Straight Party,,,INDEPENDENT PARTY (I),1,0,0,1
+,Overseas 100,Straight Party,,,LIBERTARIAN PARTY (L),4,0,0,4
+,Overseas 100,Straight Party,,,NONPARTISAN BALLOT (N),1,0,0,1
+,Overseas 100,Straight Party,,,REPUBLICAN PARTY (R),19,0,0,19
+,Overseas 100,US Representative,1,D,"ABERCROMBIE, Neil",96,0,0,96
+,Overseas 100,US Representative,1,R,"TATAII, Steve",19,0,0,19
+,Overseas 100,US Representative,1,L,"AMSTERDAM, C. Kaui Jochanan",1,0,0,1
+,Overseas 100,US Representative,1,L,"ZHAO, Li",3,0,0,3
+,Overseas 101,Straight Party,,,DEMOCRATIC PARTY (D),80,0,0,80
+,Overseas 101,Straight Party,,,INDEPENDENT PARTY (I),2,0,0,2
+,Overseas 101,Straight Party,,,LIBERTARIAN PARTY (L),4,0,0,4
+,Overseas 101,Straight Party,,,NONPARTISAN BALLOT (N),0,0,0,0
+,Overseas 101,Straight Party,,,REPUBLICAN PARTY (R),18,0,0,18
+,Overseas 101,US Representative,2,I,"STENSHOL, Shaun",2,0,0,2
+,Overseas 101,US Representative,2,D,"HIRONO, Mazie",80,0,0,80
+,Overseas 101,US Representative,2,R,"EVANS, Roger B.",18,0,0,18
+,Overseas 101,US Representative,2,L,"MALLAN, Lloyd J. (Jeff)",4,0,0,4

--- a/2008/20080920__hi__primary__precinct.csv
+++ b/2008/20080920__hi__primary__precinct.csv
@@ -1,1 +1,5366 @@
-county	precinct	office	district	party	candidate	absentee	early_votes	election_day	votesCounty of Hawaii	01-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427County of Hawaii	01-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Hawaii	01-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	01-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	01-01	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44County of Hawaii	01-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	01-01	US Representative	2	D	"HIRONO, Mazie"	0	0	321	321County of Hawaii	01-01	US Representative	2	R	"EVANS, Roger B."	0	0	36	36County of Hawaii	01-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	01-01	State Senate	3	D	"ISBELL, Virginia"	0	0	60	60County of Hawaii	01-01	State Senate	3	D	"GREEN, Josh"	0	0	344	344County of Hawaii	01-01	State Representative	1	D	"FUJIYAMA, Ken"	0	0	53	53County of Hawaii	01-01	State Representative	1	D	"KIM, Jo"	0	0	91	91County of Hawaii	01-01	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	219	219County of Hawaii	01-01	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	17	17County of Hawaii	01-01	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	22	22County of Hawaii	01-01	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	17	17County of Hawaii	01-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	241	241County of Hawaii	01-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	01-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	01-02	Straight Party			REPUBLICAN PARTY (R)	0	0	29	29County of Hawaii	01-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	01-02	US Representative	2	D	"HIRONO, Mazie"	0	0	171	171County of Hawaii	01-02	US Representative	2	R	"EVANS, Roger B."	0	0	25	25County of Hawaii	01-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-02	State Senate	3	D	"ISBELL, Virginia"	0	0	36	36County of Hawaii	01-02	State Senate	3	D	"GREEN, Josh"	0	0	195	195County of Hawaii	01-02	State Representative	1	D	"FUJIYAMA, Ken"	0	0	35	35County of Hawaii	01-02	State Representative	1	D	"KIM, Jo"	0	0	72	72County of Hawaii	01-02	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	86	86County of Hawaii	01-02	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	14	14County of Hawaii	01-02	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	13	13County of Hawaii	01-02	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	10	10County of Hawaii	01-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	82	82County of Hawaii	01-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Hawaii	01-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	01-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	01-03	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11County of Hawaii	01-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	01-03	US Representative	2	D	"HIRONO, Mazie"	0	0	55	55County of Hawaii	01-03	US Representative	2	R	"EVANS, Roger B."	0	0	6	6County of Hawaii	01-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	01-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	61	61County of Hawaii	01-03	State Senate	1	R	"HONG, Ted H.S."	0	0	9	9County of Hawaii	01-03	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7County of Hawaii	01-03	State Representative	1	D	"KIM, Jo"	0	0	32	32County of Hawaii	01-03	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	24	24County of Hawaii	01-03	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6County of Hawaii	01-03	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	7	7County of Hawaii	01-03	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	0	0County of Hawaii	01-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	582	582County of Hawaii	01-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	01-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	01-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	01-04	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58County of Hawaii	01-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	01-04	US Representative	2	D	"HIRONO, Mazie"	0	0	401	401County of Hawaii	01-04	US Representative	2	R	"EVANS, Roger B."	0	0	30	30County of Hawaii	01-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	01-04	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	472	472County of Hawaii	01-04	State Senate	1	R	"HONG, Ted H.S."	0	0	50	50County of Hawaii	01-04	State Representative	1	D	"FUJIYAMA, Ken"	0	0	30	30County of Hawaii	01-04	State Representative	1	D	"KIM, Jo"	0	0	252	252County of Hawaii	01-04	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	250	250County of Hawaii	01-04	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	13	13County of Hawaii	01-04	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	39	39County of Hawaii	01-04	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	10	10County of Hawaii	01-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	246	246County of Hawaii	01-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	01-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Hawaii	01-05	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23County of Hawaii	01-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	01-05	US Representative	2	D	"HIRONO, Mazie"	0	0	162	162County of Hawaii	01-05	US Representative	2	R	"EVANS, Roger B."	0	0	13	13County of Hawaii	01-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	01-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	191	191County of Hawaii	01-05	State Senate	1	R	"HONG, Ted H.S."	0	0	22	22County of Hawaii	01-05	State Representative	1	D	"FUJIYAMA, Ken"	0	0	22	22County of Hawaii	01-05	State Representative	1	D	"KIM, Jo"	0	0	121	121County of Hawaii	01-05	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	79	79County of Hawaii	01-05	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6County of Hawaii	01-05	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	12	12County of Hawaii	01-05	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	4	4County of Hawaii	01-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	56	56County of Hawaii	01-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Hawaii	01-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	01-06	Straight Party			REPUBLICAN PARTY (R)	0	0	10	10County of Hawaii	01-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	01-06	US Representative	2	D	"HIRONO, Mazie"	0	0	42	42County of Hawaii	01-06	US Representative	2	R	"EVANS, Roger B."	0	0	8	8County of Hawaii	01-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	42	42County of Hawaii	01-06	State Senate	1	R	"HONG, Ted H.S."	0	0	8	8County of Hawaii	01-06	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7County of Hawaii	01-06	State Representative	1	D	"KIM, Jo"	0	0	12	12County of Hawaii	01-06	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	33	33County of Hawaii	01-06	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	1	1County of Hawaii	01-06	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	8	8County of Hawaii	01-06	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	1	1County of Hawaii	01-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	185	185County of Hawaii	01-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Hawaii	01-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	01-07	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28County of Hawaii	01-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	01-07	US Representative	2	D	"HIRONO, Mazie"	0	0	132	132County of Hawaii	01-07	US Representative	2	R	"EVANS, Roger B."	0	0	20	20County of Hawaii	01-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	161	161County of Hawaii	01-07	State Senate	1	R	"HONG, Ted H.S."	0	0	25	25County of Hawaii	01-07	State Representative	1	D	"FUJIYAMA, Ken"	0	0	29	29County of Hawaii	01-07	State Representative	1	D	"KIM, Jo"	0	0	61	61County of Hawaii	01-07	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	58	58County of Hawaii	01-07	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	8	8County of Hawaii	01-07	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	19	19County of Hawaii	01-07	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	4	4County of Hawaii	01-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	73	73County of Hawaii	01-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	01-08	Straight Party			REPUBLICAN PARTY (R)	0	0	21	21County of Hawaii	01-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	01-08	US Representative	2	D	"HIRONO, Mazie"	0	0	51	51County of Hawaii	01-08	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Hawaii	01-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-08	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	55	55County of Hawaii	01-08	State Senate	1	R	"HONG, Ted H.S."	0	0	19	19County of Hawaii	01-08	State Representative	1	D	"FUJIYAMA, Ken"	0	0	8	8County of Hawaii	01-08	State Representative	1	D	"KIM, Jo"	0	0	20	20County of Hawaii	01-08	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	28	28County of Hawaii	01-08	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6County of Hawaii	01-08	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	15	15County of Hawaii	01-08	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	2	2County of Hawaii	01-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	74	74County of Hawaii	01-09	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	01-09	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8County of Hawaii	01-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	01-09	US Representative	2	D	"HIRONO, Mazie"	0	0	56	56County of Hawaii	01-09	US Representative	2	R	"EVANS, Roger B."	0	0	5	5County of Hawaii	01-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-09	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	63	63County of Hawaii	01-09	State Senate	1	R	"HONG, Ted H.S."	0	0	6	6County of Hawaii	01-09	State Representative	1	D	"FUJIYAMA, Ken"	0	0	24	24County of Hawaii	01-09	State Representative	1	D	"KIM, Jo"	0	0	18	18County of Hawaii	01-09	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	25	25County of Hawaii	01-09	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	2	2County of Hawaii	01-09	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	5	5County of Hawaii	01-09	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	3	3County of Hawaii	01-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	116	116County of Hawaii	01-10	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	01-10	Straight Party			REPUBLICAN PARTY (R)	0	0	18	18County of Hawaii	01-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	01-10	US Representative	2	D	"HIRONO, Mazie"	0	0	77	77County of Hawaii	01-10	US Representative	2	R	"EVANS, Roger B."	0	0	9	9County of Hawaii	01-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-10	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	99	99County of Hawaii	01-10	State Senate	1	R	"HONG, Ted H.S."	0	0	17	17County of Hawaii	01-10	State Representative	1	D	"FUJIYAMA, Ken"	0	0	22	22County of Hawaii	01-10	State Representative	1	D	"KIM, Jo"	0	0	22	22County of Hawaii	01-10	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	43	43County of Hawaii	01-10	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	4	4County of Hawaii	01-10	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	8	8County of Hawaii	01-10	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	3	3County of Hawaii	01-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313County of Hawaii	01-11	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5County of Hawaii	01-11	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17County of Hawaii	01-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	01-11	US Representative	2	D	"HIRONO, Mazie"	0	0	247	247County of Hawaii	01-11	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Hawaii	01-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-11	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	283	283County of Hawaii	01-11	State Senate	1	R	"HONG, Ted H.S."	0	0	15	15County of Hawaii	01-11	State Representative	1	D	"FUJIYAMA, Ken"	0	0	52	52County of Hawaii	01-11	State Representative	1	D	"KIM, Jo"	0	0	51	51County of Hawaii	01-11	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	170	170County of Hawaii	01-11	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	12	12County of Hawaii	01-11	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	11	11County of Hawaii	01-11	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	2	2County of Hawaii	01-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	228	228County of Hawaii	01-12	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	01-12	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56County of Hawaii	01-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	01-12	US Representative	2	D	"HIRONO, Mazie"	0	0	170	170County of Hawaii	01-12	US Representative	2	R	"EVANS, Roger B."	0	0	25	25County of Hawaii	01-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-12	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	176	176County of Hawaii	01-12	State Senate	1	R	"HONG, Ted H.S."	0	0	43	43County of Hawaii	01-12	State Representative	1	D	"FUJIYAMA, Ken"	0	0	64	64County of Hawaii	01-12	State Representative	1	D	"KIM, Jo"	0	0	39	39County of Hawaii	01-12	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	91	91County of Hawaii	01-12	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	8	8County of Hawaii	01-12	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	20	20County of Hawaii	01-12	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	19	19County of Hawaii	01-13	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317County of Hawaii	01-13	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-13	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	01-13	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	01-13	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47County of Hawaii	01-13	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	01-13	US Representative	2	D	"HIRONO, Mazie"	0	0	213	213County of Hawaii	01-13	US Representative	2	R	"EVANS, Roger B."	0	0	26	26County of Hawaii	01-13	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	01-13	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	231	231County of Hawaii	01-13	State Senate	1	R	"HONG, Ted H.S."	0	0	42	42County of Hawaii	01-13	State Representative	1	D	"FUJIYAMA, Ken"	0	0	81	81County of Hawaii	01-13	State Representative	1	D	"KIM, Jo"	0	0	63	63County of Hawaii	01-13	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	114	114County of Hawaii	01-13	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	17	17County of Hawaii	01-13	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	10	10County of Hawaii	01-13	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	14	14County of Hawaii	01-14	Straight Party			DEMOCRATIC PARTY (D)	0	0	97	97County of Hawaii	01-14	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	01-14	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	01-14	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	01-14	Straight Party			REPUBLICAN PARTY (R)	0	0	16	16County of Hawaii	01-14	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	01-14	US Representative	2	D	"HIRONO, Mazie"	0	0	81	81County of Hawaii	01-14	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Hawaii	01-14	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	01-14	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	72	72County of Hawaii	01-14	State Senate	1	R	"HONG, Ted H.S."	0	0	14	14County of Hawaii	01-14	State Representative	1	D	"FUJIYAMA, Ken"	0	0	29	29County of Hawaii	01-14	State Representative	1	D	"KIM, Jo"	0	0	23	23County of Hawaii	01-14	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	16	16County of Hawaii	01-14	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	11	11County of Hawaii	01-14	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	9	9County of Hawaii	01-14	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	6	6County of Hawaii	01-15	Straight Party			DEMOCRATIC PARTY (D)	0	0	95	95County of Hawaii	01-15	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Hawaii	01-15	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	01-15	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	01-15	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23County of Hawaii	01-15	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	01-15	US Representative	2	D	"HIRONO, Mazie"	0	0	82	82County of Hawaii	01-15	US Representative	2	R	"EVANS, Roger B."	0	0	23	23County of Hawaii	01-15	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Hawaii	01-15	State Senate	3	D	"ISBELL, Virginia"	0	0	14	14County of Hawaii	01-15	State Senate	3	D	"GREEN, Josh"	0	0	73	73County of Hawaii	01-15	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7County of Hawaii	01-15	State Representative	1	D	"KIM, Jo"	0	0	30	30County of Hawaii	01-15	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	30	30County of Hawaii	01-15	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	12	12County of Hawaii	01-15	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	7	7County of Hawaii	01-15	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	12	12County of Hawaii	02-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	683	683County of Hawaii	02-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5County of Hawaii	02-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	02-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	02-01	Straight Party			REPUBLICAN PARTY (R)	0	0	135	135County of Hawaii	02-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	02-01	US Representative	2	D	"HIRONO, Mazie"	0	0	480	480County of Hawaii	02-01	US Representative	2	R	"EVANS, Roger B."	0	0	44	44County of Hawaii	02-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	02-01	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	476	476County of Hawaii	02-01	State Senate	1	R	"HONG, Ted H.S."	0	0	124	124County of Hawaii	02-01	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	420	420County of Hawaii	02-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	367	367County of Hawaii	02-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	02-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	02-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Hawaii	02-02	Straight Party			REPUBLICAN PARTY (R)	0	0	77	77County of Hawaii	02-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	02-02	US Representative	2	D	"HIRONO, Mazie"	0	0	264	264County of Hawaii	02-02	US Representative	2	R	"EVANS, Roger B."	0	0	29	29County of Hawaii	02-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	02-02	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	252	252County of Hawaii	02-02	State Senate	1	R	"HONG, Ted H.S."	0	0	72	72County of Hawaii	02-02	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	253	253County of Hawaii	02-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	520	520County of Hawaii	02-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Hawaii	02-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	02-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Hawaii	02-03	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107County of Hawaii	02-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Hawaii	02-03	US Representative	2	D	"HIRONO, Mazie"	0	0	390	390County of Hawaii	02-03	US Representative	2	R	"EVANS, Roger B."	0	0	49	49County of Hawaii	02-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	02-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	367	367County of Hawaii	02-03	State Senate	1	R	"HONG, Ted H.S."	0	0	96	96County of Hawaii	02-03	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	352	352County of Hawaii	02-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129County of Hawaii	02-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	02-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	02-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	02-04	Straight Party			REPUBLICAN PARTY (R)	0	0	30	30County of Hawaii	02-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	02-04	US Representative	2	D	"HIRONO, Mazie"	0	0	92	92County of Hawaii	02-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17County of Hawaii	02-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	02-04	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	85	85County of Hawaii	02-04	State Senate	1	R	"HONG, Ted H.S."	0	0	25	25County of Hawaii	02-04	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	73	73County of Hawaii	02-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	224	224County of Hawaii	02-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	02-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4County of Hawaii	02-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	02-05	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32County of Hawaii	02-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	02-05	US Representative	2	D	"HIRONO, Mazie"	0	0	169	169County of Hawaii	02-05	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Hawaii	02-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4County of Hawaii	02-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	136	136County of Hawaii	02-05	State Senate	1	R	"HONG, Ted H.S."	0	0	26	26County of Hawaii	02-05	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	125	125County of Hawaii	02-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	335	335County of Hawaii	02-06	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5County of Hawaii	02-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	02-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	02-06	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45County of Hawaii	02-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Hawaii	02-06	US Representative	2	D	"HIRONO, Mazie"	0	0	227	227County of Hawaii	02-06	US Representative	2	R	"EVANS, Roger B."	0	0	19	19County of Hawaii	02-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	02-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	223	223County of Hawaii	02-06	State Senate	1	R	"HONG, Ted H.S."	0	0	41	41County of Hawaii	02-06	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	214	214County of Hawaii	02-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	148	148County of Hawaii	02-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	02-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	02-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	02-07	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20County of Hawaii	02-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	02-07	US Representative	2	D	"HIRONO, Mazie"	0	0	104	104County of Hawaii	02-07	US Representative	2	R	"EVANS, Roger B."	0	0	6	6County of Hawaii	02-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	02-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	112	112County of Hawaii	02-07	State Senate	1	R	"HONG, Ted H.S."	0	0	16	16County of Hawaii	02-07	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	106	106County of Hawaii	02-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	259	259County of Hawaii	02-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Hawaii	02-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	02-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	02-08	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40County of Hawaii	02-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	02-08	US Representative	2	D	"HIRONO, Mazie"	0	0	183	183County of Hawaii	02-08	US Representative	2	R	"EVANS, Roger B."	0	0	11	11County of Hawaii	02-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	02-08	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	185	185County of Hawaii	02-08	State Senate	1	R	"HONG, Ted H.S."	0	0	33	33County of Hawaii	02-08	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	167	167County of Hawaii	03-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	493	493County of Hawaii	03-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Hawaii	03-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	03-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Hawaii	03-01	Straight Party			REPUBLICAN PARTY (R)	0	0	41	41County of Hawaii	03-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	03-01	US Representative	2	D	"HIRONO, Mazie"	0	0	351	351County of Hawaii	03-01	US Representative	2	R	"EVANS, Roger B."	0	0	27	27County of Hawaii	03-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	03-01	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	362	362County of Hawaii	03-01	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	23	23County of Hawaii	03-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	127	127County of Hawaii	03-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	03-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	03-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5County of Hawaii	03-02	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13County of Hawaii	03-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	03-02	US Representative	2	D	"HIRONO, Mazie"	0	0	91	91County of Hawaii	03-02	US Representative	2	R	"EVANS, Roger B."	0	0	9	9County of Hawaii	03-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	03-02	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	111	111County of Hawaii	03-02	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	8	8County of Hawaii	03-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129County of Hawaii	03-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Hawaii	03-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	03-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	03-03	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20County of Hawaii	03-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	03-03	US Representative	2	D	"HIRONO, Mazie"	0	0	97	97County of Hawaii	03-03	US Representative	2	R	"EVANS, Roger B."	0	0	4	4County of Hawaii	03-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	03-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	101	101County of Hawaii	03-03	State Senate	1	R	"HONG, Ted H.S."	0	0	19	19County of Hawaii	03-03	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	101	101County of Hawaii	03-03	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	4	4County of Hawaii	03-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	499	499County of Hawaii	03-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	03-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	03-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Hawaii	03-04	Straight Party			REPUBLICAN PARTY (R)	0	0	46	46County of Hawaii	03-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	03-04	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380County of Hawaii	03-04	US Representative	2	R	"EVANS, Roger B."	0	0	32	32County of Hawaii	03-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	03-04	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	392	392County of Hawaii	03-04	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	23	23County of Hawaii	03-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	490	490County of Hawaii	03-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Hawaii	03-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	03-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	03-05	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63County of Hawaii	03-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6County of Hawaii	03-05	US Representative	2	D	"HIRONO, Mazie"	0	0	400	400County of Hawaii	03-05	US Representative	2	R	"EVANS, Roger B."	0	0	48	48County of Hawaii	03-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	03-05	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	362	362County of Hawaii	03-05	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	44	44County of Hawaii	03-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	709	709County of Hawaii	03-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Hawaii	03-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	03-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	15	15County of Hawaii	03-06	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78County of Hawaii	03-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Hawaii	03-06	US Representative	2	D	"HIRONO, Mazie"	0	0	499	499County of Hawaii	03-06	US Representative	2	R	"EVANS, Roger B."	0	0	30	30County of Hawaii	03-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	03-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	509	509County of Hawaii	03-06	State Senate	1	R	"HONG, Ted H.S."	0	0	65	65County of Hawaii	03-06	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	499	499County of Hawaii	03-06	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	28	28County of Hawaii	03-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	401	401County of Hawaii	03-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Hawaii	03-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	03-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Hawaii	03-07	Straight Party			REPUBLICAN PARTY (R)	0	0	37	37County of Hawaii	03-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	03-07	US Representative	2	D	"HIRONO, Mazie"	0	0	316	316County of Hawaii	03-07	US Representative	2	R	"EVANS, Roger B."	0	0	27	27County of Hawaii	03-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Hawaii	03-07	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	310	310County of Hawaii	03-07	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	16	16County of Hawaii	03-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	601	601County of Hawaii	03-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Hawaii	03-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	03-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Hawaii	03-08	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54County of Hawaii	03-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Hawaii	03-08	US Representative	2	D	"HIRONO, Mazie"	0	0	469	469County of Hawaii	03-08	US Representative	2	R	"EVANS, Roger B."	0	0	35	35County of Hawaii	03-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Hawaii	03-08	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	447	447County of Hawaii	03-08	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	38	38County of Hawaii	04-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	406	406County of Hawaii	04-01	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8County of Hawaii	04-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4County of Hawaii	04-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5County of Hawaii	04-01	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78County of Hawaii	04-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7County of Hawaii	04-01	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305County of Hawaii	04-01	US Representative	2	R	"EVANS, Roger B."	0	0	49	49County of Hawaii	04-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4County of Hawaii	04-01	State Representative	4	D	"HANOHANO, Faye P."	0	0	184	184County of Hawaii	04-01	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	76	76County of Hawaii	04-01	State Representative	4	D	"SPARKS, Steven B."	0	0	92	92County of Hawaii	04-01	State Representative	4	R	"BLAS, Fred"	0	0	56	56County of Hawaii	04-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	306	306County of Hawaii	04-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5County of Hawaii	04-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	04-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8County of Hawaii	04-02	Straight Party			REPUBLICAN PARTY (R)	0	0	52	52County of Hawaii	04-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Hawaii	04-02	US Representative	2	D	"HIRONO, Mazie"	0	0	234	234County of Hawaii	04-02	US Representative	2	R	"EVANS, Roger B."	0	0	38	38County of Hawaii	04-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	04-02	State Representative	4	D	"HANOHANO, Faye P."	0	0	144	144County of Hawaii	04-02	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	66	66County of Hawaii	04-02	State Representative	4	D	"SPARKS, Steven B."	0	0	58	58County of Hawaii	04-02	State Representative	4	R	"BLAS, Fred"	0	0	38	38County of Hawaii	04-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	517	517County of Hawaii	04-03	Straight Party			INDEPENDENT PARTY (I)	0	0	12	12County of Hawaii	04-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10County of Hawaii	04-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Hawaii	04-03	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108County of Hawaii	04-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11County of Hawaii	04-03	US Representative	2	D	"HIRONO, Mazie"	0	0	354	354County of Hawaii	04-03	US Representative	2	R	"EVANS, Roger B."	0	0	67	67County of Hawaii	04-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	10	10County of Hawaii	04-03	State Representative	4	D	"HANOHANO, Faye P."	0	0	186	186County of Hawaii	04-03	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	159	159County of Hawaii	04-03	State Representative	4	D	"SPARKS, Steven B."	0	0	109	109County of Hawaii	04-03	State Representative	4	R	"BLAS, Fred"	0	0	74	74County of Hawaii	04-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	396	396County of Hawaii	04-04	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6County of Hawaii	04-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	04-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	04-04	Straight Party			REPUBLICAN PARTY (R)	0	0	126	126County of Hawaii	04-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Hawaii	04-04	US Representative	2	D	"HIRONO, Mazie"	0	0	284	284County of Hawaii	04-04	US Representative	2	R	"EVANS, Roger B."	0	0	50	50County of Hawaii	04-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Hawaii	04-04	State Representative	4	D	"HANOHANO, Faye P."	0	0	213	213County of Hawaii	04-04	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	90	90County of Hawaii	04-04	State Representative	4	D	"SPARKS, Steven B."	0	0	45	45County of Hawaii	04-04	State Representative	4	R	"BLAS, Fred"	0	0	116	116County of Hawaii	04-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	677	677County of Hawaii	04-05	Straight Party			INDEPENDENT PARTY (I)	0	0	18	18County of Hawaii	04-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7County of Hawaii	04-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10County of Hawaii	04-05	Straight Party			REPUBLICAN PARTY (R)	0	0	94	94County of Hawaii	04-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	14	14County of Hawaii	04-05	US Representative	2	D	"HIRONO, Mazie"	0	0	410	410County of Hawaii	04-05	US Representative	2	R	"EVANS, Roger B."	0	0	52	52County of Hawaii	04-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6County of Hawaii	04-05	State Representative	4	D	"HANOHANO, Faye P."	0	0	199	199County of Hawaii	04-05	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	264	264County of Hawaii	04-05	State Representative	4	D	"SPARKS, Steven B."	0	0	161	161County of Hawaii	04-05	State Representative	4	R	"BLAS, Fred"	0	0	67	67County of Hawaii	04-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421County of Hawaii	04-06	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9County of Hawaii	04-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4County of Hawaii	04-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9County of Hawaii	04-06	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107County of Hawaii	04-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7County of Hawaii	04-06	US Representative	2	D	"HIRONO, Mazie"	0	0	317	317County of Hawaii	04-06	US Representative	2	R	"EVANS, Roger B."	0	0	75	75County of Hawaii	04-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4County of Hawaii	04-06	State Representative	4	D	"HANOHANO, Faye P."	0	0	208	208County of Hawaii	04-06	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	105	105County of Hawaii	04-06	State Representative	4	D	"SPARKS, Steven B."	0	0	61	61County of Hawaii	04-06	State Representative	4	R	"BLAS, Fred"	0	0	69	69County of Hawaii	04-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	166	166County of Hawaii	04-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	04-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	04-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	04-07	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19County of Hawaii	04-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	04-07	US Representative	2	D	"HIRONO, Mazie"	0	0	85	85County of Hawaii	04-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10County of Hawaii	04-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	04-07	State Representative	4	D	"HANOHANO, Faye P."	0	0	44	44County of Hawaii	04-07	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	46	46County of Hawaii	04-07	State Representative	4	D	"SPARKS, Steven B."	0	0	58	58County of Hawaii	04-07	State Representative	4	R	"BLAS, Fred"	0	0	16	16County of Hawaii	04-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236County of Hawaii	04-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	04-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	04-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	04-08	Straight Party			REPUBLICAN PARTY (R)	0	0	62	62County of Hawaii	04-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	04-08	US Representative	2	D	"HIRONO, Mazie"	0	0	175	175County of Hawaii	04-08	US Representative	2	R	"EVANS, Roger B."	0	0	42	42County of Hawaii	04-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	04-08	State Representative	4	D	"HANOHANO, Faye P."	0	0	116	116County of Hawaii	04-08	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	69	69County of Hawaii	04-08	State Representative	4	D	"SPARKS, Steven B."	0	0	25	25County of Hawaii	04-08	State Representative	4	R	"BLAS, Fred"	0	0	47	47County of Hawaii	05-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	142	142County of Hawaii	05-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Hawaii	05-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	05-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Hawaii	05-01	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24County of Hawaii	05-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6County of Hawaii	05-01	US Representative	2	D	"HIRONO, Mazie"	0	0	112	112County of Hawaii	05-01	US Representative	2	R	"EVANS, Roger B."	0	0	23	23County of Hawaii	05-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Hawaii	05-01	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	83	83County of Hawaii	05-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	298	298County of Hawaii	05-02	Straight Party			INDEPENDENT PARTY (I)	0	0	16	16County of Hawaii	05-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	05-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12County of Hawaii	05-02	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61County of Hawaii	05-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	16	16County of Hawaii	05-02	US Representative	2	D	"HIRONO, Mazie"	0	0	244	244County of Hawaii	05-02	US Representative	2	R	"EVANS, Roger B."	0	0	57	57County of Hawaii	05-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Hawaii	05-02	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	152	152County of Hawaii	05-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	469	469County of Hawaii	05-03	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15County of Hawaii	05-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	19	19County of Hawaii	05-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10County of Hawaii	05-03	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101County of Hawaii	05-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	13	13County of Hawaii	05-03	US Representative	2	D	"HIRONO, Mazie"	0	0	370	370County of Hawaii	05-03	US Representative	2	R	"EVANS, Roger B."	0	0	96	96County of Hawaii	05-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	19	19County of Hawaii	05-03	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	280	280County of Hawaii	05-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	205	205County of Hawaii	05-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	05-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	05-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Hawaii	05-04	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11County of Hawaii	05-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	05-04	US Representative	2	D	"HIRONO, Mazie"	0	0	169	169County of Hawaii	05-04	US Representative	2	R	"EVANS, Roger B."	0	0	10	10County of Hawaii	05-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	05-04	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	122	122County of Hawaii	05-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267County of Hawaii	05-05	Straight Party			INDEPENDENT PARTY (I)	0	0	21	21County of Hawaii	05-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	05-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10County of Hawaii	05-05	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53County of Hawaii	05-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	19	19County of Hawaii	05-05	US Representative	2	D	"HIRONO, Mazie"	0	0	203	203County of Hawaii	05-05	US Representative	2	R	"EVANS, Roger B."	0	0	48	48County of Hawaii	05-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Hawaii	05-05	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	171	171County of Hawaii	05-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	343	343County of Hawaii	05-06	Straight Party			INDEPENDENT PARTY (I)	0	0	12	12County of Hawaii	05-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	12	12County of Hawaii	05-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12County of Hawaii	05-06	Straight Party			REPUBLICAN PARTY (R)	0	0	97	97County of Hawaii	05-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10County of Hawaii	05-06	US Representative	2	D	"HIRONO, Mazie"	0	0	268	268County of Hawaii	05-06	US Representative	2	R	"EVANS, Roger B."	0	0	94	94County of Hawaii	05-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	11	11County of Hawaii	05-06	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	190	190County of Hawaii	05-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	115	115County of Hawaii	05-07	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	05-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	05-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	05-07	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11County of Hawaii	05-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	05-07	US Representative	2	D	"HIRONO, Mazie"	0	0	67	67County of Hawaii	05-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10County of Hawaii	05-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	05-07	State Senate	3	D	"ISBELL, Virginia"	0	0	30	30County of Hawaii	05-07	State Senate	3	D	"GREEN, Josh"	0	0	77	77County of Hawaii	05-07	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	66	66County of Hawaii	05-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	130	130County of Hawaii	05-08	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	05-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	05-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	05-08	Straight Party			REPUBLICAN PARTY (R)	0	0	9	9County of Hawaii	05-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	05-08	US Representative	2	D	"HIRONO, Mazie"	0	0	80	80County of Hawaii	05-08	US Representative	2	R	"EVANS, Roger B."	0	0	8	8County of Hawaii	05-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	05-08	State Senate	3	D	"ISBELL, Virginia"	0	0	43	43County of Hawaii	05-08	State Senate	3	D	"GREEN, Josh"	0	0	81	81County of Hawaii	05-08	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	68	68County of Hawaii	05-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	280	280County of Hawaii	05-09	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	05-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Hawaii	05-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	05-09	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15County of Hawaii	05-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	05-09	US Representative	2	D	"HIRONO, Mazie"	0	0	177	177County of Hawaii	05-09	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Hawaii	05-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	05-09	State Senate	3	D	"ISBELL, Virginia"	0	0	94	94County of Hawaii	05-09	State Senate	3	D	"GREEN, Josh"	0	0	174	174County of Hawaii	05-09	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	160	160County of Hawaii	05-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	119	119County of Hawaii	05-10	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	05-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	05-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	05-10	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13County of Hawaii	05-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	05-10	US Representative	2	D	"HIRONO, Mazie"	0	0	86	86County of Hawaii	05-10	US Representative	2	R	"EVANS, Roger B."	0	0	11	11County of Hawaii	05-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	05-10	State Senate	3	D	"ISBELL, Virginia"	0	0	36	36County of Hawaii	05-10	State Senate	3	D	"GREEN, Josh"	0	0	77	77County of Hawaii	05-10	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	76	76County of Hawaii	05-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	481	481County of Hawaii	05-11	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	05-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	05-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5County of Hawaii	05-11	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43County of Hawaii	05-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	05-11	US Representative	2	D	"HIRONO, Mazie"	0	0	331	331County of Hawaii	05-11	US Representative	2	R	"EVANS, Roger B."	0	0	39	39County of Hawaii	05-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	05-11	State Senate	3	D	"ISBELL, Virginia"	0	0	144	144County of Hawaii	05-11	State Senate	3	D	"GREEN, Josh"	0	0	312	312County of Hawaii	05-11	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	267	267County of Hawaii	05-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	412	412County of Hawaii	05-12	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Hawaii	05-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	05-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	05-12	Straight Party			REPUBLICAN PARTY (R)	0	0	60	60County of Hawaii	05-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Hawaii	05-12	US Representative	2	D	"HIRONO, Mazie"	0	0	278	278County of Hawaii	05-12	US Representative	2	R	"EVANS, Roger B."	0	0	56	56County of Hawaii	05-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	05-12	State Senate	3	D	"ISBELL, Virginia"	0	0	122	122County of Hawaii	05-12	State Senate	3	D	"GREEN, Josh"	0	0	277	277County of Hawaii	05-12	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	255	255County of Hawaii	06-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	301	301County of Hawaii	06-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6County of Hawaii	06-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	06-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4County of Hawaii	06-01	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63County of Hawaii	06-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	06-01	US Representative	2	D	"HIRONO, Mazie"	0	0	205	205County of Hawaii	06-01	US Representative	2	R	"EVANS, Roger B."	0	0	33	33County of Hawaii	06-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	06-01	State Senate	3	D	"ISBELL, Virginia"	0	0	69	69County of Hawaii	06-01	State Senate	3	D	"GREEN, Josh"	0	0	224	224County of Hawaii	06-01	State Representative	6	D	"COFFMAN, Denny"	0	0	101	101County of Hawaii	06-01	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	88	88County of Hawaii	06-01	State Representative	6	D	"MACGREGOR, Maegan"	0	0	47	47County of Hawaii	06-01	State Representative	6	R	"SMITH, Andy"	0	0	49	49County of Hawaii	06-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	554	554County of Hawaii	06-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6County of Hawaii	06-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	06-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	06-02	Straight Party			REPUBLICAN PARTY (R)	0	0	152	152County of Hawaii	06-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6County of Hawaii	06-02	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380County of Hawaii	06-02	US Representative	2	R	"EVANS, Roger B."	0	0	84	84County of Hawaii	06-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	06-02	State Senate	3	D	"ISBELL, Virginia"	0	0	86	86County of Hawaii	06-02	State Senate	3	D	"GREEN, Josh"	0	0	458	458County of Hawaii	06-02	State Representative	6	D	"COFFMAN, Denny"	0	0	287	287County of Hawaii	06-02	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	106	106County of Hawaii	06-02	State Representative	6	D	"MACGREGOR, Maegan"	0	0	74	74County of Hawaii	06-02	State Representative	6	R	"SMITH, Andy"	0	0	129	129County of Hawaii	06-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	214	214County of Hawaii	06-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	06-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	06-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Hawaii	06-03	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81County of Hawaii	06-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	06-03	US Representative	2	D	"HIRONO, Mazie"	0	0	145	145County of Hawaii	06-03	US Representative	2	R	"EVANS, Roger B."	0	0	43	43County of Hawaii	06-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	06-03	State Senate	3	D	"ISBELL, Virginia"	0	0	32	32County of Hawaii	06-03	State Senate	3	D	"GREEN, Josh"	0	0	179	179County of Hawaii	06-03	State Representative	6	D	"COFFMAN, Denny"	0	0	98	98County of Hawaii	06-03	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	30	30County of Hawaii	06-03	State Representative	6	D	"MACGREGOR, Maegan"	0	0	32	32County of Hawaii	06-03	State Representative	6	R	"SMITH, Andy"	0	0	73	73County of Hawaii	06-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	282	282County of Hawaii	06-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Hawaii	06-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	06-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	06-04	Straight Party			REPUBLICAN PARTY (R)	0	0	95	95County of Hawaii	06-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Hawaii	06-04	US Representative	2	D	"HIRONO, Mazie"	0	0	180	180County of Hawaii	06-04	US Representative	2	R	"EVANS, Roger B."	0	0	57	57County of Hawaii	06-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	06-04	State Senate	3	D	"ISBELL, Virginia"	0	0	49	49County of Hawaii	06-04	State Senate	3	D	"GREEN, Josh"	0	0	223	223County of Hawaii	06-04	State Representative	6	D	"COFFMAN, Denny"	0	0	74	74County of Hawaii	06-04	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	119	119County of Hawaii	06-04	State Representative	6	D	"MACGREGOR, Maegan"	0	0	34	34County of Hawaii	06-04	State Representative	6	R	"SMITH, Andy"	0	0	76	76County of Hawaii	06-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	286	286County of Hawaii	06-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Hawaii	06-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	06-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Hawaii	06-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81County of Hawaii	06-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Hawaii	06-05	US Representative	2	D	"HIRONO, Mazie"	0	0	187	187County of Hawaii	06-05	US Representative	2	R	"EVANS, Roger B."	0	0	43	43County of Hawaii	06-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	06-05	State Senate	3	D	"ISBELL, Virginia"	0	0	65	65County of Hawaii	06-05	State Senate	3	D	"GREEN, Josh"	0	0	210	210County of Hawaii	06-05	State Representative	6	D	"COFFMAN, Denny"	0	0	81	81County of Hawaii	06-05	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	88	88County of Hawaii	06-05	State Representative	6	D	"MACGREGOR, Maegan"	0	0	45	45County of Hawaii	06-05	State Representative	6	R	"SMITH, Andy"	0	0	69	69County of Hawaii	06-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	216	216County of Hawaii	06-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	06-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	06-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Hawaii	06-06	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67County of Hawaii	06-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	06-06	US Representative	2	D	"HIRONO, Mazie"	0	0	162	162County of Hawaii	06-06	US Representative	2	R	"EVANS, Roger B."	0	0	34	34County of Hawaii	06-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	06-06	State Senate	3	D	"ISBELL, Virginia"	0	0	51	51County of Hawaii	06-06	State Senate	3	D	"GREEN, Josh"	0	0	153	153County of Hawaii	06-06	State Representative	6	D	"COFFMAN, Denny"	0	0	73	73County of Hawaii	06-06	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	68	68County of Hawaii	06-06	State Representative	6	D	"MACGREGOR, Maegan"	0	0	38	38County of Hawaii	06-06	State Representative	6	R	"SMITH, Andy"	0	0	60	60County of Hawaii	06-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	183	183County of Hawaii	06-07	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5County of Hawaii	06-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	06-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8County of Hawaii	06-07	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54County of Hawaii	06-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	06-07	US Representative	2	D	"HIRONO, Mazie"	0	0	129	129County of Hawaii	06-07	US Representative	2	R	"EVANS, Roger B."	0	0	33	33County of Hawaii	06-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	06-07	State Senate	3	D	"ISBELL, Virginia"	0	0	24	24County of Hawaii	06-07	State Senate	3	D	"GREEN, Josh"	0	0	155	155County of Hawaii	06-07	State Representative	6	D	"COFFMAN, Denny"	0	0	79	79County of Hawaii	06-07	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	42	42County of Hawaii	06-07	State Representative	6	D	"MACGREGOR, Maegan"	0	0	25	25County of Hawaii	06-07	State Representative	6	R	"SMITH, Andy"	0	0	49	49County of Hawaii	06-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	291	291County of Hawaii	06-08	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Hawaii	06-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	06-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4County of Hawaii	06-08	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51County of Hawaii	06-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	06-08	US Representative	2	D	"HIRONO, Mazie"	0	0	206	206County of Hawaii	06-08	US Representative	2	R	"EVANS, Roger B."	0	0	30	30County of Hawaii	06-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	06-08	State Senate	3	D	"ISBELL, Virginia"	0	0	75	75County of Hawaii	06-08	State Senate	3	D	"GREEN, Josh"	0	0	200	200County of Hawaii	06-08	State Representative	6	D	"COFFMAN, Denny"	0	0	77	77County of Hawaii	06-08	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	93	93County of Hawaii	06-08	State Representative	6	D	"MACGREGOR, Maegan"	0	0	56	56County of Hawaii	06-08	State Representative	6	R	"SMITH, Andy"	0	0	39	39County of Hawaii	07-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	240	240County of Hawaii	07-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	07-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Hawaii	07-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4County of Hawaii	07-01	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57County of Hawaii	07-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Hawaii	07-01	US Representative	2	D	"HIRONO, Mazie"	0	0	158	158County of Hawaii	07-01	US Representative	2	R	"EVANS, Roger B."	0	0	45	45County of Hawaii	07-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Hawaii	07-01	State Senate	3	D	"ISBELL, Virginia"	0	0	40	40County of Hawaii	07-01	State Senate	3	D	"GREEN, Josh"	0	0	182	182County of Hawaii	07-01	State Representative	7	D	"EVANS, Cindy"	0	0	162	162County of Hawaii	07-01	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	32	32County of Hawaii	07-01	State Representative	7	R	"KAILIMAI, B.J."	0	0	17	17County of Hawaii	07-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	593	593County of Hawaii	07-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Hawaii	07-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	07-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12County of Hawaii	07-02	Straight Party			REPUBLICAN PARTY (R)	0	0	139	139County of Hawaii	07-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Hawaii	07-02	US Representative	2	D	"HIRONO, Mazie"	0	0	368	368County of Hawaii	07-02	US Representative	2	R	"EVANS, Roger B."	0	0	107	107County of Hawaii	07-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	07-02	State Senate	3	D	"ISBELL, Virginia"	0	0	142	142County of Hawaii	07-02	State Senate	3	D	"GREEN, Josh"	0	0	410	410County of Hawaii	07-02	State Representative	7	D	"EVANS, Cindy"	0	0	379	379County of Hawaii	07-02	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	62	62County of Hawaii	07-02	State Representative	7	R	"KAILIMAI, B.J."	0	0	36	36County of Hawaii	07-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	498	498County of Hawaii	07-03	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10County of Hawaii	07-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7County of Hawaii	07-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11County of Hawaii	07-03	Straight Party			REPUBLICAN PARTY (R)	0	0	166	166County of Hawaii	07-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10County of Hawaii	07-03	US Representative	2	D	"HIRONO, Mazie"	0	0	346	346County of Hawaii	07-03	US Representative	2	R	"EVANS, Roger B."	0	0	121	121County of Hawaii	07-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	7	7County of Hawaii	07-03	State Senate	3	D	"ISBELL, Virginia"	0	0	81	81County of Hawaii	07-03	State Senate	3	D	"GREEN, Josh"	0	0	348	348County of Hawaii	07-03	State Representative	7	D	"EVANS, Cindy"	0	0	401	401County of Hawaii	07-03	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	86	86County of Hawaii	07-03	State Representative	7	R	"KAILIMAI, B.J."	0	0	61	61County of Hawaii	07-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	70	70County of Hawaii	07-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	07-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	07-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	07-04	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26County of Hawaii	07-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	07-04	US Representative	2	D	"HIRONO, Mazie"	0	0	53	53County of Hawaii	07-04	US Representative	2	R	"EVANS, Roger B."	0	0	18	18County of Hawaii	07-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	07-04	State Senate	3	D	"ISBELL, Virginia"	0	0	9	9County of Hawaii	07-04	State Senate	3	D	"GREEN, Josh"	0	0	51	51County of Hawaii	07-04	State Representative	7	D	"EVANS, Cindy"	0	0	52	52County of Hawaii	07-04	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	13	13County of Hawaii	07-04	State Representative	7	R	"KAILIMAI, B.J."	0	0	6	6County of Hawaii	07-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	329	329County of Hawaii	07-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	07-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4County of Hawaii	07-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4County of Hawaii	07-05	Straight Party			REPUBLICAN PARTY (R)	0	0	131	131County of Hawaii	07-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	07-05	US Representative	2	D	"HIRONO, Mazie"	0	0	216	216County of Hawaii	07-05	US Representative	2	R	"EVANS, Roger B."	0	0	84	84County of Hawaii	07-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4County of Hawaii	07-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	223	223County of Hawaii	07-05	State Senate	1	R	"HONG, Ted H.S."	0	0	94	94County of Hawaii	07-05	State Representative	7	D	"EVANS, Cindy"	0	0	210	210County of Hawaii	07-05	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	48	48County of Hawaii	07-05	State Representative	7	R	"KAILIMAI, B.J."	0	0	64	64County of Hawaii	07-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319County of Hawaii	07-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	07-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	07-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5County of Hawaii	07-06	Straight Party			REPUBLICAN PARTY (R)	0	0	104	104County of Hawaii	07-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	07-06	US Representative	2	D	"HIRONO, Mazie"	0	0	204	204County of Hawaii	07-06	US Representative	2	R	"EVANS, Roger B."	0	0	55	55County of Hawaii	07-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	07-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	214	214County of Hawaii	07-06	State Senate	1	R	"HONG, Ted H.S."	0	0	65	65County of Hawaii	07-06	State Representative	7	D	"EVANS, Cindy"	0	0	207	207County of Hawaii	07-06	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	32	32County of Hawaii	07-06	State Representative	7	R	"KAILIMAI, B.J."	0	0	56	56County of Hawaii	07-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	161	161County of Hawaii	07-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Hawaii	07-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Hawaii	07-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Hawaii	07-07	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67County of Hawaii	07-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Hawaii	07-07	US Representative	2	D	"HIRONO, Mazie"	0	0	99	99County of Hawaii	07-07	US Representative	2	R	"EVANS, Roger B."	0	0	36	36County of Hawaii	07-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Hawaii	07-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	109	109County of Hawaii	07-07	State Senate	1	R	"HONG, Ted H.S."	0	0	43	43County of Hawaii	07-07	State Representative	7	D	"EVANS, Cindy"	0	0	92	92County of Hawaii	07-07	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	19	19County of Hawaii	07-07	State Representative	7	R	"KAILIMAI, B.J."	0	0	38	38County of Hawaii	07-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	33	33County of Hawaii	07-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Hawaii	07-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Hawaii	07-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Hawaii	07-08	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11County of Hawaii	07-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Hawaii	07-08	US Representative	2	D	"HIRONO, Mazie"	0	0	20	20County of Hawaii	07-08	US Representative	2	R	"EVANS, Roger B."	0	0	8	8County of Hawaii	07-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Hawaii	07-08	State Senate	3	D	"ISBELL, Virginia"	0	0	2	2County of Hawaii	07-08	State Senate	3	D	"GREEN, Josh"	0	0	26	26County of Hawaii	07-08	State Representative	7	D	"EVANS, Cindy"	0	0	25	25County of Hawaii	07-08	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	3	3County of Hawaii	07-08	State Representative	7	R	"KAILIMAI, B.J."	0	0	6	6County of Maui	08-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	264	264County of Maui	08-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	08-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	08-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	08-01	Straight Party			REPUBLICAN PARTY (R)	0	0	27	27County of Maui	08-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Maui	08-01	US Representative	2	D	"HIRONO, Mazie"	0	0	193	193County of Maui	08-01	US Representative	2	R	"EVANS, Roger B."	0	0	24	24County of Maui	08-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	08-01	State Representative	8	D	"KAMA, Tasha"	0	0	160	160County of Maui	08-01	State Representative	8	D	"SOUKI, Joe"	0	0	93	93County of Maui	08-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	452	452County of Maui	08-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	08-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	08-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5County of Maui	08-02	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44County of Maui	08-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Maui	08-02	US Representative	2	D	"HIRONO, Mazie"	0	0	338	338County of Maui	08-02	US Representative	2	R	"EVANS, Roger B."	0	0	38	38County of Maui	08-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	08-02	State Representative	8	D	"KAMA, Tasha"	0	0	234	234County of Maui	08-02	State Representative	8	D	"SOUKI, Joe"	0	0	192	192County of Maui	08-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	213	213County of Maui	08-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Maui	08-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	08-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	08-03	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26County of Maui	08-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	08-03	US Representative	2	D	"HIRONO, Mazie"	0	0	168	168County of Maui	08-03	US Representative	2	R	"EVANS, Roger B."	0	0	24	24County of Maui	08-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	08-03	State Representative	8	D	"KAMA, Tasha"	0	0	69	69County of Maui	08-03	State Representative	8	D	"SOUKI, Joe"	0	0	127	127County of Maui	08-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	209	209County of Maui	08-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Maui	08-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	08-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4County of Maui	08-04	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14County of Maui	08-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	08-04	US Representative	2	D	"HIRONO, Mazie"	0	0	158	158County of Maui	08-04	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Maui	08-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	08-04	State Representative	8	D	"KAMA, Tasha"	0	0	92	92County of Maui	08-04	State Representative	8	D	"SOUKI, Joe"	0	0	95	95County of Maui	08-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	426	426County of Maui	08-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	08-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	08-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4County of Maui	08-05	Straight Party			REPUBLICAN PARTY (R)	0	0	70	70County of Maui	08-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	08-05	US Representative	2	D	"HIRONO, Mazie"	0	0	333	333County of Maui	08-05	US Representative	2	R	"EVANS, Roger B."	0	0	61	61County of Maui	08-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	08-05	State Representative	8	D	"KAMA, Tasha"	0	0	178	178County of Maui	08-05	State Representative	8	D	"SOUKI, Joe"	0	0	216	216County of Maui	08-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223County of Maui	08-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	08-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	08-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	08-06	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15County of Maui	08-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	08-06	US Representative	2	D	"HIRONO, Mazie"	0	0	181	181County of Maui	08-06	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Maui	08-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Maui	08-06	State Representative	8	D	"KAMA, Tasha"	0	0	85	85County of Maui	08-06	State Representative	8	D	"SOUKI, Joe"	0	0	118	118County of Maui	08-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	141	141County of Maui	08-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	08-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	08-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	08-07	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11County of Maui	08-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	08-07	US Representative	2	D	"HIRONO, Mazie"	0	0	115	115County of Maui	08-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10County of Maui	08-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	08-07	State Representative	8	D	"KAMA, Tasha"	0	0	61	61County of Maui	08-07	State Representative	8	D	"SOUKI, Joe"	0	0	71	71County of Maui	09-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	192	192County of Maui	09-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	09-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	09-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Maui	09-01	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28County of Maui	09-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	09-01	US Representative	2	D	"HIRONO, Mazie"	0	0	148	148County of Maui	09-01	US Representative	2	R	"EVANS, Roger B."	0	0	20	20County of Maui	09-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	09-01	State Representative	9	D	"NAKASONE, Bob"	0	0	123	123County of Maui	09-01	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	21	21County of Maui	09-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392County of Maui	09-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	09-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	09-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	09-02	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56County of Maui	09-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	09-02	US Representative	2	D	"HIRONO, Mazie"	0	0	337	337County of Maui	09-02	US Representative	2	R	"EVANS, Roger B."	0	0	31	31County of Maui	09-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Maui	09-02	State Representative	9	D	"NAKASONE, Bob"	0	0	268	268County of Maui	09-02	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	34	34County of Maui	09-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	338	338County of Maui	09-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	09-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	09-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Maui	09-03	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40County of Maui	09-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	09-03	US Representative	2	D	"HIRONO, Mazie"	0	0	287	287County of Maui	09-03	US Representative	2	R	"EVANS, Roger B."	0	0	25	25County of Maui	09-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	09-03	State Representative	9	D	"NAKASONE, Bob"	0	0	246	246County of Maui	09-03	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	24	24County of Maui	09-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	299	299County of Maui	09-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Maui	09-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	09-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	09-04	Straight Party			REPUBLICAN PARTY (R)	0	0	33	33County of Maui	09-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	09-04	US Representative	2	D	"HIRONO, Mazie"	0	0	249	249County of Maui	09-04	US Representative	2	R	"EVANS, Roger B."	0	0	14	14County of Maui	09-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	09-04	State Representative	9	D	"NAKASONE, Bob"	0	0	183	183County of Maui	09-04	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	24	24County of Maui	09-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	381	381County of Maui	09-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Maui	09-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	09-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	09-05	Straight Party			REPUBLICAN PARTY (R)	0	0	30	30County of Maui	09-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Maui	09-05	US Representative	2	D	"HIRONO, Mazie"	0	0	312	312County of Maui	09-05	US Representative	2	R	"EVANS, Roger B."	0	0	24	24County of Maui	09-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	09-05	State Representative	9	D	"NAKASONE, Bob"	0	0	256	256County of Maui	09-05	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	18	18County of Maui	09-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	22	22County of Maui	09-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	09-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	09-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	09-06	Straight Party			REPUBLICAN PARTY (R)	0	0	2	2County of Maui	09-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	09-06	US Representative	2	D	"HIRONO, Mazie"	0	0	17	17County of Maui	09-06	US Representative	2	R	"EVANS, Roger B."	0	0	1	1County of Maui	09-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	09-06	State Representative	9	D	"NAKASONE, Bob"	0	0	11	11County of Maui	09-06	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	1	1County of Maui	09-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	120	120County of Maui	09-07	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Maui	09-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Maui	09-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Maui	09-07	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26County of Maui	09-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Maui	09-07	US Representative	2	D	"HIRONO, Mazie"	0	0	98	98County of Maui	09-07	US Representative	2	R	"EVANS, Roger B."	0	0	12	12County of Maui	09-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Maui	09-07	State Representative	9	D	"NAKASONE, Bob"	0	0	60	60County of Maui	09-07	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	19	19County of Maui	10-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	114	114County of Maui	10-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Maui	10-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	10-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	10-01	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24County of Maui	10-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7County of Maui	10-01	US Representative	2	D	"HIRONO, Mazie"	0	0	90	90County of Maui	10-01	US Representative	2	R	"EVANS, Roger B."	0	0	10	10County of Maui	10-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	10-01	State Senate	5	D	"BAKER, Roz"	0	0	89	89County of Maui	10-01	State Senate	5	D	"MULVIHILL, Bart"	0	0	13	13County of Maui	10-01	State Senate	5	R	"SHIELDS, Jan"	0	0	17	17County of Maui	10-01	State Representative	10	D	"MCKELVEY, Angus"	0	0	76	76County of Maui	10-01	State Representative	10	R	"MADDEN, Ramon K."	0	0	14	14County of Maui	10-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176County of Maui	10-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	10-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	10-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	10-02	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58County of Maui	10-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	10-02	US Representative	2	D	"HIRONO, Mazie"	0	0	125	125County of Maui	10-02	US Representative	2	R	"EVANS, Roger B."	0	0	25	25County of Maui	10-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	10-02	State Senate	5	D	"BAKER, Roz"	0	0	112	112County of Maui	10-02	State Senate	5	D	"MULVIHILL, Bart"	0	0	42	42County of Maui	10-02	State Senate	5	R	"SHIELDS, Jan"	0	0	52	52County of Maui	10-02	State Representative	10	D	"MCKELVEY, Angus"	0	0	136	136County of Maui	10-02	State Representative	10	R	"MADDEN, Ramon K."	0	0	26	26County of Maui	10-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	246	246County of Maui	10-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Maui	10-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	10-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	10-03	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26County of Maui	10-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Maui	10-03	US Representative	2	D	"HIRONO, Mazie"	0	0	206	206County of Maui	10-03	US Representative	2	R	"EVANS, Roger B."	0	0	12	12County of Maui	10-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	10-03	State Senate	5	D	"BAKER, Roz"	0	0	194	194County of Maui	10-03	State Senate	5	D	"MULVIHILL, Bart"	0	0	37	37County of Maui	10-03	State Senate	5	R	"SHIELDS, Jan"	0	0	22	22County of Maui	10-03	State Representative	10	D	"MCKELVEY, Angus"	0	0	191	191County of Maui	10-03	State Representative	10	R	"MADDEN, Ramon K."	0	0	15	15County of Maui	10-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176County of Maui	10-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	10-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	10-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Maui	10-04	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45County of Maui	10-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	10-04	US Representative	2	D	"HIRONO, Mazie"	0	0	145	145County of Maui	10-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17County of Maui	10-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Maui	10-04	State Senate	5	D	"BAKER, Roz"	0	0	132	132County of Maui	10-04	State Senate	5	D	"MULVIHILL, Bart"	0	0	31	31County of Maui	10-04	State Senate	5	R	"SHIELDS, Jan"	0	0	37	37County of Maui	10-04	State Representative	10	D	"MCKELVEY, Angus"	0	0	151	151County of Maui	10-04	State Representative	10	R	"MADDEN, Ramon K."	0	0	22	22County of Maui	10-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	162	162County of Maui	10-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	10-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	10-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	10-05	Straight Party			REPUBLICAN PARTY (R)	0	0	87	87County of Maui	10-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	10-05	US Representative	2	D	"HIRONO, Mazie"	0	0	111	111County of Maui	10-05	US Representative	2	R	"EVANS, Roger B."	0	0	36	36County of Maui	10-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	10-05	State Senate	5	D	"BAKER, Roz"	0	0	105	105County of Maui	10-05	State Senate	5	D	"MULVIHILL, Bart"	0	0	46	46County of Maui	10-05	State Senate	5	R	"SHIELDS, Jan"	0	0	74	74County of Maui	10-05	State Representative	10	D	"MCKELVEY, Angus"	0	0	125	125County of Maui	10-05	State Representative	10	R	"MADDEN, Ramon K."	0	0	39	39County of Maui	10-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200County of Maui	10-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Maui	10-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	10-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Maui	10-06	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81County of Maui	10-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	10-06	US Representative	2	D	"HIRONO, Mazie"	0	0	142	142County of Maui	10-06	US Representative	2	R	"EVANS, Roger B."	0	0	36	36County of Maui	10-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	10-06	State Senate	5	D	"BAKER, Roz"	0	0	129	129County of Maui	10-06	State Senate	5	D	"MULVIHILL, Bart"	0	0	52	52County of Maui	10-06	State Senate	5	R	"SHIELDS, Jan"	0	0	74	74County of Maui	10-06	State Representative	10	D	"MCKELVEY, Angus"	0	0	153	153County of Maui	10-06	State Representative	10	R	"MADDEN, Ramon K."	0	0	35	35County of Maui	11-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	299	299County of Maui	11-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Maui	11-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	11-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	11-01	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67County of Maui	11-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7County of Maui	11-01	US Representative	2	D	"HIRONO, Mazie"	0	0	239	239County of Maui	11-01	US Representative	2	R	"EVANS, Roger B."	0	0	26	26County of Maui	11-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	11-01	State Senate	5	D	"BAKER, Roz"	0	0	217	217County of Maui	11-01	State Senate	5	D	"MULVIHILL, Bart"	0	0	55	55County of Maui	11-01	State Senate	5	R	"SHIELDS, Jan"	0	0	47	47County of Maui	11-01	State Representative	11	D	"GINGERICH, Michael"	0	0	86	86County of Maui	11-01	State Representative	11	D	"BERTRAM, Joe, III"	0	0	175	175County of Maui	11-01	State Representative	11	R	"FONTAINE, George R."	0	0	35	35County of Maui	11-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	462	462County of Maui	11-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5County of Maui	11-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	11-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Maui	11-02	Straight Party			REPUBLICAN PARTY (R)	0	0	159	159County of Maui	11-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Maui	11-02	US Representative	2	D	"HIRONO, Mazie"	0	0	342	342County of Maui	11-02	US Representative	2	R	"EVANS, Roger B."	0	0	77	77County of Maui	11-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Maui	11-02	State Senate	5	D	"BAKER, Roz"	0	0	270	270County of Maui	11-02	State Senate	5	D	"MULVIHILL, Bart"	0	0	153	153County of Maui	11-02	State Senate	5	R	"SHIELDS, Jan"	0	0	135	135County of Maui	11-02	State Representative	11	D	"GINGERICH, Michael"	0	0	131	131County of Maui	11-02	State Representative	11	D	"BERTRAM, Joe, III"	0	0	296	296County of Maui	11-02	State Representative	11	R	"FONTAINE, George R."	0	0	108	108County of Maui	11-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	272	272County of Maui	11-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2County of Maui	11-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	11-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Maui	11-03	Straight Party			REPUBLICAN PARTY (R)	0	0	116	116County of Maui	11-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Maui	11-03	US Representative	2	D	"HIRONO, Mazie"	0	0	196	196County of Maui	11-03	US Representative	2	R	"EVANS, Roger B."	0	0	45	45County of Maui	11-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	11-03	State Senate	5	D	"BAKER, Roz"	0	0	175	175County of Maui	11-03	State Senate	5	D	"MULVIHILL, Bart"	0	0	84	84County of Maui	11-03	State Senate	5	R	"SHIELDS, Jan"	0	0	97	97County of Maui	11-03	State Representative	11	D	"GINGERICH, Michael"	0	0	61	61County of Maui	11-03	State Representative	11	D	"BERTRAM, Joe, III"	0	0	183	183County of Maui	11-03	State Representative	11	R	"FONTAINE, George R."	0	0	67	67County of Maui	11-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293County of Maui	11-04	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6County of Maui	11-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	11-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5County of Maui	11-04	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112County of Maui	11-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Maui	11-04	US Representative	2	D	"HIRONO, Mazie"	0	0	218	218County of Maui	11-04	US Representative	2	R	"EVANS, Roger B."	0	0	62	62County of Maui	11-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	11-04	State Senate	5	D	"BAKER, Roz"	0	0	202	202County of Maui	11-04	State Senate	5	D	"MULVIHILL, Bart"	0	0	73	73County of Maui	11-04	State Senate	5	R	"SHIELDS, Jan"	0	0	85	85County of Maui	11-04	State Representative	11	D	"GINGERICH, Michael"	0	0	81	81County of Maui	11-04	State Representative	11	D	"BERTRAM, Joe, III"	0	0	180	180County of Maui	11-04	State Representative	11	R	"FONTAINE, George R."	0	0	75	75County of Maui	12-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	516	516County of Maui	12-01	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8County of Maui	12-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	12-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	12-01	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58County of Maui	12-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4County of Maui	12-01	US Representative	2	D	"HIRONO, Mazie"	0	0	367	367County of Maui	12-01	US Representative	2	R	"EVANS, Roger B."	0	0	29	29County of Maui	12-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Maui	12-01	State Senate	6	I	"BLUMER-BUELL, John"	0	0	6	6County of Maui	12-01	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	344	344County of Maui	12-01	State Representative	12	D	"YAMASHITA, Kyle"	0	0	300	300County of Maui	12-01	State Representative	12	D	"STARR, Summer"	0	0	195	195County of Maui	12-01	State Representative	12	R	"VIERRA, Mickey"	0	0	49	49County of Maui	12-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	403	403County of Maui	12-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	12-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	12-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	12-02	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36County of Maui	12-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	12-02	US Representative	2	D	"HIRONO, Mazie"	0	0	247	247County of Maui	12-02	US Representative	2	R	"EVANS, Roger B."	0	0	15	15County of Maui	12-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Maui	12-02	State Senate	6	I	"BLUMER-BUELL, John"	0	0	3	3County of Maui	12-02	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	249	249County of Maui	12-02	State Representative	12	D	"YAMASHITA, Kyle"	0	0	191	191County of Maui	12-02	State Representative	12	D	"STARR, Summer"	0	0	203	203County of Maui	12-02	State Representative	12	R	"VIERRA, Mickey"	0	0	27	27County of Maui	12-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	532	532County of Maui	12-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Maui	12-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	12-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Maui	12-03	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63County of Maui	12-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	12-03	US Representative	2	D	"HIRONO, Mazie"	0	0	344	344County of Maui	12-03	US Representative	2	R	"EVANS, Roger B."	0	0	30	30County of Maui	12-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	12-03	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2County of Maui	12-03	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	319	319County of Maui	12-03	State Representative	12	D	"YAMASHITA, Kyle"	0	0	275	275County of Maui	12-03	State Representative	12	D	"STARR, Summer"	0	0	239	239County of Maui	12-03	State Representative	12	R	"VIERRA, Mickey"	0	0	51	51County of Maui	12-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	679	679County of Maui	12-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Maui	12-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	12-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	12-04	Straight Party			REPUBLICAN PARTY (R)	0	0	90	90County of Maui	12-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	12-04	US Representative	2	D	"HIRONO, Mazie"	0	0	492	492County of Maui	12-04	US Representative	2	R	"EVANS, Roger B."	0	0	32	32County of Maui	12-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	12-04	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2County of Maui	12-04	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	448	448County of Maui	12-04	State Representative	12	D	"YAMASHITA, Kyle"	0	0	444	444County of Maui	12-04	State Representative	12	D	"STARR, Summer"	0	0	211	211County of Maui	12-04	State Representative	12	R	"VIERRA, Mickey"	0	0	72	72County of Maui	12-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	306	306County of Maui	12-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Maui	12-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	12-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Maui	12-05	Straight Party			REPUBLICAN PARTY (R)	0	0	46	46County of Maui	12-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	12-05	US Representative	2	D	"HIRONO, Mazie"	0	0	208	208County of Maui	12-05	US Representative	2	R	"EVANS, Roger B."	0	0	16	16County of Maui	12-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	12-05	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0County of Maui	12-05	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	204	204County of Maui	12-05	State Representative	12	D	"YAMASHITA, Kyle"	0	0	149	149County of Maui	12-05	State Representative	12	D	"STARR, Summer"	0	0	141	141County of Maui	12-05	State Representative	12	R	"VIERRA, Mickey"	0	0	34	34County of Maui	12-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	524	524County of Maui	12-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3County of Maui	12-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Maui	12-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	12-06	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61County of Maui	12-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	12-06	US Representative	2	D	"HIRONO, Mazie"	0	0	324	324County of Maui	12-06	US Representative	2	R	"EVANS, Roger B."	0	0	34	34County of Maui	12-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Maui	12-06	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2County of Maui	12-06	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	331	331County of Maui	12-06	State Representative	12	D	"YAMASHITA, Kyle"	0	0	220	220County of Maui	12-06	State Representative	12	D	"STARR, Summer"	0	0	288	288County of Maui	12-06	State Representative	12	R	"VIERRA, Mickey"	0	0	49	49County of Maui	12-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	33	33County of Maui	12-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	12-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	12-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	12-07	Straight Party			REPUBLICAN PARTY (R)	0	0	5	5County of Maui	12-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	12-07	US Representative	2	D	"HIRONO, Mazie"	0	0	17	17County of Maui	12-07	US Representative	2	R	"EVANS, Roger B."	0	0	3	3County of Maui	12-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	12-07	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0County of Maui	12-07	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	25	25County of Maui	12-07	State Representative	12	D	"YAMASHITA, Kyle"	0	0	6	6County of Maui	12-07	State Representative	12	D	"STARR, Summer"	0	0	27	27County of Maui	12-07	State Representative	12	R	"VIERRA, Mickey"	0	0	4	4County of Maui	13-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	151	151County of Maui	13-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Maui	13-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	13-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Maui	13-01	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19County of Maui	13-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	13-01	US Representative	2	D	"HIRONO, Mazie"	0	0	103	103County of Maui	13-01	US Representative	2	R	"EVANS, Roger B."	0	0	18	18County of Maui	13-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	13-01	State Senate	6	I	"BLUMER-BUELL, John"	0	0	1	1County of Maui	13-01	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	104	104County of Maui	13-01	State Representative	13	D	"CARROLL, Mele"	0	0	94	94County of Maui	13-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	358	358County of Maui	13-02	Straight Party			INDEPENDENT PARTY (I)	0	0	13	13County of Maui	13-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Maui	13-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	13-02	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56County of Maui	13-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Maui	13-02	US Representative	2	D	"HIRONO, Mazie"	0	0	208	208County of Maui	13-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54County of Maui	13-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Maui	13-02	State Senate	6	I	"BLUMER-BUELL, John"	0	0	10	10County of Maui	13-02	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	230	230County of Maui	13-02	State Representative	13	D	"CARROLL, Mele"	0	0	213	213County of Maui	13-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	389	389County of Maui	13-03	Straight Party			INDEPENDENT PARTY (I)	0	0	21	21County of Maui	13-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7County of Maui	13-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Maui	13-03	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32County of Maui	13-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6County of Maui	13-03	US Representative	2	D	"HIRONO, Mazie"	0	0	254	254County of Maui	13-03	US Representative	2	R	"EVANS, Roger B."	0	0	30	30County of Maui	13-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6County of Maui	13-03	State Senate	6	I	"BLUMER-BUELL, John"	0	0	19	19County of Maui	13-03	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	261	261County of Maui	13-03	State Representative	13	D	"CARROLL, Mele"	0	0	253	253County of Maui	13-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	95	95County of Maui	13-04	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Maui	13-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	13-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	13-04	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8County of Maui	13-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	13-04	US Representative	2	D	"HIRONO, Mazie"	0	0	54	54County of Maui	13-04	US Representative	2	R	"EVANS, Roger B."	0	0	8	8County of Maui	13-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	13-04	State Senate	6	I	"BLUMER-BUELL, John"	0	0	7	7County of Maui	13-04	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	67	67County of Maui	13-04	State Representative	13	D	"CARROLL, Mele"	0	0	68	68County of Maui	13-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	19	19County of Maui	13-05	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5County of Maui	13-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	13-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	13-05	Straight Party			REPUBLICAN PARTY (R)	0	0	7	7County of Maui	13-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Maui	13-05	US Representative	2	D	"HIRONO, Mazie"	0	0	12	12County of Maui	13-05	US Representative	2	R	"EVANS, Roger B."	0	0	6	6County of Maui	13-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	13-05	State Senate	6	I	"BLUMER-BUELL, John"	0	0	5	5County of Maui	13-05	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	13	13County of Maui	13-05	State Representative	13	D	"CARROLL, Mele"	0	0	11	11County of Maui	13-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	192	192County of Maui	13-06	Straight Party			INDEPENDENT PARTY (I)	0	0	23	23County of Maui	13-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	13-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	13-06	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17County of Maui	13-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Maui	13-06	US Representative	2	D	"HIRONO, Mazie"	0	0	109	109County of Maui	13-06	US Representative	2	R	"EVANS, Roger B."	0	0	15	15County of Maui	13-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	13-06	State Senate	6	I	"BLUMER-BUELL, John"	0	0	23	23County of Maui	13-06	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	160	160County of Maui	13-06	State Representative	13	D	"CARROLL, Mele"	0	0	108	108County of Maui	13-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	362	362County of Maui	13-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6County of Maui	13-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Maui	13-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	13-07	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47County of Maui	13-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Maui	13-07	US Representative	2	D	"HIRONO, Mazie"	0	0	259	259County of Maui	13-07	US Representative	2	R	"EVANS, Roger B."	0	0	43	43County of Maui	13-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	13-07	State Senate	6	I	"BLUMER-BUELL, John"	0	0	4	4County of Maui	13-07	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	184	184County of Maui	13-07	State Representative	13	D	"CARROLL, Mele"	0	0	177	177County of Maui	13-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	59	59County of Maui	13-08	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	13-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	13-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	13-08	Straight Party			REPUBLICAN PARTY (R)	0	0	12	12County of Maui	13-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	13-08	US Representative	2	D	"HIRONO, Mazie"	0	0	32	32County of Maui	13-08	US Representative	2	R	"EVANS, Roger B."	0	0	10	10County of Maui	13-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	13-08	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0County of Maui	13-08	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	43	43County of Maui	13-08	State Representative	13	D	"CARROLL, Mele"	0	0	37	37County of Maui	13-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223County of Maui	13-09	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	13-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	13-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1County of Maui	13-09	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20County of Maui	13-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	13-09	US Representative	2	D	"HIRONO, Mazie"	0	0	155	155County of Maui	13-09	US Representative	2	R	"EVANS, Roger B."	0	0	20	20County of Maui	13-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	13-09	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0County of Maui	13-09	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	150	150County of Maui	13-09	State Representative	13	D	"CARROLL, Mele"	0	0	124	124County of Maui	13-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	25	25County of Maui	13-10	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	13-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	13-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	13-10	Straight Party			REPUBLICAN PARTY (R)	0	0	9	9County of Maui	13-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	13-10	US Representative	2	D	"HIRONO, Mazie"	0	0	18	18County of Maui	13-10	US Representative	2	R	"EVANS, Roger B."	0	0	9	9County of Maui	13-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	13-10	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0County of Maui	13-10	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	17	17County of Maui	13-10	State Representative	13	D	"CARROLL, Mele"	0	0	16	16County of Maui	13-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	172	172County of Maui	13-11	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	13-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Maui	13-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	13-11	Straight Party			REPUBLICAN PARTY (R)	0	0	12	12County of Maui	13-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	13-11	US Representative	2	D	"HIRONO, Mazie"	0	0	109	109County of Maui	13-11	US Representative	2	R	"EVANS, Roger B."	0	0	11	11County of Maui	13-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Maui	13-11	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0County of Maui	13-11	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	116	116County of Maui	13-11	State Representative	13	D	"CARROLL, Mele"	0	0	103	103County of Maui	13-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	0	0County of Maui	13-12	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Maui	13-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Maui	13-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Maui	13-12	Straight Party			REPUBLICAN PARTY (R)	0	0	0	0County of Maui	13-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Maui	13-12	US Representative	2	D	"HIRONO, Mazie"	0	0	0	0County of Maui	13-12	US Representative	2	R	"EVANS, Roger B."	0	0	0	0County of Maui	13-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Maui	13-12	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0County of Maui	13-12	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	0	0County of Maui	13-12	State Representative	13	D	"CARROLL, Mele"	0	0	0	0County of Kauai	14-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	442	442County of Kauai	14-01	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9County of Kauai	14-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5County of Kauai	14-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Kauai	14-01	Straight Party			REPUBLICAN PARTY (R)	0	0	134	134County of Kauai	14-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7County of Kauai	14-01	US Representative	2	D	"HIRONO, Mazie"	0	0	232	232County of Kauai	14-01	US Representative	2	R	"EVANS, Roger B."	0	0	82	82County of Kauai	14-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5County of Kauai	14-01	State Senate	7	D	"HOOSER, Gary L."	0	0	324	324County of Kauai	14-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	101	101County of Kauai	14-01	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	323	323County of Kauai	14-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	525	525County of Kauai	14-02	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14County of Kauai	14-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Kauai	14-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10County of Kauai	14-02	Straight Party			REPUBLICAN PARTY (R)	0	0	88	88County of Kauai	14-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11County of Kauai	14-02	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305County of Kauai	14-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54County of Kauai	14-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Kauai	14-02	State Senate	7	D	"HOOSER, Gary L."	0	0	390	390County of Kauai	14-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	61	61County of Kauai	14-02	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	355	355County of Kauai	14-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	321	321County of Kauai	14-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6County of Kauai	14-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Kauai	14-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Kauai	14-03	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43County of Kauai	14-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Kauai	14-03	US Representative	2	D	"HIRONO, Mazie"	0	0	149	149County of Kauai	14-03	US Representative	2	R	"EVANS, Roger B."	0	0	25	25County of Kauai	14-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Kauai	14-03	State Senate	7	D	"HOOSER, Gary L."	0	0	197	197County of Kauai	14-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	27	27County of Kauai	14-03	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	173	173County of Kauai	14-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	1079	1079County of Kauai	14-04	Straight Party			INDEPENDENT PARTY (I)	0	0	19	19County of Kauai	14-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Kauai	14-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12County of Kauai	14-04	Straight Party			REPUBLICAN PARTY (R)	0	0	180	180County of Kauai	14-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	13	13County of Kauai	14-04	US Representative	2	D	"HIRONO, Mazie"	0	0	595	595County of Kauai	14-04	US Representative	2	R	"EVANS, Roger B."	0	0	100	100County of Kauai	14-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Kauai	14-04	State Senate	7	D	"HOOSER, Gary L."	0	0	773	773County of Kauai	14-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	117	117County of Kauai	14-04	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	539	539County of Kauai	14-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311County of Kauai	14-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7County of Kauai	14-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Kauai	14-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3County of Kauai	14-05	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53County of Kauai	14-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6County of Kauai	14-05	US Representative	2	D	"HIRONO, Mazie"	0	0	161	161County of Kauai	14-05	US Representative	2	R	"EVANS, Roger B."	0	0	27	27County of Kauai	14-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Kauai	14-05	State Senate	7	D	"HOOSER, Gary L."	0	0	202	202County of Kauai	14-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	43	43County of Kauai	14-05	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	140	140County of Kauai	15-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	722	722County of Kauai	15-01	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11County of Kauai	15-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Kauai	15-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Kauai	15-01	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136County of Kauai	15-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8County of Kauai	15-01	US Representative	2	D	"HIRONO, Mazie"	0	0	405	405County of Kauai	15-01	US Representative	2	R	"EVANS, Roger B."	0	0	74	74County of Kauai	15-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Kauai	15-01	State Senate	7	D	"HOOSER, Gary L."	0	0	529	529County of Kauai	15-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	96	96County of Kauai	15-01	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	366	366County of Kauai	15-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	463	463County of Kauai	15-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Kauai	15-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Kauai	15-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Kauai	15-02	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44County of Kauai	15-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Kauai	15-02	US Representative	2	D	"HIRONO, Mazie"	0	0	298	298County of Kauai	15-02	US Representative	2	R	"EVANS, Roger B."	0	0	21	21County of Kauai	15-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Kauai	15-02	State Senate	7	D	"HOOSER, Gary L."	0	0	270	270County of Kauai	15-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	24	24County of Kauai	15-02	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	244	244County of Kauai	15-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	537	537County of Kauai	15-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5County of Kauai	15-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1County of Kauai	15-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Kauai	15-03	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78County of Kauai	15-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5County of Kauai	15-03	US Representative	2	D	"HIRONO, Mazie"	0	0	327	327County of Kauai	15-03	US Representative	2	R	"EVANS, Roger B."	0	0	42	42County of Kauai	15-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1County of Kauai	15-03	State Senate	7	D	"HOOSER, Gary L."	0	0	323	323County of Kauai	15-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	56	56County of Kauai	15-03	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	302	302County of Kauai	15-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	624	624County of Kauai	15-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9County of Kauai	15-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6County of Kauai	15-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9County of Kauai	15-04	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101County of Kauai	15-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7County of Kauai	15-04	US Representative	2	D	"HIRONO, Mazie"	0	0	373	373County of Kauai	15-04	US Representative	2	R	"EVANS, Roger B."	0	0	60	60County of Kauai	15-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6County of Kauai	15-04	State Senate	7	D	"HOOSER, Gary L."	0	0	399	399County of Kauai	15-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	71	71County of Kauai	15-04	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	364	364County of Kauai	15-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	257	257County of Kauai	15-05	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10County of Kauai	15-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Kauai	15-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4County of Kauai	15-05	Straight Party			REPUBLICAN PARTY (R)	0	0	50	50County of Kauai	15-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6County of Kauai	15-05	US Representative	2	D	"HIRONO, Mazie"	0	0	137	137County of Kauai	15-05	US Representative	2	R	"EVANS, Roger B."	0	0	23	23County of Kauai	15-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Kauai	15-05	State Senate	7	D	"HOOSER, Gary L."	0	0	169	169County of Kauai	15-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	33	33County of Kauai	15-05	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	107	107County of Kauai	16-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	385	385County of Kauai	16-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Kauai	16-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4County of Kauai	16-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2County of Kauai	16-01	Straight Party			REPUBLICAN PARTY (R)	0	0	85	85County of Kauai	16-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3County of Kauai	16-01	US Representative	2	D	"HIRONO, Mazie"	0	0	245	245County of Kauai	16-01	US Representative	2	R	"EVANS, Roger B."	0	0	48	48County of Kauai	16-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Kauai	16-01	State Senate	7	D	"HOOSER, Gary L."	0	0	253	253County of Kauai	16-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	60	60County of Kauai	16-01	State Representative	16	D	"SAGUM, Roland D., III"	0	0	181	181County of Kauai	16-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	807	807County of Kauai	16-02	Straight Party			INDEPENDENT PARTY (I)	0	0	13	13County of Kauai	16-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5County of Kauai	16-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7County of Kauai	16-02	Straight Party			REPUBLICAN PARTY (R)	0	0	165	165County of Kauai	16-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	12	12County of Kauai	16-02	US Representative	2	D	"HIRONO, Mazie"	0	0	448	448County of Kauai	16-02	US Representative	2	R	"EVANS, Roger B."	0	0	90	90County of Kauai	16-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4County of Kauai	16-02	State Senate	7	D	"HOOSER, Gary L."	0	0	549	549County of Kauai	16-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	128	128County of Kauai	16-02	State Representative	16	D	"SAGUM, Roland D., III"	0	0	349	349County of Kauai	16-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	590	590County of Kauai	16-03	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11County of Kauai	16-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Kauai	16-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13County of Kauai	16-03	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80County of Kauai	16-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8County of Kauai	16-03	US Representative	2	D	"HIRONO, Mazie"	0	0	377	377County of Kauai	16-03	US Representative	2	R	"EVANS, Roger B."	0	0	31	31County of Kauai	16-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Kauai	16-03	State Senate	7	D	"HOOSER, Gary L."	0	0	372	372County of Kauai	16-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	64	64County of Kauai	16-03	State Representative	16	D	"SAGUM, Roland D., III"	0	0	285	285County of Kauai	16-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	79	79County of Kauai	16-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1County of Kauai	16-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Kauai	16-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Kauai	16-04	Straight Party			REPUBLICAN PARTY (R)	0	0	4	4County of Kauai	16-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1County of Kauai	16-04	US Representative	2	D	"HIRONO, Mazie"	0	0	52	52County of Kauai	16-04	US Representative	2	R	"EVANS, Roger B."	0	0	3	3County of Kauai	16-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Kauai	16-04	State Senate	7	D	"HOOSER, Gary L."	0	0	45	45County of Kauai	16-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	2	2County of Kauai	16-04	State Representative	16	D	"SAGUM, Roland D., III"	0	0	43	43County of Kauai	16-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	373	373County of Kauai	16-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4County of Kauai	16-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2County of Kauai	16-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6County of Kauai	16-05	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42County of Kauai	16-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2County of Kauai	16-05	US Representative	2	D	"HIRONO, Mazie"	0	0	256	256County of Kauai	16-05	US Representative	2	R	"EVANS, Roger B."	0	0	25	25County of Kauai	16-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2County of Kauai	16-05	State Senate	7	D	"HOOSER, Gary L."	0	0	203	203County of Kauai	16-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	32	32County of Kauai	16-05	State Representative	16	D	"SAGUM, Roland D., III"	0	0	203	203County of Kauai	16-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	484	484County of Kauai	16-06	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11County of Kauai	16-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3County of Kauai	16-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13County of Kauai	16-06	Straight Party			REPUBLICAN PARTY (R)	0	0	68	68County of Kauai	16-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	9	9County of Kauai	16-06	US Representative	2	D	"HIRONO, Mazie"	0	0	306	306County of Kauai	16-06	US Representative	2	R	"EVANS, Roger B."	0	0	36	36County of Kauai	16-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3County of Kauai	16-06	State Senate	7	D	"HOOSER, Gary L."	0	0	276	276County of Kauai	16-06	State Senate	7	R	"GEORGI, JoAnne S."	0	0	51	51County of Kauai	16-06	State Representative	16	D	"SAGUM, Roland D., III"	0	0	240	240County of Kauai	16-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	24	24County of Kauai	16-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0County of Kauai	16-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0County of Kauai	16-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0County of Kauai	16-07	Straight Party			REPUBLICAN PARTY (R)	0	0	6	6County of Kauai	16-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0County of Kauai	16-07	US Representative	2	D	"HIRONO, Mazie"	0	0	6	6County of Kauai	16-07	US Representative	2	R	"EVANS, Roger B."	0	0	2	2County of Kauai	16-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0County of Kauai	16-07	State Senate	7	D	"HOOSER, Gary L."	0	0	17	17County of Kauai	16-07	State Senate	7	R	"GEORGI, JoAnne S."	0	0	4	4County of Kauai	16-07	State Representative	16	D	"SAGUM, Roland D., III"	0	0	1	1City & County of Honolulu	17-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	433	433City & County of Honolulu	17-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	17-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	17-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	17-01	Straight Party			REPUBLICAN PARTY (R)	0	0	167	167City & County of Honolulu	17-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	334	334City & County of Honolulu	17-01	US Representative	1	R	"TATAII, Steve"	0	0	60	60City & County of Honolulu	17-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	17-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	17-01	State Representative	17	D	"MONK, Amy Yukiko"	0	0	281	281City & County of Honolulu	17-01	State Representative	17	R	"WARD, Gene"	0	0	153	153City & County of Honolulu	17-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317City & County of Honolulu	17-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	17-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	17-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	17-02	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80City & County of Honolulu	17-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	236	236City & County of Honolulu	17-02	US Representative	1	R	"TATAII, Steve"	0	0	22	22City & County of Honolulu	17-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	17-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	17-02	State Representative	17	D	"MONK, Amy Yukiko"	0	0	191	191City & County of Honolulu	17-02	State Representative	17	R	"WARD, Gene"	0	0	79	79City & County of Honolulu	17-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	391	391City & County of Honolulu	17-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	17-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6City & County of Honolulu	17-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	17-03	Straight Party			REPUBLICAN PARTY (R)	0	0	292	292City & County of Honolulu	17-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	273	273City & County of Honolulu	17-03	US Representative	1	R	"TATAII, Steve"	0	0	94	94City & County of Honolulu	17-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3City & County of Honolulu	17-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	17-03	State Representative	17	D	"MONK, Amy Yukiko"	0	0	251	251City & County of Honolulu	17-03	State Representative	17	R	"WARD, Gene"	0	0	272	272City & County of Honolulu	17-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	168	168City & County of Honolulu	17-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	17-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	17-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	17-04	Straight Party			REPUBLICAN PARTY (R)	0	0	132	132City & County of Honolulu	17-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	130	130City & County of Honolulu	17-04	US Representative	1	R	"TATAII, Steve"	0	0	62	62City & County of Honolulu	17-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	17-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	17-04	State Representative	17	D	"MONK, Amy Yukiko"	0	0	120	120City & County of Honolulu	17-04	State Representative	17	R	"WARD, Gene"	0	0	130	130City & County of Honolulu	17-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	459	459City & County of Honolulu	17-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	17-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	17-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10City & County of Honolulu	17-05	Straight Party			REPUBLICAN PARTY (R)	0	0	282	282City & County of Honolulu	17-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	359	359City & County of Honolulu	17-05	US Representative	1	R	"TATAII, Steve"	0	0	82	82City & County of Honolulu	17-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	17-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	17-05	State Representative	17	D	"MONK, Amy Yukiko"	0	0	264	264City & County of Honolulu	17-05	State Representative	17	R	"WARD, Gene"	0	0	274	274City & County of Honolulu	17-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	350	350City & County of Honolulu	17-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	17-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	17-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	17-06	Straight Party			REPUBLICAN PARTY (R)	0	0	151	151City & County of Honolulu	17-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	258	258City & County of Honolulu	17-06	US Representative	1	R	"TATAII, Steve"	0	0	34	34City & County of Honolulu	17-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	17-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	17-06	State Representative	17	D	"MONK, Amy Yukiko"	0	0	235	235City & County of Honolulu	17-06	State Representative	17	R	"WARD, Gene"	0	0	146	146City & County of Honolulu	17-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	494	494City & County of Honolulu	17-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	17-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	17-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	17-07	Straight Party			REPUBLICAN PARTY (R)	0	0	243	243City & County of Honolulu	17-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	382	382City & County of Honolulu	17-07	US Representative	1	R	"TATAII, Steve"	0	0	74	74City & County of Honolulu	17-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	17-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	17-07	State Representative	17	D	"MONK, Amy Yukiko"	0	0	332	332City & County of Honolulu	17-07	State Representative	17	R	"WARD, Gene"	0	0	236	236City & County of Honolulu	18-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	156	156City & County of Honolulu	18-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	18-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	18-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	18-01	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57City & County of Honolulu	18-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	120	120City & County of Honolulu	18-01	US Representative	1	R	"TATAII, Steve"	0	0	51	51City & County of Honolulu	18-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	18-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	18-01	State Representative	18	D	"BERG, Lyla B."	0	0	112	112City & County of Honolulu	18-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	420	420City & County of Honolulu	18-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	18-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8City & County of Honolulu	18-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8City & County of Honolulu	18-02	Straight Party			REPUBLICAN PARTY (R)	0	0	133	133City & County of Honolulu	18-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	316	316City & County of Honolulu	18-02	US Representative	1	R	"TATAII, Steve"	0	0	121	121City & County of Honolulu	18-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5City & County of Honolulu	18-02	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	18-02	State Representative	18	D	"BERG, Lyla B."	0	0	277	277City & County of Honolulu	18-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	346	346City & County of Honolulu	18-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	18-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	18-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	18-03	Straight Party			REPUBLICAN PARTY (R)	0	0	98	98City & County of Honolulu	18-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	254	254City & County of Honolulu	18-03	US Representative	1	R	"TATAII, Steve"	0	0	87	87City & County of Honolulu	18-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	18-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	18-03	State Representative	18	D	"BERG, Lyla B."	0	0	241	241City & County of Honolulu	18-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427City & County of Honolulu	18-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	18-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7City & County of Honolulu	18-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11City & County of Honolulu	18-04	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112City & County of Honolulu	18-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	308	308City & County of Honolulu	18-04	US Representative	1	R	"TATAII, Steve"	0	0	91	91City & County of Honolulu	18-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3City & County of Honolulu	18-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	18-04	State Representative	18	D	"BERG, Lyla B."	0	0	325	325City & County of Honolulu	18-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	542	542City & County of Honolulu	18-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	18-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8City & County of Honolulu	18-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	18-05	Straight Party			REPUBLICAN PARTY (R)	0	0	156	156City & County of Honolulu	18-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	414	414City & County of Honolulu	18-05	US Representative	1	R	"TATAII, Steve"	0	0	146	146City & County of Honolulu	18-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	18-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	18-05	State Representative	18	D	"BERG, Lyla B."	0	0	368	368City & County of Honolulu	18-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	321	321City & County of Honolulu	18-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	18-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6City & County of Honolulu	18-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	18-06	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48City & County of Honolulu	18-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	236	236City & County of Honolulu	18-06	US Representative	1	R	"TATAII, Steve"	0	0	42	42City & County of Honolulu	18-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	18-06	US Representative	1	L	"ZHAO, Li"	0	0	5	5City & County of Honolulu	18-06	State Representative	18	D	"BERG, Lyla B."	0	0	230	230City & County of Honolulu	18-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	570	570City & County of Honolulu	18-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	18-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6City & County of Honolulu	18-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	18-07	Straight Party			REPUBLICAN PARTY (R)	0	0	146	146City & County of Honolulu	18-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	417	417City & County of Honolulu	18-07	US Representative	1	R	"TATAII, Steve"	0	0	130	130City & County of Honolulu	18-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	18-07	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	18-07	State Representative	18	D	"BERG, Lyla B."	0	0	356	356City & County of Honolulu	19-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	430	430City & County of Honolulu	19-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	19-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	19-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	19-01	Straight Party			REPUBLICAN PARTY (R)	0	0	301	301City & County of Honolulu	19-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	321	321City & County of Honolulu	19-01	US Representative	1	R	"TATAII, Steve"	0	0	101	101City & County of Honolulu	19-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	19-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	19-01	State Representative	19	D	"ABE, Michael (Mike)"	0	0	248	248City & County of Honolulu	19-01	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	282	282City & County of Honolulu	19-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	466	466City & County of Honolulu	19-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	19-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	19-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	19-02	Straight Party			REPUBLICAN PARTY (R)	0	0	178	178City & County of Honolulu	19-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	363	363City & County of Honolulu	19-02	US Representative	1	R	"TATAII, Steve"	0	0	63	63City & County of Honolulu	19-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	19-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	19-02	State Representative	19	D	"ABE, Michael (Mike)"	0	0	251	251City & County of Honolulu	19-02	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	170	170City & County of Honolulu	19-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	355	355City & County of Honolulu	19-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	19-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	19-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	19-03	Straight Party			REPUBLICAN PARTY (R)	0	0	120	120City & County of Honolulu	19-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	268	268City & County of Honolulu	19-03	US Representative	1	R	"TATAII, Steve"	0	0	33	33City & County of Honolulu	19-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	19-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	19-03	State Representative	19	D	"ABE, Michael (Mike)"	0	0	203	203City & County of Honolulu	19-03	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	112	112City & County of Honolulu	19-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	603	603City & County of Honolulu	19-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	19-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	19-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	19-04	Straight Party			REPUBLICAN PARTY (R)	0	0	218	218City & County of Honolulu	19-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	474	474City & County of Honolulu	19-04	US Representative	1	R	"TATAII, Steve"	0	0	68	68City & County of Honolulu	19-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	19-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	19-04	State Representative	19	D	"ABE, Michael (Mike)"	0	0	332	332City & County of Honolulu	19-04	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	209	209City & County of Honolulu	19-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	363	363City & County of Honolulu	19-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	19-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	19-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	19-05	Straight Party			REPUBLICAN PARTY (R)	0	0	205	205City & County of Honolulu	19-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	281	281City & County of Honolulu	19-05	US Representative	1	R	"TATAII, Steve"	0	0	56	56City & County of Honolulu	19-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	19-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	19-05	State Representative	19	D	"ABE, Michael (Mike)"	0	0	192	192City & County of Honolulu	19-05	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	192	192City & County of Honolulu	19-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	326	326City & County of Honolulu	19-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	19-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	19-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	19-06	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80City & County of Honolulu	19-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	257	257City & County of Honolulu	19-06	US Representative	1	R	"TATAII, Steve"	0	0	28	28City & County of Honolulu	19-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	19-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	19-06	State Representative	19	D	"ABE, Michael (Mike)"	0	0	195	195City & County of Honolulu	19-06	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	71	71City & County of Honolulu	19-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	233	233City & County of Honolulu	19-07	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	19-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	19-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	19-07	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61City & County of Honolulu	19-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	194	194City & County of Honolulu	19-07	US Representative	1	R	"TATAII, Steve"	0	0	22	22City & County of Honolulu	19-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	19-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	19-07	State Representative	19	D	"ABE, Michael (Mike)"	0	0	141	141City & County of Honolulu	19-07	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	59	59City & County of Honolulu	20-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	332	332City & County of Honolulu	20-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	20-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	20-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	20-01	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47City & County of Honolulu	20-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	271	271City & County of Honolulu	20-01	US Representative	1	R	"TATAII, Steve"	0	0	26	26City & County of Honolulu	20-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	20-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	20-01	State Representative	20	D	"SAY, Calvin K. Y."	0	0	272	272City & County of Honolulu	20-01	State Representative	20	R	"ALLEN, Julia E."	0	0	40	40City & County of Honolulu	20-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	406	406City & County of Honolulu	20-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	20-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	20-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	20-02	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81City & County of Honolulu	20-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	307	307City & County of Honolulu	20-02	US Representative	1	R	"TATAII, Steve"	0	0	51	51City & County of Honolulu	20-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	20-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	20-02	State Representative	20	D	"SAY, Calvin K. Y."	0	0	344	344City & County of Honolulu	20-02	State Representative	20	R	"ALLEN, Julia E."	0	0	64	64City & County of Honolulu	20-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	284	284City & County of Honolulu	20-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	20-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	20-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	20-03	Straight Party			REPUBLICAN PARTY (R)	0	0	72	72City & County of Honolulu	20-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	212	212City & County of Honolulu	20-03	US Representative	1	R	"TATAII, Steve"	0	0	40	40City & County of Honolulu	20-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	20-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	20-03	State Representative	20	D	"SAY, Calvin K. Y."	0	0	197	197City & County of Honolulu	20-03	State Representative	20	R	"ALLEN, Julia E."	0	0	57	57City & County of Honolulu	20-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421City & County of Honolulu	20-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	20-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6City & County of Honolulu	20-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	20-04	Straight Party			REPUBLICAN PARTY (R)	0	0	86	86City & County of Honolulu	20-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	346	346City & County of Honolulu	20-04	US Representative	1	R	"TATAII, Steve"	0	0	53	53City & County of Honolulu	20-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	20-04	US Representative	1	L	"ZHAO, Li"	0	0	6	6City & County of Honolulu	20-04	State Representative	20	D	"SAY, Calvin K. Y."	0	0	295	295City & County of Honolulu	20-04	State Representative	20	R	"ALLEN, Julia E."	0	0	68	68City & County of Honolulu	20-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	646	646City & County of Honolulu	20-05	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14City & County of Honolulu	20-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7City & County of Honolulu	20-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10City & County of Honolulu	20-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81City & County of Honolulu	20-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	483	483City & County of Honolulu	20-05	US Representative	1	R	"TATAII, Steve"	0	0	42	42City & County of Honolulu	20-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	20-05	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	20-05	State Representative	20	D	"SAY, Calvin K. Y."	0	0	561	561City & County of Honolulu	20-05	State Representative	20	R	"ALLEN, Julia E."	0	0	67	67City & County of Honolulu	20-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	569	569City & County of Honolulu	20-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	20-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	20-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	20-06	Straight Party			REPUBLICAN PARTY (R)	0	0	114	114City & County of Honolulu	20-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	426	426City & County of Honolulu	20-06	US Representative	1	R	"TATAII, Steve"	0	0	65	65City & County of Honolulu	20-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	20-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	20-06	State Representative	20	D	"SAY, Calvin K. Y."	0	0	463	463City & County of Honolulu	20-06	State Representative	20	R	"ALLEN, Julia E."	0	0	99	99City & County of Honolulu	21-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	353	353City & County of Honolulu	21-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	21-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	21-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	21-01	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44City & County of Honolulu	21-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	255	255City & County of Honolulu	21-01	US Representative	1	R	"TATAII, Steve"	0	0	38	38City & County of Honolulu	21-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	21-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	21-01	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	264	264City & County of Honolulu	21-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	645	645City & County of Honolulu	21-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	21-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	21-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12City & County of Honolulu	21-02	Straight Party			REPUBLICAN PARTY (R)	0	0	87	87City & County of Honolulu	21-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	472	472City & County of Honolulu	21-02	US Representative	1	R	"TATAII, Steve"	0	0	78	78City & County of Honolulu	21-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	21-02	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	21-02	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	515	515City & County of Honolulu	21-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	483	483City & County of Honolulu	21-03	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11City & County of Honolulu	21-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10City & County of Honolulu	21-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	14	14City & County of Honolulu	21-03	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105City & County of Honolulu	21-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	383	383City & County of Honolulu	21-03	US Representative	1	R	"TATAII, Steve"	0	0	98	98City & County of Honolulu	21-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	21-03	US Representative	1	L	"ZHAO, Li"	0	0	8	8City & County of Honolulu	21-03	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	322	322City & County of Honolulu	21-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	265	265City & County of Honolulu	21-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	21-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	21-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	21-04	Straight Party			REPUBLICAN PARTY (R)	0	0	98	98City & County of Honolulu	21-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	192	192City & County of Honolulu	21-04	US Representative	1	R	"TATAII, Steve"	0	0	92	92City & County of Honolulu	21-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3City & County of Honolulu	21-04	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	21-04	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	184	184City & County of Honolulu	21-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267City & County of Honolulu	21-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	21-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	21-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	21-05	Straight Party			REPUBLICAN PARTY (R)	0	0	99	99City & County of Honolulu	21-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	216	216City & County of Honolulu	21-05	US Representative	1	R	"TATAII, Steve"	0	0	54	54City & County of Honolulu	21-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	21-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	21-05	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	134	134City & County of Honolulu	21-05	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	50	50City & County of Honolulu	21-05	State Senate	12	R	"TRIMBLE, Gordon"	0	0	92	92City & County of Honolulu	21-05	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	171	171City & County of Honolulu	21-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	252	252City & County of Honolulu	21-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	21-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	21-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	21-06	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20City & County of Honolulu	21-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	191	191City & County of Honolulu	21-06	US Representative	1	R	"TATAII, Steve"	0	0	18	18City & County of Honolulu	21-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	21-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	21-06	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	187	187City & County of Honolulu	22-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	120	120City & County of Honolulu	22-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	22-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	22-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	22-01	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20City & County of Honolulu	22-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	91	91City & County of Honolulu	22-01	US Representative	1	R	"TATAII, Steve"	0	0	17	17City & County of Honolulu	22-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	22-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	22-01	State Representative	22	D	"SAIKI, Scott K."	0	0	81	81City & County of Honolulu	22-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236City & County of Honolulu	22-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	22-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	22-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	22-02	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26City & County of Honolulu	22-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	203	203City & County of Honolulu	22-02	US Representative	1	R	"TATAII, Steve"	0	0	25	25City & County of Honolulu	22-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	22-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	22-02	State Representative	22	D	"SAIKI, Scott K."	0	0	169	169City & County of Honolulu	22-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	100	100City & County of Honolulu	22-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	22-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	22-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	22-03	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14City & County of Honolulu	22-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	81	81City & County of Honolulu	22-03	US Representative	1	R	"TATAII, Steve"	0	0	11	11City & County of Honolulu	22-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	22-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	22-03	State Representative	22	D	"SAIKI, Scott K."	0	0	58	58City & County of Honolulu	22-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293City & County of Honolulu	22-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	22-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7City & County of Honolulu	22-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	22-04	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45City & County of Honolulu	22-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	225	225City & County of Honolulu	22-04	US Representative	1	R	"TATAII, Steve"	0	0	42	42City & County of Honolulu	22-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3City & County of Honolulu	22-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	22-04	State Representative	22	D	"SAIKI, Scott K."	0	0	220	220City & County of Honolulu	22-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	292	292City & County of Honolulu	22-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	22-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8City & County of Honolulu	22-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	22-05	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43City & County of Honolulu	22-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	226	226City & County of Honolulu	22-05	US Representative	1	R	"TATAII, Steve"	0	0	40	40City & County of Honolulu	22-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5City & County of Honolulu	22-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	22-05	State Representative	22	D	"SAIKI, Scott K."	0	0	214	214City & County of Honolulu	22-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	374	374City & County of Honolulu	22-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	22-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	22-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	22-06	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48City & County of Honolulu	22-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	283	283City & County of Honolulu	22-06	US Representative	1	R	"TATAII, Steve"	0	0	41	41City & County of Honolulu	22-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	22-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	22-06	State Representative	22	D	"SAIKI, Scott K."	0	0	243	243City & County of Honolulu	22-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	279	279City & County of Honolulu	22-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	22-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	22-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	22-07	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75City & County of Honolulu	22-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	222	222City & County of Honolulu	22-07	US Representative	1	R	"TATAII, Steve"	0	0	67	67City & County of Honolulu	22-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	22-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	22-07	State Representative	22	D	"SAIKI, Scott K."	0	0	175	175City & County of Honolulu	23-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176City & County of Honolulu	23-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	23-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	23-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	23-01	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81City & County of Honolulu	23-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	150	150City & County of Honolulu	23-01	US Representative	1	R	"TATAII, Steve"	0	0	45	45City & County of Honolulu	23-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	23-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	23-01	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	96	96City & County of Honolulu	23-01	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	35	35City & County of Honolulu	23-01	State Senate	12	R	"TRIMBLE, Gordon"	0	0	63	63City & County of Honolulu	23-01	State Representative	23	D	"BROWER, Tom"	0	0	115	115City & County of Honolulu	23-01	State Representative	23	R	"STEVENS, Anne V."	0	0	61	61City & County of Honolulu	23-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200City & County of Honolulu	23-02	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	23-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	23-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	23-02	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105City & County of Honolulu	23-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	152	152City & County of Honolulu	23-02	US Representative	1	R	"TATAII, Steve"	0	0	59	59City & County of Honolulu	23-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	23-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	23-02	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	109	109City & County of Honolulu	23-02	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	40	40City & County of Honolulu	23-02	State Senate	12	R	"TRIMBLE, Gordon"	0	0	77	77City & County of Honolulu	23-02	State Representative	23	D	"BROWER, Tom"	0	0	133	133City & County of Honolulu	23-02	State Representative	23	R	"STEVENS, Anne V."	0	0	77	77City & County of Honolulu	23-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	352	352City & County of Honolulu	23-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	23-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	23-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	23-03	Straight Party			REPUBLICAN PARTY (R)	0	0	185	185City & County of Honolulu	23-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	289	289City & County of Honolulu	23-03	US Representative	1	R	"TATAII, Steve"	0	0	99	99City & County of Honolulu	23-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	23-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	23-03	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	202	202City & County of Honolulu	23-03	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	62	62City & County of Honolulu	23-03	State Senate	12	R	"TRIMBLE, Gordon"	0	0	131	131City & County of Honolulu	23-03	State Representative	23	D	"BROWER, Tom"	0	0	244	244City & County of Honolulu	23-03	State Representative	23	R	"STEVENS, Anne V."	0	0	147	147City & County of Honolulu	23-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	314	314City & County of Honolulu	23-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	23-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	23-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	23-04	Straight Party			REPUBLICAN PARTY (R)	0	0	146	146City & County of Honolulu	23-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	265	265City & County of Honolulu	23-04	US Representative	1	R	"TATAII, Steve"	0	0	68	68City & County of Honolulu	23-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	23-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	23-04	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	173	173City & County of Honolulu	23-04	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	42	42City & County of Honolulu	23-04	State Senate	12	R	"TRIMBLE, Gordon"	0	0	105	105City & County of Honolulu	23-04	State Representative	23	D	"BROWER, Tom"	0	0	193	193City & County of Honolulu	23-04	State Representative	23	R	"STEVENS, Anne V."	0	0	111	111City & County of Honolulu	24-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	753	753City & County of Honolulu	24-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	24-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	24-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9City & County of Honolulu	24-01	Straight Party			REPUBLICAN PARTY (R)	0	0	109	109City & County of Honolulu	24-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	558	558City & County of Honolulu	24-01	US Representative	1	R	"TATAII, Steve"	0	0	42	42City & County of Honolulu	24-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	24-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	24-01	State Representative	24	D	"CHOY, Isaac W."	0	0	476	476City & County of Honolulu	24-01	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	101	101City & County of Honolulu	24-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	414	414City & County of Honolulu	24-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	24-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	24-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	24-02	Straight Party			REPUBLICAN PARTY (R)	0	0	76	76City & County of Honolulu	24-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	309	309City & County of Honolulu	24-02	US Representative	1	R	"TATAII, Steve"	0	0	38	38City & County of Honolulu	24-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	24-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	24-02	State Representative	24	D	"CHOY, Isaac W."	0	0	247	247City & County of Honolulu	24-02	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	70	70City & County of Honolulu	24-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	346	346City & County of Honolulu	24-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	24-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	24-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	24-03	Straight Party			REPUBLICAN PARTY (R)	0	0	62	62City & County of Honolulu	24-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	280	280City & County of Honolulu	24-03	US Representative	1	R	"TATAII, Steve"	0	0	34	34City & County of Honolulu	24-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	24-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	24-03	State Representative	24	D	"CHOY, Isaac W."	0	0	169	169City & County of Honolulu	24-03	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	51	51City & County of Honolulu	24-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	414	414City & County of Honolulu	24-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	24-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	14	14City & County of Honolulu	24-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	24-04	Straight Party			REPUBLICAN PARTY (R)	0	0	91	91City & County of Honolulu	24-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	338	338City & County of Honolulu	24-04	US Representative	1	R	"TATAII, Steve"	0	0	44	44City & County of Honolulu	24-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5City & County of Honolulu	24-04	US Representative	1	L	"ZHAO, Li"	0	0	9	9City & County of Honolulu	24-04	State Representative	24	D	"CHOY, Isaac W."	0	0	177	177City & County of Honolulu	24-04	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	79	79City & County of Honolulu	24-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	565	565City & County of Honolulu	24-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	24-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10City & County of Honolulu	24-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	24-05	Straight Party			REPUBLICAN PARTY (R)	0	0	111	111City & County of Honolulu	24-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	422	422City & County of Honolulu	24-05	US Representative	1	R	"TATAII, Steve"	0	0	57	57City & County of Honolulu	24-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	24-05	US Representative	1	L	"ZHAO, Li"	0	0	6	6City & County of Honolulu	24-05	State Representative	24	D	"CHOY, Isaac W."	0	0	337	337City & County of Honolulu	24-05	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	93	93City & County of Honolulu	24-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	671	671City & County of Honolulu	24-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	24-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7City & County of Honolulu	24-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	24-06	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115City & County of Honolulu	24-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	502	502City & County of Honolulu	24-06	US Representative	1	R	"TATAII, Steve"	0	0	54	54City & County of Honolulu	24-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	6	6City & County of Honolulu	24-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	24-06	State Representative	24	D	"CHOY, Isaac W."	0	0	409	409City & County of Honolulu	24-06	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	103	103City & County of Honolulu	25-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	375	375City & County of Honolulu	25-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	25-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	25-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	25-01	Straight Party			REPUBLICAN PARTY (R)	0	0	94	94City & County of Honolulu	25-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	279	279City & County of Honolulu	25-01	US Representative	1	R	"TATAII, Steve"	0	0	86	86City & County of Honolulu	25-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	25-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	25-01	State Representative	25	D	"BELATTI, Della A."	0	0	236	236City & County of Honolulu	25-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	377	377City & County of Honolulu	25-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	25-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7City & County of Honolulu	25-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	25-02	Straight Party			REPUBLICAN PARTY (R)	0	0	74	74City & County of Honolulu	25-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	297	297City & County of Honolulu	25-02	US Representative	1	R	"TATAII, Steve"	0	0	64	64City & County of Honolulu	25-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	25-02	US Representative	1	L	"ZHAO, Li"	0	0	5	5City & County of Honolulu	25-02	State Representative	25	D	"BELATTI, Della A."	0	0	250	250City & County of Honolulu	25-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	31	31City & County of Honolulu	25-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	25-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	25-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	25-03	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8City & County of Honolulu	25-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	21	21City & County of Honolulu	25-03	US Representative	1	R	"TATAII, Steve"	0	0	7	7City & County of Honolulu	25-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	25-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	25-03	State Representative	25	D	"BELATTI, Della A."	0	0	19	19City & County of Honolulu	25-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	186	186City & County of Honolulu	25-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	25-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	25-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	25-04	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31City & County of Honolulu	25-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	147	147City & County of Honolulu	25-04	US Representative	1	R	"TATAII, Steve"	0	0	29	29City & County of Honolulu	25-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	25-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	25-04	State Representative	25	D	"BELATTI, Della A."	0	0	95	95City & County of Honolulu	25-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	394	394City & County of Honolulu	25-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	25-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	25-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	25-05	Straight Party			REPUBLICAN PARTY (R)	0	0	88	88City & County of Honolulu	25-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	318	318City & County of Honolulu	25-05	US Representative	1	R	"TATAII, Steve"	0	0	82	82City & County of Honolulu	25-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	25-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	25-05	State Representative	25	D	"BELATTI, Della A."	0	0	240	240City & County of Honolulu	25-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	316	316City & County of Honolulu	25-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	25-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	25-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	25-06	Straight Party			REPUBLICAN PARTY (R)	0	0	65	65City & County of Honolulu	25-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	256	256City & County of Honolulu	25-06	US Representative	1	R	"TATAII, Steve"	0	0	57	57City & County of Honolulu	25-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	25-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	25-06	State Representative	25	D	"BELATTI, Della A."	0	0	203	203City & County of Honolulu	25-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	285	285City & County of Honolulu	25-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	25-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	25-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	25-07	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57City & County of Honolulu	25-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	225	225City & County of Honolulu	25-07	US Representative	1	R	"TATAII, Steve"	0	0	51	51City & County of Honolulu	25-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	25-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	25-07	State Representative	25	D	"BELATTI, Della A."	0	0	172	172City & County of Honolulu	26-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	598	598City & County of Honolulu	26-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	26-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6City & County of Honolulu	26-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	26-01	Straight Party			REPUBLICAN PARTY (R)	0	0	66	66City & County of Honolulu	26-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	463	463City & County of Honolulu	26-01	US Representative	1	R	"TATAII, Steve"	0	0	55	55City & County of Honolulu	26-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	26-01	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	26-01	State Representative	26	D	"LUKE, Sylvia"	0	0	480	480City & County of Honolulu	26-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	185	185City & County of Honolulu	26-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	26-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	26-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	26-02	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15City & County of Honolulu	26-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	153	153City & County of Honolulu	26-02	US Representative	1	R	"TATAII, Steve"	0	0	14	14City & County of Honolulu	26-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	26-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	26-02	State Representative	26	D	"LUKE, Sylvia"	0	0	128	128City & County of Honolulu	26-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	300	300City & County of Honolulu	26-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	26-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	26-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9City & County of Honolulu	26-03	Straight Party			REPUBLICAN PARTY (R)	0	0	68	68City & County of Honolulu	26-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	248	248City & County of Honolulu	26-03	US Representative	1	R	"TATAII, Steve"	0	0	62	62City & County of Honolulu	26-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	26-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	26-03	State Representative	26	D	"LUKE, Sylvia"	0	0	199	199City & County of Honolulu	26-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	207	207City & County of Honolulu	26-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	26-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	26-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	26-04	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51City & County of Honolulu	26-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	163	163City & County of Honolulu	26-04	US Representative	1	R	"TATAII, Steve"	0	0	48	48City & County of Honolulu	26-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	26-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	26-04	State Representative	26	D	"LUKE, Sylvia"	0	0	129	129City & County of Honolulu	26-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319City & County of Honolulu	26-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	26-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6City & County of Honolulu	26-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	26-05	Straight Party			REPUBLICAN PARTY (R)	1	0	52	53City & County of Honolulu	26-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	252	252City & County of Honolulu	26-05	US Representative	1	R	"TATAII, Steve"	1	0	47	48City & County of Honolulu	26-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	26-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	26-05	State Representative	26	D	"LUKE, Sylvia"	0	0	220	220City & County of Honolulu	26-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	575	575City & County of Honolulu	26-06	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	26-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	9	9City & County of Honolulu	26-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	17	17City & County of Honolulu	26-06	Straight Party			REPUBLICAN PARTY (R)	0	0	126	126City & County of Honolulu	26-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	454	454City & County of Honolulu	26-06	US Representative	1	R	"TATAII, Steve"	0	0	117	117City & County of Honolulu	26-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	26-06	US Representative	1	L	"ZHAO, Li"	0	0	7	7City & County of Honolulu	26-06	State Representative	26	D	"LUKE, Sylvia"	0	0	418	418City & County of Honolulu	26-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	623	623City & County of Honolulu	26-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	26-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8City & County of Honolulu	26-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	26-07	Straight Party			REPUBLICAN PARTY (R)	0	0	139	139City & County of Honolulu	26-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	451	451City & County of Honolulu	26-07	US Representative	1	R	"TATAII, Steve"	0	0	125	125City & County of Honolulu	26-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	26-07	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	26-07	State Representative	26	D	"LUKE, Sylvia"	0	0	485	485City & County of Honolulu	27-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	65	65City & County of Honolulu	27-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	27-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	27-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	27-01	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20City & County of Honolulu	27-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	55	55City & County of Honolulu	27-01	US Representative	1	R	"TATAII, Steve"	0	0	6	6City & County of Honolulu	27-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	27-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	27-01	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	34	34City & County of Honolulu	27-01	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	19	19City & County of Honolulu	27-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	292	292City & County of Honolulu	27-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	27-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	27-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	27-02	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59City & County of Honolulu	27-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	240	240City & County of Honolulu	27-02	US Representative	1	R	"TATAII, Steve"	0	0	27	27City & County of Honolulu	27-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	27-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	27-02	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	174	174City & County of Honolulu	27-02	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	56	56City & County of Honolulu	27-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	668	668City & County of Honolulu	27-03	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	27-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	27-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	27-03	Straight Party			REPUBLICAN PARTY (R)	0	0	199	199City & County of Honolulu	27-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	540	540City & County of Honolulu	27-03	US Representative	1	R	"TATAII, Steve"	0	0	54	54City & County of Honolulu	27-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	27-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	27-03	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	406	406City & County of Honolulu	27-03	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	189	189City & County of Honolulu	27-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	122	122City & County of Honolulu	27-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	27-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	27-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	27-04	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35City & County of Honolulu	27-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	98	98City & County of Honolulu	27-04	US Representative	1	R	"TATAII, Steve"	0	0	11	11City & County of Honolulu	27-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	27-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	27-04	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	64	64City & County of Honolulu	27-04	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	34	34City & County of Honolulu	27-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	231	231City & County of Honolulu	27-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	27-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	27-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	27-05	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51City & County of Honolulu	27-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	203	203City & County of Honolulu	27-05	US Representative	1	R	"TATAII, Steve"	0	0	15	15City & County of Honolulu	27-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3City & County of Honolulu	27-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	27-05	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	77	77City & County of Honolulu	27-05	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	49	49City & County of Honolulu	27-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	348	348City & County of Honolulu	27-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	27-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	27-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	27-06	Straight Party			REPUBLICAN PARTY (R)	0	0	93	93City & County of Honolulu	27-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	298	298City & County of Honolulu	27-06	US Representative	1	R	"TATAII, Steve"	0	0	31	31City & County of Honolulu	27-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	27-06	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	27-06	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	161	161City & County of Honolulu	27-06	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	89	89City & County of Honolulu	27-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	112	112City & County of Honolulu	27-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	27-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	27-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	27-07	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31City & County of Honolulu	27-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	93	93City & County of Honolulu	27-07	US Representative	1	R	"TATAII, Steve"	0	0	11	11City & County of Honolulu	27-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	27-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	27-07	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	37	37City & County of Honolulu	27-07	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	27	27City & County of Honolulu	27-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	266	266City & County of Honolulu	27-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	27-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	27-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	27-08	Straight Party			REPUBLICAN PARTY (R)	0	0	84	84City & County of Honolulu	27-08	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	223	223City & County of Honolulu	27-08	US Representative	1	R	"TATAII, Steve"	0	0	31	31City & County of Honolulu	27-08	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	27-08	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	27-08	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	137	137City & County of Honolulu	27-08	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	79	79City & County of Honolulu	28-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200City & County of Honolulu	28-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	28-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	28-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	28-01	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28City & County of Honolulu	28-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	155	155City & County of Honolulu	28-01	US Representative	1	R	"TATAII, Steve"	0	0	25	25City & County of Honolulu	28-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	28-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	28-01	State Representative	28	D	"RHOADS, Karl"	0	0	118	118City & County of Honolulu	28-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	235	235City & County of Honolulu	28-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	28-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	28-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	28-02	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53City & County of Honolulu	28-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	191	191City & County of Honolulu	28-02	US Representative	1	R	"TATAII, Steve"	0	0	50	50City & County of Honolulu	28-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3City & County of Honolulu	28-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	28-02	State Representative	28	D	"RHOADS, Karl"	0	0	101	101City & County of Honolulu	28-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	135	135City & County of Honolulu	28-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	28-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	28-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	28-03	Straight Party			REPUBLICAN PARTY (R)	0	0	52	52City & County of Honolulu	28-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	110	110City & County of Honolulu	28-03	US Representative	1	R	"TATAII, Steve"	0	0	29	29City & County of Honolulu	28-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	28-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	28-03	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	83	83City & County of Honolulu	28-03	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	18	18City & County of Honolulu	28-03	State Senate	12	R	"TRIMBLE, Gordon"	0	0	47	47City & County of Honolulu	28-03	State Representative	28	D	"RHOADS, Karl"	0	0	83	83City & County of Honolulu	28-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176City & County of Honolulu	28-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	28-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	28-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	28-04	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51City & County of Honolulu	28-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	145	145City & County of Honolulu	28-04	US Representative	1	R	"TATAII, Steve"	0	0	34	34City & County of Honolulu	28-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	28-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	28-04	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	110	110City & County of Honolulu	28-04	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	29	29City & County of Honolulu	28-04	State Senate	12	R	"TRIMBLE, Gordon"	0	0	40	40City & County of Honolulu	28-04	State Representative	28	D	"RHOADS, Karl"	0	0	127	127City & County of Honolulu	28-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	521	521City & County of Honolulu	28-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	28-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8City & County of Honolulu	28-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11City & County of Honolulu	28-05	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108City & County of Honolulu	28-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	386	386City & County of Honolulu	28-05	US Representative	1	R	"TATAII, Steve"	0	0	68	68City & County of Honolulu	28-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	28-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	28-05	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	293	293City & County of Honolulu	28-05	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	85	85City & County of Honolulu	28-05	State Senate	12	R	"TRIMBLE, Gordon"	0	0	94	94City & County of Honolulu	28-05	State Representative	28	D	"RHOADS, Karl"	0	0	327	327City & County of Honolulu	28-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	138	138City & County of Honolulu	28-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	28-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	28-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	28-06	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22City & County of Honolulu	28-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	115	115City & County of Honolulu	28-06	US Representative	1	R	"TATAII, Steve"	0	0	16	16City & County of Honolulu	28-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	28-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	28-06	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	67	67City & County of Honolulu	28-06	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	23	23City & County of Honolulu	28-06	State Senate	12	R	"TRIMBLE, Gordon"	0	0	17	17City & County of Honolulu	28-06	State Representative	28	D	"RHOADS, Karl"	0	0	98	98City & County of Honolulu	29-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	360	360City & County of Honolulu	29-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	29-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	29-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	29-01	Straight Party			REPUBLICAN PARTY (R)	0	0	50	50City & County of Honolulu	29-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	265	265City & County of Honolulu	29-01	US Representative	1	R	"TATAII, Steve"	0	0	31	31City & County of Honolulu	29-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	29-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	29-01	State Representative	29	D	"MANAHAN, Joey"	0	0	252	252City & County of Honolulu	29-01	State Representative	29	R	"YAW, Shane D. K."	0	0	34	34City & County of Honolulu	29-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	389	389City & County of Honolulu	29-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	29-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	29-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	29-02	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45City & County of Honolulu	29-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	320	320City & County of Honolulu	29-02	US Representative	1	R	"TATAII, Steve"	0	0	28	28City & County of Honolulu	29-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	29-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	29-02	State Representative	29	D	"MANAHAN, Joey"	0	0	290	290City & County of Honolulu	29-02	State Representative	29	R	"YAW, Shane D. K."	0	0	33	33City & County of Honolulu	29-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	265	265City & County of Honolulu	29-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	29-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	29-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	29-03	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23City & County of Honolulu	29-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	211	211City & County of Honolulu	29-03	US Representative	1	R	"TATAII, Steve"	0	0	13	13City & County of Honolulu	29-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	29-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	29-03	State Representative	29	D	"MANAHAN, Joey"	0	0	173	173City & County of Honolulu	29-03	State Representative	29	R	"YAW, Shane D. K."	0	0	15	15City & County of Honolulu	29-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129City & County of Honolulu	29-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	29-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	29-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	29-04	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32City & County of Honolulu	29-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	109	109City & County of Honolulu	29-04	US Representative	1	R	"TATAII, Steve"	0	0	25	25City & County of Honolulu	29-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	29-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	29-04	State Representative	29	D	"MANAHAN, Joey"	0	0	64	64City & County of Honolulu	29-04	State Representative	29	R	"YAW, Shane D. K."	0	0	20	20City & County of Honolulu	29-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236City & County of Honolulu	29-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	29-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	29-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	29-05	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17City & County of Honolulu	29-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	180	180City & County of Honolulu	29-05	US Representative	1	R	"TATAII, Steve"	0	0	10	10City & County of Honolulu	29-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	29-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	29-05	State Representative	29	D	"MANAHAN, Joey"	0	0	180	180City & County of Honolulu	29-05	State Representative	29	R	"YAW, Shane D. K."	0	0	9	9City & County of Honolulu	30-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	395	395City & County of Honolulu	30-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	30-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	30-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	30-01	Straight Party			REPUBLICAN PARTY (R)	0	0	70	70City & County of Honolulu	30-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	313	313City & County of Honolulu	30-01	US Representative	1	R	"TATAII, Steve"	0	0	67	67City & County of Honolulu	30-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	30-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	30-01	State Representative	30	D	"MIZUNO, John"	0	0	314	314City & County of Honolulu	30-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	339	339City & County of Honolulu	30-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	30-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	30-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	30-02	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45City & County of Honolulu	30-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	264	264City & County of Honolulu	30-02	US Representative	1	R	"TATAII, Steve"	0	0	42	42City & County of Honolulu	30-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	30-02	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	30-02	State Representative	30	D	"MIZUNO, John"	0	0	242	242City & County of Honolulu	30-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	256	256City & County of Honolulu	30-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	30-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	30-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	30-03	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28City & County of Honolulu	30-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	201	201City & County of Honolulu	30-03	US Representative	1	R	"TATAII, Steve"	0	0	26	26City & County of Honolulu	30-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	30-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	30-03	State Representative	30	D	"MIZUNO, John"	0	0	175	175City & County of Honolulu	30-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	175	175City & County of Honolulu	30-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	30-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	30-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	30-04	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13City & County of Honolulu	30-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	127	127City & County of Honolulu	30-04	US Representative	1	R	"TATAII, Steve"	0	0	12	12City & County of Honolulu	30-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	30-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	30-04	State Representative	30	D	"MIZUNO, John"	0	0	147	147City & County of Honolulu	30-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	56	56City & County of Honolulu	30-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	30-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	30-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	30-05	Straight Party			REPUBLICAN PARTY (R)	0	0	18	18City & County of Honolulu	30-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	41	41City & County of Honolulu	30-05	US Representative	1	R	"TATAII, Steve"	0	0	17	17City & County of Honolulu	30-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	30-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	30-05	State Representative	30	D	"MIZUNO, John"	0	0	31	31City & County of Honolulu	30-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	470	470City & County of Honolulu	30-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	30-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	30-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	30-06	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59City & County of Honolulu	30-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	394	394City & County of Honolulu	30-06	US Representative	1	R	"TATAII, Steve"	0	0	57	57City & County of Honolulu	30-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	30-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	30-06	State Representative	30	D	"MIZUNO, John"	0	0	345	345City & County of Honolulu	31-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	491	491City & County of Honolulu	31-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	31-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	31-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	31-01	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54City & County of Honolulu	31-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	357	357City & County of Honolulu	31-01	US Representative	1	R	"TATAII, Steve"	0	0	46	46City & County of Honolulu	31-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	31-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	31-01	State Representative	31	D	"WAKAI, Glenn"	0	0	417	417City & County of Honolulu	31-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	515	515City & County of Honolulu	31-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	31-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10City & County of Honolulu	31-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	31-02	Straight Party			REPUBLICAN PARTY (R)	0	0	72	72City & County of Honolulu	31-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	412	412City & County of Honolulu	31-02	US Representative	1	R	"TATAII, Steve"	0	0	66	66City & County of Honolulu	31-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	31-02	US Representative	1	L	"ZHAO, Li"	0	0	10	10City & County of Honolulu	31-02	State Representative	31	D	"WAKAI, Glenn"	0	0	413	413City & County of Honolulu	31-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	333	333City & County of Honolulu	31-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	31-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	31-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8City & County of Honolulu	31-03	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55City & County of Honolulu	31-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	264	264City & County of Honolulu	31-03	US Representative	1	R	"TATAII, Steve"	0	0	53	53City & County of Honolulu	31-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	31-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	31-03	State Representative	31	D	"WAKAI, Glenn"	0	0	262	262City & County of Honolulu	31-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	347	347City & County of Honolulu	31-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	31-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	31-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8City & County of Honolulu	31-04	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75City & County of Honolulu	31-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	261	261City & County of Honolulu	31-04	US Representative	1	R	"TATAII, Steve"	0	0	67	67City & County of Honolulu	31-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	31-04	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	31-04	State Representative	31	D	"WAKAI, Glenn"	0	0	261	261City & County of Honolulu	31-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	634	634City & County of Honolulu	31-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	31-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	31-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	31-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81City & County of Honolulu	31-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	483	483City & County of Honolulu	31-05	US Representative	1	R	"TATAII, Steve"	0	0	74	74City & County of Honolulu	31-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	31-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	31-05	State Representative	31	D	"WAKAI, Glenn"	0	0	515	515City & County of Honolulu	32-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	429	429City & County of Honolulu	32-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	32-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	32-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	32-01	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105City & County of Honolulu	32-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	390	390City & County of Honolulu	32-01	US Representative	1	R	"TATAII, Steve"	0	0	42	42City & County of Honolulu	32-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	32-01	State Representative	32	R	"FINNEGAN, Lynn"	0	0	95	95City & County of Honolulu	32-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	42	42City & County of Honolulu	32-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	32-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	32-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	32-02	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11City & County of Honolulu	32-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	40	40City & County of Honolulu	32-02	US Representative	1	R	"TATAII, Steve"	0	0	3	3City & County of Honolulu	32-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	32-02	State Representative	32	R	"FINNEGAN, Lynn"	0	0	9	9City & County of Honolulu	32-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	22	22City & County of Honolulu	32-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	32-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	32-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	32-03	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19City & County of Honolulu	32-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	19	19City & County of Honolulu	32-03	US Representative	1	R	"TATAII, Steve"	0	0	13	13City & County of Honolulu	32-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	32-03	State Representative	32	R	"FINNEGAN, Lynn"	0	0	13	13City & County of Honolulu	32-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	210	210City & County of Honolulu	32-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	32-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	32-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	32-04	Straight Party			REPUBLICAN PARTY (R)	0	0	65	65City & County of Honolulu	32-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	201	201City & County of Honolulu	32-04	US Representative	1	R	"TATAII, Steve"	0	0	23	23City & County of Honolulu	32-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	32-04	State Representative	32	R	"FINNEGAN, Lynn"	0	0	61	61City & County of Honolulu	32-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	471	471City & County of Honolulu	32-05	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9City & County of Honolulu	32-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	32-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	32-05	Straight Party			REPUBLICAN PARTY (R)	0	0	255	255City & County of Honolulu	32-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	429	429City & County of Honolulu	32-05	US Representative	1	R	"TATAII, Steve"	0	0	98	98City & County of Honolulu	32-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	32-05	State Representative	32	R	"FINNEGAN, Lynn"	0	0	235	235City & County of Honolulu	32-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	211	211City & County of Honolulu	32-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	32-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	32-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	32-06	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58City & County of Honolulu	32-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	193	193City & County of Honolulu	32-06	US Representative	1	R	"TATAII, Steve"	0	0	19	19City & County of Honolulu	32-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	32-06	State Representative	32	R	"FINNEGAN, Lynn"	0	0	48	48City & County of Honolulu	32-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	145	145City & County of Honolulu	32-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	32-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	32-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	32-07	Straight Party			REPUBLICAN PARTY (R)	0	0	41	41City & County of Honolulu	32-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	138	138City & County of Honolulu	32-07	US Representative	1	R	"TATAII, Steve"	0	0	13	13City & County of Honolulu	32-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-07	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	32-07	State Representative	32	R	"FINNEGAN, Lynn"	0	0	38	38City & County of Honolulu	32-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	266	266City & County of Honolulu	32-08	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	32-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	32-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	32-08	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107City & County of Honolulu	32-08	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	250	250City & County of Honolulu	32-08	US Representative	1	R	"TATAII, Steve"	0	0	44	44City & County of Honolulu	32-08	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	32-08	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	32-08	State Representative	32	R	"FINNEGAN, Lynn"	0	0	93	93City & County of Honolulu	33-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	77	77City & County of Honolulu	33-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	33-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	33-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	33-01	Straight Party			REPUBLICAN PARTY (R)	0	0	21	21City & County of Honolulu	33-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	58	58City & County of Honolulu	33-01	US Representative	1	R	"TATAII, Steve"	0	0	20	20City & County of Honolulu	33-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	33-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	33-01	State Representative	33	D	"OSHIRO, Blake K."	0	0	46	46City & County of Honolulu	33-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	205	205City & County of Honolulu	33-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	33-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	33-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	33-02	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34City & County of Honolulu	33-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	169	169City & County of Honolulu	33-02	US Representative	1	R	"TATAII, Steve"	0	0	32	32City & County of Honolulu	33-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	33-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	33-02	State Representative	33	D	"OSHIRO, Blake K."	0	0	143	143City & County of Honolulu	33-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	478	478City & County of Honolulu	33-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	33-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	33-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	33-03	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55City & County of Honolulu	33-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	381	381City & County of Honolulu	33-03	US Representative	1	R	"TATAII, Steve"	0	0	45	45City & County of Honolulu	33-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	33-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	33-03	State Representative	33	D	"OSHIRO, Blake K."	0	0	332	332City & County of Honolulu	33-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	775	775City & County of Honolulu	33-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9City & County of Honolulu	33-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8City & County of Honolulu	33-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12City & County of Honolulu	33-04	Straight Party			REPUBLICAN PARTY (R)	0	0	149	149City & County of Honolulu	33-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	599	599City & County of Honolulu	33-04	US Representative	1	R	"TATAII, Steve"	0	0	132	132City & County of Honolulu	33-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3City & County of Honolulu	33-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	33-04	State Senate	16	D	"IGE, David Y."	0	0	436	436City & County of Honolulu	33-04	State Representative	33	D	"OSHIRO, Blake K."	0	0	517	517City & County of Honolulu	33-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	455	455City & County of Honolulu	33-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	33-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	33-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10City & County of Honolulu	33-05	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107City & County of Honolulu	33-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	367	367City & County of Honolulu	33-05	US Representative	1	R	"TATAII, Steve"	0	0	100	100City & County of Honolulu	33-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	33-05	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	33-05	State Senate	16	D	"IGE, David Y."	0	0	284	284City & County of Honolulu	33-05	State Representative	33	D	"OSHIRO, Blake K."	0	0	308	308City & County of Honolulu	33-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311City & County of Honolulu	33-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	33-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	33-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	33-06	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55City & County of Honolulu	33-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	255	255City & County of Honolulu	33-06	US Representative	1	R	"TATAII, Steve"	0	0	49	49City & County of Honolulu	33-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	33-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	33-06	State Senate	16	D	"IGE, David Y."	0	0	176	176City & County of Honolulu	33-06	State Representative	33	D	"OSHIRO, Blake K."	0	0	198	198City & County of Honolulu	34-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	394	394City & County of Honolulu	34-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	34-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	34-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	34-01	Straight Party			REPUBLICAN PARTY (R)	0	0	64	64City & County of Honolulu	34-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	299	299City & County of Honolulu	34-01	US Representative	1	R	"TATAII, Steve"	0	0	59	59City & County of Honolulu	34-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	34-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	34-01	State Senate	16	D	"IGE, David Y."	0	0	244	244City & County of Honolulu	34-01	State Representative	34	D	"TAKAI, K. Mark"	0	0	282	282City & County of Honolulu	34-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	355	355City & County of Honolulu	34-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	34-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	34-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	34-02	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80City & County of Honolulu	34-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	272	272City & County of Honolulu	34-02	US Representative	1	R	"TATAII, Steve"	0	0	78	78City & County of Honolulu	34-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	34-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	34-02	State Senate	16	D	"IGE, David Y."	0	0	214	214City & County of Honolulu	34-02	State Representative	34	D	"TAKAI, K. Mark"	0	0	261	261City & County of Honolulu	34-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223City & County of Honolulu	34-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	34-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	34-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	34-03	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23City & County of Honolulu	34-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	179	179City & County of Honolulu	34-03	US Representative	1	R	"TATAII, Steve"	0	0	19	19City & County of Honolulu	34-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	34-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	34-03	State Senate	16	D	"IGE, David Y."	0	0	151	151City & County of Honolulu	34-03	State Representative	34	D	"TAKAI, K. Mark"	0	0	169	169City & County of Honolulu	34-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	395	395City & County of Honolulu	34-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	34-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	34-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	34-04	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36City & County of Honolulu	34-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	305	305City & County of Honolulu	34-04	US Representative	1	R	"TATAII, Steve"	0	0	29	29City & County of Honolulu	34-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	34-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	34-04	State Senate	16	D	"IGE, David Y."	0	0	244	244City & County of Honolulu	34-04	State Representative	34	D	"TAKAI, K. Mark"	0	0	292	292City & County of Honolulu	34-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	238	238City & County of Honolulu	34-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	34-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	34-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	34-05	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23City & County of Honolulu	34-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	187	187City & County of Honolulu	34-05	US Representative	1	R	"TATAII, Steve"	0	0	21	21City & County of Honolulu	34-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	34-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	34-05	State Senate	16	D	"IGE, David Y."	0	0	142	142City & County of Honolulu	34-05	State Representative	34	D	"TAKAI, K. Mark"	0	0	160	160City & County of Honolulu	34-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	68	68City & County of Honolulu	34-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	34-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	34-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	34-06	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14City & County of Honolulu	34-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	61	61City & County of Honolulu	34-06	US Representative	1	R	"TATAII, Steve"	0	0	11	11City & County of Honolulu	34-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	34-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	34-06	State Senate	18	D	"SONSON, Alex M."	0	0	27	27City & County of Honolulu	34-06	State Senate	18	D	"NISHIHARA, Clarence"	0	0	29	29City & County of Honolulu	34-06	State Representative	34	D	"TAKAI, K. Mark"	0	0	52	52City & County of Honolulu	34-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	1034	1034City & County of Honolulu	34-07	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	34-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	9	9City & County of Honolulu	34-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	34-07	Straight Party			REPUBLICAN PARTY (R)	0	0	103	103City & County of Honolulu	34-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	780	780City & County of Honolulu	34-07	US Representative	1	R	"TATAII, Steve"	0	0	95	95City & County of Honolulu	34-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	34-07	US Representative	1	L	"ZHAO, Li"	0	0	5	5City & County of Honolulu	34-07	State Senate	16	D	"IGE, David Y."	0	0	727	727City & County of Honolulu	34-07	State Representative	34	D	"TAKAI, K. Mark"	0	0	809	809City & County of Honolulu	35-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	499	499City & County of Honolulu	35-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	35-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	35-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	35-01	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61City & County of Honolulu	35-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	373	373City & County of Honolulu	35-01	US Representative	1	R	"TATAII, Steve"	0	0	41	41City & County of Honolulu	35-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	35-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	35-01	State Senate	18	D	"SONSON, Alex M."	0	0	211	211City & County of Honolulu	35-01	State Senate	18	D	"NISHIHARA, Clarence"	0	0	262	262City & County of Honolulu	35-01	State Representative	35	D	"AQUINO, Henry James C."	0	0	215	215City & County of Honolulu	35-01	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	178	178City & County of Honolulu	35-01	State Representative	35	D	"VERDADERO, Dante M."	0	0	19	19City & County of Honolulu	35-01	State Representative	35	D	"DOMINGO, Constante A."	0	0	21	21City & County of Honolulu	35-01	State Representative	35	D	"PARAYNO, Ilalo"	0	0	31	31City & County of Honolulu	35-01	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	46	46City & County of Honolulu	35-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	745	745City & County of Honolulu	35-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	35-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	35-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	35-02	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40City & County of Honolulu	35-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	572	572City & County of Honolulu	35-02	US Representative	1	R	"TATAII, Steve"	0	0	17	17City & County of Honolulu	35-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	35-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	35-02	State Senate	18	D	"SONSON, Alex M."	0	0	445	445City & County of Honolulu	35-02	State Senate	18	D	"NISHIHARA, Clarence"	0	0	268	268City & County of Honolulu	35-02	State Representative	35	D	"AQUINO, Henry James C."	0	0	494	494City & County of Honolulu	35-02	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	147	147City & County of Honolulu	35-02	State Representative	35	D	"VERDADERO, Dante M."	0	0	36	36City & County of Honolulu	35-02	State Representative	35	D	"DOMINGO, Constante A."	0	0	16	16City & County of Honolulu	35-02	State Representative	35	D	"PARAYNO, Ilalo"	0	0	25	25City & County of Honolulu	35-02	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	32	32City & County of Honolulu	35-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	221	221City & County of Honolulu	35-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	35-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	35-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	35-03	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17City & County of Honolulu	35-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	169	169City & County of Honolulu	35-03	US Representative	1	R	"TATAII, Steve"	0	0	6	6City & County of Honolulu	35-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	35-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	35-03	State Senate	18	D	"SONSON, Alex M."	0	0	113	113City & County of Honolulu	35-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	99	99City & County of Honolulu	35-03	State Representative	35	D	"AQUINO, Henry James C."	0	0	133	133City & County of Honolulu	35-03	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	30	30City & County of Honolulu	35-03	State Representative	35	D	"VERDADERO, Dante M."	0	0	17	17City & County of Honolulu	35-03	State Representative	35	D	"DOMINGO, Constante A."	0	0	10	10City & County of Honolulu	35-03	State Representative	35	D	"PARAYNO, Ilalo"	0	0	12	12City & County of Honolulu	35-03	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	14	14City & County of Honolulu	35-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	330	330City & County of Honolulu	35-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	35-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	35-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	35-04	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22City & County of Honolulu	35-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	272	272City & County of Honolulu	35-04	US Representative	1	R	"TATAII, Steve"	0	0	15	15City & County of Honolulu	35-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	35-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	35-04	State Senate	18	D	"SONSON, Alex M."	0	0	163	163City & County of Honolulu	35-04	State Senate	18	D	"NISHIHARA, Clarence"	0	0	157	157City & County of Honolulu	35-04	State Representative	35	D	"AQUINO, Henry James C."	0	0	192	192City & County of Honolulu	35-04	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	57	57City & County of Honolulu	35-04	State Representative	35	D	"VERDADERO, Dante M."	0	0	9	9City & County of Honolulu	35-04	State Representative	35	D	"DOMINGO, Constante A."	0	0	12	12City & County of Honolulu	35-04	State Representative	35	D	"PARAYNO, Ilalo"	0	0	33	33City & County of Honolulu	35-04	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	18	18City & County of Honolulu	35-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	279	279City & County of Honolulu	35-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	35-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	35-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	35-05	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13City & County of Honolulu	35-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	231	231City & County of Honolulu	35-05	US Representative	1	R	"TATAII, Steve"	0	0	6	6City & County of Honolulu	35-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	35-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	35-05	State Senate	18	D	"SONSON, Alex M."	0	0	173	173City & County of Honolulu	35-05	State Senate	18	D	"NISHIHARA, Clarence"	0	0	96	96City & County of Honolulu	35-05	State Representative	35	D	"AQUINO, Henry James C."	0	0	176	176City & County of Honolulu	35-05	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	36	36City & County of Honolulu	35-05	State Representative	35	D	"VERDADERO, Dante M."	0	0	15	15City & County of Honolulu	35-05	State Representative	35	D	"DOMINGO, Constante A."	0	0	12	12City & County of Honolulu	35-05	State Representative	35	D	"PARAYNO, Ilalo"	0	0	27	27City & County of Honolulu	35-05	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	11	11City & County of Honolulu	35-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	862	862City & County of Honolulu	35-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	35-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	35-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	35-06	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35City & County of Honolulu	35-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	705	705City & County of Honolulu	35-06	US Representative	1	R	"TATAII, Steve"	0	0	16	16City & County of Honolulu	35-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	35-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	35-06	State Senate	18	D	"SONSON, Alex M."	0	0	515	515City & County of Honolulu	35-06	State Senate	18	D	"NISHIHARA, Clarence"	0	0	321	321City & County of Honolulu	35-06	State Representative	35	D	"AQUINO, Henry James C."	0	0	580	580City & County of Honolulu	35-06	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	134	134City & County of Honolulu	35-06	State Representative	35	D	"VERDADERO, Dante M."	0	0	24	24City & County of Honolulu	35-06	State Representative	35	D	"DOMINGO, Constante A."	0	0	23	23City & County of Honolulu	35-06	State Representative	35	D	"PARAYNO, Ilalo"	0	0	74	74City & County of Honolulu	35-06	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	30	30City & County of Honolulu	36-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	531	531City & County of Honolulu	36-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	36-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	36-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	36-01	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51City & County of Honolulu	36-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	429	429City & County of Honolulu	36-01	US Representative	1	R	"TATAII, Steve"	0	0	46	46City & County of Honolulu	36-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	36-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	36-01	State Senate	16	D	"IGE, David Y."	0	0	338	338City & County of Honolulu	36-01	State Representative	36	D	"TAKUMI, Roy M."	0	0	372	372City & County of Honolulu	36-01	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	3	3City & County of Honolulu	36-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	384	384City & County of Honolulu	36-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	36-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	36-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	16	16City & County of Honolulu	36-02	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40City & County of Honolulu	36-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	317	317City & County of Honolulu	36-02	US Representative	1	R	"TATAII, Steve"	0	0	36	36City & County of Honolulu	36-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	36-02	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	36-02	State Senate	16	D	"IGE, David Y."	0	0	239	239City & County of Honolulu	36-02	State Representative	36	D	"TAKUMI, Roy M."	0	0	249	249City & County of Honolulu	36-02	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	15	15City & County of Honolulu	36-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	273	273City & County of Honolulu	36-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	36-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	36-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	36-03	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59City & County of Honolulu	36-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	226	226City & County of Honolulu	36-03	US Representative	1	R	"TATAII, Steve"	0	0	59	59City & County of Honolulu	36-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	36-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	36-03	State Senate	18	D	"SONSON, Alex M."	0	0	98	98City & County of Honolulu	36-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	135	135City & County of Honolulu	36-03	State Representative	36	D	"TAKUMI, Roy M."	0	0	203	203City & County of Honolulu	36-03	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0City & County of Honolulu	36-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	29	29City & County of Honolulu	36-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	36-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	36-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	36-04	Straight Party			REPUBLICAN PARTY (R)	0	0	4	4City & County of Honolulu	36-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	26	26City & County of Honolulu	36-04	US Representative	1	R	"TATAII, Steve"	0	0	4	4City & County of Honolulu	36-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	36-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	36-04	State Senate	18	D	"SONSON, Alex M."	0	0	10	10City & County of Honolulu	36-04	State Senate	18	D	"NISHIHARA, Clarence"	0	0	15	15City & County of Honolulu	36-04	State Representative	36	D	"TAKUMI, Roy M."	0	0	23	23City & County of Honolulu	36-04	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0City & County of Honolulu	36-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	765	765City & County of Honolulu	36-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	36-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	36-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	36-05	Straight Party			REPUBLICAN PARTY (R)	0	0	69	69City & County of Honolulu	36-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	614	614City & County of Honolulu	36-05	US Representative	1	R	"TATAII, Steve"	0	0	56	56City & County of Honolulu	36-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	36-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	36-05	State Senate	18	D	"SONSON, Alex M."	0	0	212	212City & County of Honolulu	36-05	State Senate	18	D	"NISHIHARA, Clarence"	0	0	496	496City & County of Honolulu	36-05	State Representative	36	D	"TAKUMI, Roy M."	0	0	599	599City & County of Honolulu	36-05	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	4	4City & County of Honolulu	36-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	541	541City & County of Honolulu	36-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	36-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	36-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11City & County of Honolulu	36-06	Straight Party			REPUBLICAN PARTY (R)	0	0	97	97City & County of Honolulu	36-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	427	427City & County of Honolulu	36-06	US Representative	1	R	"TATAII, Steve"	0	0	91	91City & County of Honolulu	36-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	36-06	US Representative	1	L	"ZHAO, Li"	0	0	4	4City & County of Honolulu	36-06	State Senate	16	D	"IGE, David Y."	0	0	320	320City & County of Honolulu	36-06	State Representative	36	D	"TAKUMI, Roy M."	0	0	355	355City & County of Honolulu	36-06	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	8	8City & County of Honolulu	36-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	396	396City & County of Honolulu	36-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	36-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	36-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9City & County of Honolulu	36-07	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67City & County of Honolulu	36-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	310	310City & County of Honolulu	36-07	US Representative	1	R	"TATAII, Steve"	0	0	65	65City & County of Honolulu	36-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	36-07	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	36-07	State Senate	16	D	"IGE, David Y."	0	0	228	228City & County of Honolulu	36-07	State Representative	36	D	"TAKUMI, Roy M."	0	0	247	247City & County of Honolulu	36-07	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	9	9City & County of Honolulu	37-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	940	940City & County of Honolulu	37-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	37-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	37-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	37-01	Straight Party			REPUBLICAN PARTY (R)	0	0	119	119City & County of Honolulu	37-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	753	753City & County of Honolulu	37-01	US Representative	1	R	"TATAII, Steve"	0	0	111	111City & County of Honolulu	37-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	37-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	37-01	State Senate	17	D	"KIDANI, Michelle"	0	0	420	420City & County of Honolulu	37-01	State Senate	17	D	"MENOR, Ron"	0	0	295	295City & County of Honolulu	37-01	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	162	162City & County of Honolulu	37-01	State Representative	37	D	"YAMANE, Ryan I."	0	0	773	773City & County of Honolulu	37-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	708	708City & County of Honolulu	37-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	37-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	37-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	37-02	Straight Party			REPUBLICAN PARTY (R)	0	0	129	129City & County of Honolulu	37-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	567	567City & County of Honolulu	37-02	US Representative	1	R	"TATAII, Steve"	0	0	117	117City & County of Honolulu	37-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	37-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	37-02	State Senate	17	D	"KIDANI, Michelle"	0	0	306	306City & County of Honolulu	37-02	State Senate	17	D	"MENOR, Ron"	0	0	276	276City & County of Honolulu	37-02	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	90	90City & County of Honolulu	37-02	State Representative	37	D	"YAMANE, Ryan I."	0	0	567	567City & County of Honolulu	37-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	880	880City & County of Honolulu	37-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	37-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	37-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	37-03	Straight Party			REPUBLICAN PARTY (R)	0	0	138	138City & County of Honolulu	37-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	674	674City & County of Honolulu	37-03	US Representative	1	R	"TATAII, Steve"	0	0	133	133City & County of Honolulu	37-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	37-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	37-03	State Senate	17	D	"KIDANI, Michelle"	0	0	354	354City & County of Honolulu	37-03	State Senate	17	D	"MENOR, Ron"	0	0	384	384City & County of Honolulu	37-03	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	100	100City & County of Honolulu	37-03	State Representative	37	D	"YAMANE, Ryan I."	0	0	684	684City & County of Honolulu	37-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	738	738City & County of Honolulu	37-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	37-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	37-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	37-04	Straight Party			REPUBLICAN PARTY (R)	0	0	121	121City & County of Honolulu	37-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	581	581City & County of Honolulu	37-04	US Representative	1	R	"TATAII, Steve"	0	0	111	111City & County of Honolulu	37-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	37-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	37-04	State Senate	17	D	"KIDANI, Michelle"	0	0	310	310City & County of Honolulu	37-04	State Senate	17	D	"MENOR, Ron"	0	0	309	309City & County of Honolulu	37-04	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	78	78City & County of Honolulu	37-04	State Representative	37	D	"YAMANE, Ryan I."	0	0	598	598City & County of Honolulu	38-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	818	818City & County of Honolulu	38-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	38-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7City & County of Honolulu	38-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13City & County of Honolulu	38-01	Straight Party			REPUBLICAN PARTY (R)	0	0	210	210City & County of Honolulu	38-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	665	665City & County of Honolulu	38-01	US Representative	1	R	"TATAII, Steve"	0	0	117	117City & County of Honolulu	38-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	38-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3City & County of Honolulu	38-01	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	503	503City & County of Honolulu	38-01	State Representative	38	D	"LEE, Marilyn B."	0	0	539	539City & County of Honolulu	38-01	State Representative	38	R	"APANA, Melvin K."	0	0	178	178City & County of Honolulu	38-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	972	972City & County of Honolulu	38-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	38-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	38-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	38-02	Straight Party			REPUBLICAN PARTY (R)	0	0	180	180City & County of Honolulu	38-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	770	770City & County of Honolulu	38-02	US Representative	1	R	"TATAII, Steve"	0	0	126	126City & County of Honolulu	38-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4City & County of Honolulu	38-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	38-02	State Senate	17	D	"KIDANI, Michelle"	0	0	436	436City & County of Honolulu	38-02	State Senate	17	D	"MENOR, Ron"	0	0	388	388City & County of Honolulu	38-02	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	102	102City & County of Honolulu	38-02	State Representative	38	D	"LEE, Marilyn B."	0	0	776	776City & County of Honolulu	38-02	State Representative	38	R	"APANA, Melvin K."	0	0	155	155City & County of Honolulu	38-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	676	676City & County of Honolulu	38-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	38-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	38-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	38-03	Straight Party			REPUBLICAN PARTY (R)	0	0	114	114City & County of Honolulu	38-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	521	521City & County of Honolulu	38-03	US Representative	1	R	"TATAII, Steve"	0	0	74	74City & County of Honolulu	38-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	38-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	38-03	State Senate	17	D	"KIDANI, Michelle"	0	0	258	258City & County of Honolulu	38-03	State Senate	17	D	"MENOR, Ron"	0	0	269	269City & County of Honolulu	38-03	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	117	117City & County of Honolulu	38-03	State Representative	38	D	"LEE, Marilyn B."	0	0	515	515City & County of Honolulu	38-03	State Representative	38	R	"APANA, Melvin K."	0	0	90	90City & County of Honolulu	38-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	500	500City & County of Honolulu	38-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	38-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	38-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	38-04	Straight Party			REPUBLICAN PARTY (R)	0	0	145	145City & County of Honolulu	38-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	382	382City & County of Honolulu	38-04	US Representative	1	R	"TATAII, Steve"	0	0	94	94City & County of Honolulu	38-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	38-04	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	38-04	State Senate	17	D	"KIDANI, Michelle"	0	0	195	195City & County of Honolulu	38-04	State Senate	17	D	"MENOR, Ron"	0	0	204	204City & County of Honolulu	38-04	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	77	77City & County of Honolulu	38-04	State Representative	38	D	"LEE, Marilyn B."	0	0	380	380City & County of Honolulu	38-04	State Representative	38	R	"APANA, Melvin K."	0	0	118	118City & County of Honolulu	38-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	569	569City & County of Honolulu	38-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	38-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	38-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	38-05	Straight Party			REPUBLICAN PARTY (R)	0	0	111	111City & County of Honolulu	38-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	478	478City & County of Honolulu	38-05	US Representative	1	R	"TATAII, Steve"	0	0	80	80City & County of Honolulu	38-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	38-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	38-05	State Senate	17	D	"KIDANI, Michelle"	0	0	181	181City & County of Honolulu	38-05	State Senate	17	D	"MENOR, Ron"	0	0	259	259City & County of Honolulu	38-05	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	92	92City & County of Honolulu	38-05	State Representative	38	D	"LEE, Marilyn B."	0	0	426	426City & County of Honolulu	38-05	State Representative	38	R	"APANA, Melvin K."	0	0	88	88City & County of Honolulu	39-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	271	271City & County of Honolulu	39-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	39-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	39-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	39-01	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51City & County of Honolulu	39-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	39-01	US Representative	2	D	"HIRONO, Mazie"	0	0	183	183City & County of Honolulu	39-01	US Representative	2	R	"EVANS, Roger B."	0	0	48	48City & County of Honolulu	39-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	39-01	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	209	209City & County of Honolulu	39-01	State Representative	39	D	"OSHIRO, Marcus R."	0	0	171	171City & County of Honolulu	39-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	412	412City & County of Honolulu	39-02	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	39-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	39-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	39-02	Straight Party			REPUBLICAN PARTY (R)	0	0	49	49City & County of Honolulu	39-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7City & County of Honolulu	39-02	US Representative	2	D	"HIRONO, Mazie"	0	0	308	308City & County of Honolulu	39-02	US Representative	2	R	"EVANS, Roger B."	0	0	45	45City & County of Honolulu	39-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	39-02	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	317	317City & County of Honolulu	39-02	State Representative	39	D	"OSHIRO, Marcus R."	0	0	296	296City & County of Honolulu	39-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	534	534City & County of Honolulu	39-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	39-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	39-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	39-03	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83City & County of Honolulu	39-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6City & County of Honolulu	39-03	US Representative	2	D	"HIRONO, Mazie"	0	0	364	364City & County of Honolulu	39-03	US Representative	2	R	"EVANS, Roger B."	0	0	76	76City & County of Honolulu	39-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	39-03	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	400	400City & County of Honolulu	39-03	State Representative	39	D	"OSHIRO, Marcus R."	0	0	373	373City & County of Honolulu	39-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392City & County of Honolulu	39-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	39-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	39-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12City & County of Honolulu	39-04	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83City & County of Honolulu	39-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	39-04	US Representative	2	D	"HIRONO, Mazie"	0	0	299	299City & County of Honolulu	39-04	US Representative	2	R	"EVANS, Roger B."	0	0	79	79City & County of Honolulu	39-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	39-04	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	280	280City & County of Honolulu	39-04	State Representative	39	D	"OSHIRO, Marcus R."	0	0	268	268City & County of Honolulu	39-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	121	121City & County of Honolulu	39-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	39-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	39-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	39-05	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35City & County of Honolulu	39-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	99	99City & County of Honolulu	39-05	US Representative	1	R	"TATAII, Steve"	0	0	35	35City & County of Honolulu	39-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	39-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	39-05	State Senate	17	D	"KIDANI, Michelle"	0	0	49	49City & County of Honolulu	39-05	State Senate	17	D	"MENOR, Ron"	0	0	46	46City & County of Honolulu	39-05	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	7	7City & County of Honolulu	39-05	State Representative	39	D	"OSHIRO, Marcus R."	0	0	81	81City & County of Honolulu	39-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	352	352City & County of Honolulu	39-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	39-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	39-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	39-06	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42City & County of Honolulu	39-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	39-06	US Representative	2	D	"HIRONO, Mazie"	0	0	270	270City & County of Honolulu	39-06	US Representative	2	R	"EVANS, Roger B."	0	0	39	39City & County of Honolulu	39-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5City & County of Honolulu	39-06	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	243	243City & County of Honolulu	39-06	State Representative	39	D	"OSHIRO, Marcus R."	0	0	229	229City & County of Honolulu	40-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	231	231City & County of Honolulu	40-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	40-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	40-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	40-01	Straight Party			REPUBLICAN PARTY (R)	0	0	66	66City & County of Honolulu	40-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	40-01	US Representative	2	D	"HIRONO, Mazie"	0	0	181	181City & County of Honolulu	40-01	US Representative	2	R	"EVANS, Roger B."	0	0	49	49City & County of Honolulu	40-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	40-01	State Representative	40	D	"HAR, Sharon E."	0	0	179	179City & County of Honolulu	40-01	State Representative	40	R	"LEGAL,  Jack M."	0	0	47	47City & County of Honolulu	40-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	316	316City & County of Honolulu	40-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	40-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	40-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	40-02	Straight Party			REPUBLICAN PARTY (R)	0	0	118	118City & County of Honolulu	40-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4City & County of Honolulu	40-02	US Representative	2	D	"HIRONO, Mazie"	0	0	240	240City & County of Honolulu	40-02	US Representative	2	R	"EVANS, Roger B."	0	0	76	76City & County of Honolulu	40-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	40-02	State Representative	40	D	"HAR, Sharon E."	0	0	232	232City & County of Honolulu	40-02	State Representative	40	R	"LEGAL,  Jack M."	0	0	98	98City & County of Honolulu	40-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	463	463City & County of Honolulu	40-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	40-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	40-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	40-03	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154City & County of Honolulu	40-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5City & County of Honolulu	40-03	US Representative	2	D	"HIRONO, Mazie"	0	0	323	323City & County of Honolulu	40-03	US Representative	2	R	"EVANS, Roger B."	0	0	94	94City & County of Honolulu	40-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	40-03	State Representative	40	D	"HAR, Sharon E."	0	0	342	342City & County of Honolulu	40-03	State Representative	40	R	"LEGAL,  Jack M."	0	0	120	120City & County of Honolulu	40-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427City & County of Honolulu	40-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	40-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	40-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	40-04	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154City & County of Honolulu	40-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	40-04	US Representative	2	D	"HIRONO, Mazie"	0	0	299	299City & County of Honolulu	40-04	US Representative	2	R	"EVANS, Roger B."	0	0	73	73City & County of Honolulu	40-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	40-04	State Representative	40	D	"HAR, Sharon E."	0	0	355	355City & County of Honolulu	40-04	State Representative	40	R	"LEGAL,  Jack M."	0	0	126	126City & County of Honolulu	40-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	393	393City & County of Honolulu	40-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	40-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	40-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	40-05	Straight Party			REPUBLICAN PARTY (R)	0	0	166	166City & County of Honolulu	40-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	40-05	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305City & County of Honolulu	40-05	US Representative	2	R	"EVANS, Roger B."	0	0	98	98City & County of Honolulu	40-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	40-05	State Representative	40	D	"HAR, Sharon E."	0	0	300	300City & County of Honolulu	40-05	State Representative	40	R	"LEGAL,  Jack M."	0	0	142	142City & County of Honolulu	40-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	222	222City & County of Honolulu	40-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	40-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	40-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	40-06	Straight Party			REPUBLICAN PARTY (R)	0	0	142	142City & County of Honolulu	40-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	40-06	US Representative	2	D	"HIRONO, Mazie"	0	0	174	174City & County of Honolulu	40-06	US Representative	2	R	"EVANS, Roger B."	0	0	87	87City & County of Honolulu	40-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	40-06	State Representative	40	D	"HAR, Sharon E."	0	0	180	180City & County of Honolulu	40-06	State Representative	40	R	"LEGAL,  Jack M."	0	0	114	114City & County of Honolulu	41-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	343	343City & County of Honolulu	41-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	41-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	41-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	41-01	Straight Party			REPUBLICAN PARTY (R)	0	0	82	82City & County of Honolulu	41-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	293	293City & County of Honolulu	41-01	US Representative	1	R	"TATAII, Steve"	0	0	54	54City & County of Honolulu	41-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2City & County of Honolulu	41-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	41-01	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	123	123City & County of Honolulu	41-01	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	185	185City & County of Honolulu	41-01	State Representative	41	R	"SANIATAN, Rito C."	0	0	62	62City & County of Honolulu	41-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	347	347City & County of Honolulu	41-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	41-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	41-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	41-02	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78City & County of Honolulu	41-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	289	289City & County of Honolulu	41-02	US Representative	1	R	"TATAII, Steve"	0	0	39	39City & County of Honolulu	41-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	41-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	41-02	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	119	119City & County of Honolulu	41-02	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	197	197City & County of Honolulu	41-02	State Representative	41	R	"SANIATAN, Rito C."	0	0	68	68City & County of Honolulu	41-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	538	538City & County of Honolulu	41-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	41-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	41-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	41-03	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40City & County of Honolulu	41-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	422	422City & County of Honolulu	41-03	US Representative	1	R	"TATAII, Steve"	0	0	17	17City & County of Honolulu	41-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	41-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	41-03	State Senate	18	D	"SONSON, Alex M."	0	0	237	237City & County of Honolulu	41-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	265	265City & County of Honolulu	41-03	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	242	242City & County of Honolulu	41-03	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	232	232City & County of Honolulu	41-03	State Representative	41	R	"SANIATAN, Rito C."	0	0	33	33City & County of Honolulu	41-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	66	66City & County of Honolulu	41-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	41-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	41-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	41-04	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22City & County of Honolulu	41-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	53	53City & County of Honolulu	41-04	US Representative	1	R	"TATAII, Steve"	0	0	11	11City & County of Honolulu	41-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	41-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	41-04	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	38	38City & County of Honolulu	41-04	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	17	17City & County of Honolulu	41-04	State Representative	41	R	"SANIATAN, Rito C."	0	0	20	20City & County of Honolulu	41-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	505	505City & County of Honolulu	41-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	41-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	41-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	41-05	Straight Party			REPUBLICAN PARTY (R)	0	0	131	131City & County of Honolulu	41-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	41-05	US Representative	2	D	"HIRONO, Mazie"	0	0	400	400City & County of Honolulu	41-05	US Representative	2	R	"EVANS, Roger B."	0	0	58	58City & County of Honolulu	41-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	41-05	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	255	255City & County of Honolulu	41-05	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	211	211City & County of Honolulu	41-05	State Representative	41	R	"SANIATAN, Rito C."	0	0	110	110City & County of Honolulu	41-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313City & County of Honolulu	41-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	41-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	41-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	41-06	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113City & County of Honolulu	41-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	41-06	US Representative	2	D	"HIRONO, Mazie"	0	0	249	249City & County of Honolulu	41-06	US Representative	2	R	"EVANS, Roger B."	0	0	52	52City & County of Honolulu	41-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	41-06	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	143	143City & County of Honolulu	41-06	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	133	133City & County of Honolulu	41-06	State Representative	41	R	"SANIATAN, Rito C."	0	0	90	90City & County of Honolulu	42-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	287	287City & County of Honolulu	42-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	42-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	42-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	42-01	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26City & County of Honolulu	42-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	234	234City & County of Honolulu	42-01	US Representative	1	R	"TATAII, Steve"	0	0	10	10City & County of Honolulu	42-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	42-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	42-01	State Senate	18	D	"SONSON, Alex M."	0	0	148	148City & County of Honolulu	42-01	State Senate	18	D	"NISHIHARA, Clarence"	0	0	125	125City & County of Honolulu	42-01	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	23	23City & County of Honolulu	42-01	State Representative	42	D	"SCHULTZ, Mike P."	0	0	81	81City & County of Honolulu	42-01	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	158	158City & County of Honolulu	42-01	State Representative	42	R	"BERG, Tom"	0	0	25	25City & County of Honolulu	42-01	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0City & County of Honolulu	42-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	107	107City & County of Honolulu	42-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	42-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	42-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	42-02	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31City & County of Honolulu	42-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	90	90City & County of Honolulu	42-02	US Representative	1	R	"TATAII, Steve"	0	0	20	20City & County of Honolulu	42-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	42-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	42-02	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	10	10City & County of Honolulu	42-02	State Representative	42	D	"SCHULTZ, Mike P."	0	0	24	24City & County of Honolulu	42-02	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	53	53City & County of Honolulu	42-02	State Representative	42	R	"BERG, Tom"	0	0	24	24City & County of Honolulu	42-02	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0City & County of Honolulu	42-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	220	220City & County of Honolulu	42-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	42-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	42-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	42-03	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28City & County of Honolulu	42-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	173	173City & County of Honolulu	42-03	US Representative	1	R	"TATAII, Steve"	0	0	18	18City & County of Honolulu	42-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	42-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	42-03	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	19	19City & County of Honolulu	42-03	State Representative	42	D	"SCHULTZ, Mike P."	0	0	97	97City & County of Honolulu	42-03	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	93	93City & County of Honolulu	42-03	State Representative	42	R	"BERG, Tom"	0	0	24	24City & County of Honolulu	42-03	State Representative	42	N	"BIMBO, Genaro Q."	0	0	1	1City & County of Honolulu	42-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	520	520City & County of Honolulu	42-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	42-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	42-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	42-04	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58City & County of Honolulu	42-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	421	421City & County of Honolulu	42-04	US Representative	1	R	"TATAII, Steve"	0	0	17	17City & County of Honolulu	42-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	42-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	42-04	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	22	22City & County of Honolulu	42-04	State Representative	42	D	"SCHULTZ, Mike P."	0	0	177	177City & County of Honolulu	42-04	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	293	293City & County of Honolulu	42-04	State Representative	42	R	"BERG, Tom"	0	0	55	55City & County of Honolulu	42-04	State Representative	42	N	"BIMBO, Genaro Q."	0	0	5	5City & County of Honolulu	42-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	403	403City & County of Honolulu	42-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	42-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	42-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	42-05	Straight Party			REPUBLICAN PARTY (R)	0	0	117	117City & County of Honolulu	42-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	342	342City & County of Honolulu	42-05	US Representative	1	R	"TATAII, Steve"	0	0	48	48City & County of Honolulu	42-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	42-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	42-05	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	18	18City & County of Honolulu	42-05	State Representative	42	D	"SCHULTZ, Mike P."	0	0	187	187City & County of Honolulu	42-05	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	155	155City & County of Honolulu	42-05	State Representative	42	R	"BERG, Tom"	0	0	108	108City & County of Honolulu	42-05	State Representative	42	N	"BIMBO, Genaro Q."	0	0	3	3City & County of Honolulu	43-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	219	219City & County of Honolulu	43-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	43-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	43-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	43-01	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107City & County of Honolulu	43-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	186	186City & County of Honolulu	43-01	US Representative	1	R	"TATAII, Steve"	0	0	30	30City & County of Honolulu	43-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	43-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	43-01	State Representative	43	D	"FEVELLA, Kurt"	0	0	83	83City & County of Honolulu	43-01	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	103	103City & County of Honolulu	43-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	411	411City & County of Honolulu	43-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	43-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	43-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	43-02	Straight Party			REPUBLICAN PARTY (R)	0	0	252	252City & County of Honolulu	43-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	361	361City & County of Honolulu	43-02	US Representative	1	R	"TATAII, Steve"	0	0	105	105City & County of Honolulu	43-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	43-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	43-02	State Representative	43	D	"FEVELLA, Kurt"	0	0	158	158City & County of Honolulu	43-02	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	236	236City & County of Honolulu	43-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	254	254City & County of Honolulu	43-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	43-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	43-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	43-03	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113City & County of Honolulu	43-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	206	206City & County of Honolulu	43-03	US Representative	1	R	"TATAII, Steve"	0	0	42	42City & County of Honolulu	43-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	43-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1City & County of Honolulu	43-03	State Representative	43	D	"FEVELLA, Kurt"	0	0	132	132City & County of Honolulu	43-03	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	104	104City & County of Honolulu	43-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	272	272City & County of Honolulu	43-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	43-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	43-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	43-04	Straight Party			REPUBLICAN PARTY (R)	0	0	160	160City & County of Honolulu	43-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	230	230City & County of Honolulu	43-04	US Representative	1	R	"TATAII, Steve"	0	0	56	56City & County of Honolulu	43-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0City & County of Honolulu	43-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	43-04	State Representative	43	D	"FEVELLA, Kurt"	0	0	146	146City & County of Honolulu	43-04	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	156	156City & County of Honolulu	43-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	354	354City & County of Honolulu	43-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	43-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	43-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	43-05	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136City & County of Honolulu	43-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	297	297City & County of Honolulu	43-05	US Representative	1	R	"TATAII, Steve"	0	0	49	49City & County of Honolulu	43-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	43-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0City & County of Honolulu	43-05	State Representative	43	D	"FEVELLA, Kurt"	0	0	150	150City & County of Honolulu	43-05	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	128	128City & County of Honolulu	43-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319City & County of Honolulu	43-06	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	43-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	43-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	43-06	Straight Party			REPUBLICAN PARTY (R)	0	0	209	209City & County of Honolulu	43-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	275	275City & County of Honolulu	43-06	US Representative	1	R	"TATAII, Steve"	0	0	59	59City & County of Honolulu	43-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1City & County of Honolulu	43-06	US Representative	1	L	"ZHAO, Li"	0	0	2	2City & County of Honolulu	43-06	State Representative	43	D	"FEVELLA, Kurt"	0	0	128	128City & County of Honolulu	43-06	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	198	198City & County of Honolulu	44-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	126	126City & County of Honolulu	44-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	44-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	44-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	44-01	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34City & County of Honolulu	44-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	44-01	US Representative	2	D	"HIRONO, Mazie"	0	0	108	108City & County of Honolulu	44-01	US Representative	2	R	"EVANS, Roger B."	0	0	31	31City & County of Honolulu	44-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	44-01	State Representative	44	D	"AWANA, Karen Leinani"	0	0	82	82City & County of Honolulu	44-01	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	35	35City & County of Honolulu	44-01	State Representative	44	R	"KU, Tercia L."	0	0	23	23City & County of Honolulu	44-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	603	603City & County of Honolulu	44-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	44-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	44-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	44-02	Straight Party			REPUBLICAN PARTY (R)	0	0	33	33City & County of Honolulu	44-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	44-02	US Representative	2	D	"HIRONO, Mazie"	0	0	355	355City & County of Honolulu	44-02	US Representative	2	R	"EVANS, Roger B."	0	0	13	13City & County of Honolulu	44-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	44-02	State Senate	21	D	"HANABUSA, Colleen"	0	0	430	430City & County of Honolulu	44-02	State Senate	21	R	"JOHNSON, Dickyj"	0	0	16	16City & County of Honolulu	44-02	State Representative	44	D	"AWANA, Karen Leinani"	0	0	242	242City & County of Honolulu	44-02	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	315	315City & County of Honolulu	44-02	State Representative	44	R	"KU, Tercia L."	0	0	21	21City & County of Honolulu	44-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421City & County of Honolulu	44-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	44-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	44-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	44-03	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57City & County of Honolulu	44-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	44-03	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300City & County of Honolulu	44-03	US Representative	2	R	"EVANS, Roger B."	0	0	35	35City & County of Honolulu	44-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	44-03	State Senate	21	D	"HANABUSA, Colleen"	0	0	295	295City & County of Honolulu	44-03	State Senate	21	R	"JOHNSON, Dickyj"	0	0	42	42City & County of Honolulu	44-03	State Representative	44	D	"AWANA, Karen Leinani"	0	0	172	172City & County of Honolulu	44-03	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	200	200City & County of Honolulu	44-03	State Representative	44	R	"KU, Tercia L."	0	0	38	38City & County of Honolulu	44-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	477	477City & County of Honolulu	44-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	44-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	44-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	44-04	Straight Party			REPUBLICAN PARTY (R)	0	0	90	90City & County of Honolulu	44-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	44-04	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300City & County of Honolulu	44-04	US Representative	2	R	"EVANS, Roger B."	0	0	57	57City & County of Honolulu	44-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	44-04	State Senate	21	D	"HANABUSA, Colleen"	0	0	341	341City & County of Honolulu	44-04	State Senate	21	R	"JOHNSON, Dickyj"	0	0	58	58City & County of Honolulu	44-04	State Representative	44	D	"AWANA, Karen Leinani"	0	0	232	232City & County of Honolulu	44-04	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	175	175City & County of Honolulu	44-04	State Representative	44	R	"KU, Tercia L."	0	0	64	64City & County of Honolulu	45-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	637	637City & County of Honolulu	45-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	45-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	45-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	45-01	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101City & County of Honolulu	45-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	45-01	US Representative	2	D	"HIRONO, Mazie"	0	0	433	433City & County of Honolulu	45-01	US Representative	2	R	"EVANS, Roger B."	0	0	53	53City & County of Honolulu	45-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	45-01	State Senate	21	D	"HANABUSA, Colleen"	0	0	497	497City & County of Honolulu	45-01	State Senate	21	R	"JOHNSON, Dickyj"	0	0	58	58City & County of Honolulu	45-01	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	471	471City & County of Honolulu	45-01	State Representative	45	D	"SAYLORS, Denise"	0	0	85	85City & County of Honolulu	45-01	State Representative	45	R	"GAPOL, Derek A."	0	0	72	72City & County of Honolulu	45-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	312	312City & County of Honolulu	45-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	45-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	45-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	45-02	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42City & County of Honolulu	45-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	45-02	US Representative	2	D	"HIRONO, Mazie"	0	0	221	221City & County of Honolulu	45-02	US Representative	2	R	"EVANS, Roger B."	0	0	21	21City & County of Honolulu	45-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	45-02	State Senate	21	D	"HANABUSA, Colleen"	0	0	237	237City & County of Honolulu	45-02	State Senate	21	R	"JOHNSON, Dickyj"	0	0	20	20City & County of Honolulu	45-02	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	213	213City & County of Honolulu	45-02	State Representative	45	D	"SAYLORS, Denise"	0	0	53	53City & County of Honolulu	45-02	State Representative	45	R	"GAPOL, Derek A."	0	0	28	28City & County of Honolulu	45-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	136	136City & County of Honolulu	45-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	45-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	45-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	45-03	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24City & County of Honolulu	45-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	45-03	US Representative	2	D	"HIRONO, Mazie"	0	0	88	88City & County of Honolulu	45-03	US Representative	2	R	"EVANS, Roger B."	0	0	11	11City & County of Honolulu	45-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	45-03	State Senate	21	D	"HANABUSA, Colleen"	0	0	98	98City & County of Honolulu	45-03	State Senate	21	R	"JOHNSON, Dickyj"	0	0	13	13City & County of Honolulu	45-03	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	96	96City & County of Honolulu	45-03	State Representative	45	D	"SAYLORS, Denise"	0	0	24	24City & County of Honolulu	45-03	State Representative	45	R	"GAPOL, Derek A."	0	0	13	13City & County of Honolulu	45-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	424	424City & County of Honolulu	45-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	45-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	45-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	45-04	Straight Party			REPUBLICAN PARTY (R)	0	0	91	91City & County of Honolulu	45-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	45-04	US Representative	2	D	"HIRONO, Mazie"	0	0	266	266City & County of Honolulu	45-04	US Representative	2	R	"EVANS, Roger B."	0	0	44	44City & County of Honolulu	45-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	45-04	State Senate	21	D	"HANABUSA, Colleen"	0	0	291	291City & County of Honolulu	45-04	State Senate	21	R	"JOHNSON, Dickyj"	0	0	56	56City & County of Honolulu	45-04	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	265	265City & County of Honolulu	45-04	State Representative	45	D	"SAYLORS, Denise"	0	0	110	110City & County of Honolulu	45-04	State Representative	45	R	"GAPOL, Derek A."	0	0	63	63City & County of Honolulu	46-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	225	225City & County of Honolulu	46-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	46-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	46-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	46-01	Straight Party			REPUBLICAN PARTY (R)	0	0	164	164City & County of Honolulu	46-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	46-01	US Representative	2	D	"HIRONO, Mazie"	0	0	152	152City & County of Honolulu	46-01	US Representative	2	R	"EVANS, Roger B."	0	0	106	106City & County of Honolulu	46-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	46-01	State Senate	23	D	"HEE, Clayton"	0	0	162	162City & County of Honolulu	46-01	State Senate	23	D	"MURAKI, Noel S."	0	0	35	35City & County of Honolulu	46-01	State Senate	23	R	"FALE, Richard"	0	0	117	117City & County of Honolulu	46-01	State Representative	46	D	"LUNASCO, Ollie"	0	0	6	6City & County of Honolulu	46-01	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	155	155City & County of Honolulu	46-01	State Representative	46	D	"WASSON, Dawn K."	0	0	50	50City & County of Honolulu	46-01	State Representative	46	R	"PHILIPS, Carol"	0	0	102	102City & County of Honolulu	46-01	State Representative	46	R	"RIVIERE, Gil"	0	0	49	49City & County of Honolulu	46-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	42	42City & County of Honolulu	46-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	46-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	46-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	46-02	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8City & County of Honolulu	46-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	46-02	US Representative	2	D	"HIRONO, Mazie"	0	0	33	33City & County of Honolulu	46-02	US Representative	2	R	"EVANS, Roger B."	0	0	5	5City & County of Honolulu	46-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	46-02	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	30	30City & County of Honolulu	46-02	State Representative	46	D	"LUNASCO, Ollie"	0	0	8	8City & County of Honolulu	46-02	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	28	28City & County of Honolulu	46-02	State Representative	46	D	"WASSON, Dawn K."	0	0	3	3City & County of Honolulu	46-02	State Representative	46	R	"PHILIPS, Carol"	0	0	6	6City & County of Honolulu	46-02	State Representative	46	R	"RIVIERE, Gil"	0	0	1	1City & County of Honolulu	46-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	481	481City & County of Honolulu	46-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	46-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	46-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	46-03	Straight Party			REPUBLICAN PARTY (R)	0	0	222	222City & County of Honolulu	46-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	46-03	US Representative	2	D	"HIRONO, Mazie"	0	0	346	346City & County of Honolulu	46-03	US Representative	2	R	"EVANS, Roger B."	0	0	79	79City & County of Honolulu	46-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	46-03	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	352	352City & County of Honolulu	46-03	State Representative	46	D	"LUNASCO, Ollie"	0	0	91	91City & County of Honolulu	46-03	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	328	328City & County of Honolulu	46-03	State Representative	46	D	"WASSON, Dawn K."	0	0	39	39City & County of Honolulu	46-03	State Representative	46	R	"PHILIPS, Carol"	0	0	100	100City & County of Honolulu	46-03	State Representative	46	R	"RIVIERE, Gil"	0	0	119	119City & County of Honolulu	46-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392City & County of Honolulu	46-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	46-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	46-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	46-04	Straight Party			REPUBLICAN PARTY (R)	0	0	208	208City & County of Honolulu	46-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	46-04	US Representative	2	D	"HIRONO, Mazie"	0	0	307	307City & County of Honolulu	46-04	US Representative	2	R	"EVANS, Roger B."	0	0	70	70City & County of Honolulu	46-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	46-04	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	289	289City & County of Honolulu	46-04	State Representative	46	D	"LUNASCO, Ollie"	0	0	57	57City & County of Honolulu	46-04	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	289	289City & County of Honolulu	46-04	State Representative	46	D	"WASSON, Dawn K."	0	0	25	25City & County of Honolulu	46-04	State Representative	46	R	"PHILIPS, Carol"	0	0	88	88City & County of Honolulu	46-04	State Representative	46	R	"RIVIERE, Gil"	0	0	117	117City & County of Honolulu	46-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	254	254City & County of Honolulu	46-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	46-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	46-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	46-05	Straight Party			REPUBLICAN PARTY (R)	0	0	295	295City & County of Honolulu	46-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	46-05	US Representative	2	D	"HIRONO, Mazie"	0	0	174	174City & County of Honolulu	46-05	US Representative	2	R	"EVANS, Roger B."	0	0	106	106City & County of Honolulu	46-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	46-05	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	154	154City & County of Honolulu	46-05	State Representative	46	D	"LUNASCO, Ollie"	0	0	31	31City & County of Honolulu	46-05	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	160	160City & County of Honolulu	46-05	State Representative	46	D	"WASSON, Dawn K."	0	0	35	35City & County of Honolulu	46-05	State Representative	46	R	"PHILIPS, Carol"	0	0	108	108City & County of Honolulu	46-05	State Representative	46	R	"RIVIERE, Gil"	0	0	186	186City & County of Honolulu	46-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	220	220City & County of Honolulu	46-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	46-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	46-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	46-06	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115City & County of Honolulu	46-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	46-06	US Representative	2	D	"HIRONO, Mazie"	0	0	177	177City & County of Honolulu	46-06	US Representative	2	R	"EVANS, Roger B."	0	0	51	51City & County of Honolulu	46-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	46-06	State Senate	23	D	"HEE, Clayton"	0	0	153	153City & County of Honolulu	46-06	State Senate	23	D	"MURAKI, Noel S."	0	0	29	29City & County of Honolulu	46-06	State Senate	23	R	"FALE, Richard"	0	0	66	66City & County of Honolulu	46-06	State Representative	46	D	"LUNASCO, Ollie"	0	0	26	26City & County of Honolulu	46-06	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	130	130City & County of Honolulu	46-06	State Representative	46	D	"WASSON, Dawn K."	0	0	51	51City & County of Honolulu	46-06	State Representative	46	R	"PHILIPS, Carol"	0	0	55	55City & County of Honolulu	46-06	State Representative	46	R	"RIVIERE, Gil"	0	0	50	50City & County of Honolulu	47-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	496	496City & County of Honolulu	47-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	47-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	47-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	47-01	Straight Party			REPUBLICAN PARTY (R)	0	0	258	258City & County of Honolulu	47-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	47-01	US Representative	2	D	"HIRONO, Mazie"	0	0	348	348City & County of Honolulu	47-01	US Representative	2	R	"EVANS, Roger B."	0	0	107	107City & County of Honolulu	47-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	47-01	State Senate	23	D	"HEE, Clayton"	0	0	309	309City & County of Honolulu	47-01	State Senate	23	D	"MURAKI, Noel S."	0	0	112	112City & County of Honolulu	47-01	State Senate	23	R	"FALE, Richard"	0	0	129	129City & County of Honolulu	47-01	State Representative	47	D	"PACHECO, Maria"	0	0	131	131City & County of Honolulu	47-01	State Representative	47	D	"WOOLEY, Jessica"	0	0	299	299City & County of Honolulu	47-01	State Representative	47	R	"MEYER, Colleen"	0	0	223	223City & County of Honolulu	47-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	383	383City & County of Honolulu	47-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	47-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	47-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	47-02	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113City & County of Honolulu	47-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	47-02	US Representative	2	D	"HIRONO, Mazie"	0	0	288	288City & County of Honolulu	47-02	US Representative	2	R	"EVANS, Roger B."	0	0	33	33City & County of Honolulu	47-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	47-02	State Senate	23	D	"HEE, Clayton"	0	0	253	253City & County of Honolulu	47-02	State Senate	23	D	"MURAKI, Noel S."	0	0	81	81City & County of Honolulu	47-02	State Senate	23	R	"FALE, Richard"	0	0	34	34City & County of Honolulu	47-02	State Representative	47	D	"PACHECO, Maria"	0	0	74	74City & County of Honolulu	47-02	State Representative	47	D	"WOOLEY, Jessica"	0	0	265	265City & County of Honolulu	47-02	State Representative	47	R	"MEYER, Colleen"	0	0	109	109City & County of Honolulu	47-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	387	387City & County of Honolulu	47-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	47-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	47-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	47-03	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136City & County of Honolulu	47-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	47-03	US Representative	2	D	"HIRONO, Mazie"	0	0	310	310City & County of Honolulu	47-03	US Representative	2	R	"EVANS, Roger B."	0	0	63	63City & County of Honolulu	47-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	47-03	State Senate	23	D	"HEE, Clayton"	0	0	255	255City & County of Honolulu	47-03	State Senate	23	D	"MURAKI, Noel S."	0	0	93	93City & County of Honolulu	47-03	State Senate	23	R	"FALE, Richard"	0	0	60	60City & County of Honolulu	47-03	State Representative	47	D	"PACHECO, Maria"	0	0	82	82City & County of Honolulu	47-03	State Representative	47	D	"WOOLEY, Jessica"	0	0	270	270City & County of Honolulu	47-03	State Representative	47	R	"MEYER, Colleen"	0	0	129	129City & County of Honolulu	47-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	147	147City & County of Honolulu	47-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	47-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	47-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	47-04	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36City & County of Honolulu	47-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0City & County of Honolulu	47-04	US Representative	2	D	"HIRONO, Mazie"	0	0	117	117City & County of Honolulu	47-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17City & County of Honolulu	47-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	47-04	State Senate	23	D	"HEE, Clayton"	0	0	93	93City & County of Honolulu	47-04	State Senate	23	D	"MURAKI, Noel S."	0	0	33	33City & County of Honolulu	47-04	State Senate	23	R	"FALE, Richard"	0	0	13	13City & County of Honolulu	47-04	State Representative	47	D	"PACHECO, Maria"	0	0	22	22City & County of Honolulu	47-04	State Representative	47	D	"WOOLEY, Jessica"	0	0	98	98City & County of Honolulu	47-04	State Representative	47	R	"MEYER, Colleen"	0	0	34	34City & County of Honolulu	47-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	87	87City & County of Honolulu	47-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	47-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	47-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	47-05	Straight Party			REPUBLICAN PARTY (R)	0	0	37	37City & County of Honolulu	47-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	47-05	US Representative	2	D	"HIRONO, Mazie"	0	0	73	73City & County of Honolulu	47-05	US Representative	2	R	"EVANS, Roger B."	0	0	19	19City & County of Honolulu	47-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	47-05	State Senate	23	D	"HEE, Clayton"	0	0	44	44City & County of Honolulu	47-05	State Senate	23	D	"MURAKI, Noel S."	0	0	35	35City & County of Honolulu	47-05	State Senate	23	R	"FALE, Richard"	0	0	20	20City & County of Honolulu	47-05	State Representative	47	D	"PACHECO, Maria"	0	0	20	20City & County of Honolulu	47-05	State Representative	47	D	"WOOLEY, Jessica"	0	0	55	55City & County of Honolulu	47-05	State Representative	47	R	"MEYER, Colleen"	0	0	35	35City & County of Honolulu	47-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	984	984City & County of Honolulu	47-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	47-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7City & County of Honolulu	47-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	47-06	Straight Party			REPUBLICAN PARTY (R)	0	0	240	240City & County of Honolulu	47-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7City & County of Honolulu	47-06	US Representative	2	D	"HIRONO, Mazie"	0	0	730	730City & County of Honolulu	47-06	US Representative	2	R	"EVANS, Roger B."	0	0	90	90City & County of Honolulu	47-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	7	7City & County of Honolulu	47-06	State Senate	23	D	"HEE, Clayton"	0	0	645	645City & County of Honolulu	47-06	State Senate	23	D	"MURAKI, Noel S."	0	0	220	220City & County of Honolulu	47-06	State Senate	23	R	"FALE, Richard"	0	0	85	85City & County of Honolulu	47-06	State Representative	47	D	"PACHECO, Maria"	0	0	160	160City & County of Honolulu	47-06	State Representative	47	D	"WOOLEY, Jessica"	0	0	683	683City & County of Honolulu	47-06	State Representative	47	R	"MEYER, Colleen"	0	0	231	231City & County of Honolulu	48-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	600	600City & County of Honolulu	48-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	48-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	48-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	48-01	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112City & County of Honolulu	48-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	48-01	US Representative	2	D	"HIRONO, Mazie"	0	0	481	481City & County of Honolulu	48-01	US Representative	2	R	"EVANS, Roger B."	0	0	85	85City & County of Honolulu	48-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	48-01	State Senate	23	D	"HEE, Clayton"	0	0	356	356City & County of Honolulu	48-01	State Senate	23	D	"MURAKI, Noel S."	0	0	150	150City & County of Honolulu	48-01	State Senate	23	R	"FALE, Richard"	0	0	75	75City & County of Honolulu	48-01	State Representative	48	D	"ITO, Ken"	0	0	452	452City & County of Honolulu	48-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	486	486City & County of Honolulu	48-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	48-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	48-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	48-02	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108City & County of Honolulu	48-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5City & County of Honolulu	48-02	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380City & County of Honolulu	48-02	US Representative	2	R	"EVANS, Roger B."	0	0	104	104City & County of Honolulu	48-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	48-02	State Representative	48	D	"ITO, Ken"	0	0	355	355City & County of Honolulu	48-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	642	642City & County of Honolulu	48-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	48-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	48-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11City & County of Honolulu	48-03	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115City & County of Honolulu	48-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7City & County of Honolulu	48-03	US Representative	2	D	"HIRONO, Mazie"	0	0	487	487City & County of Honolulu	48-03	US Representative	2	R	"EVANS, Roger B."	0	0	107	107City & County of Honolulu	48-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	48-03	State Representative	48	D	"ITO, Ken"	0	0	493	493City & County of Honolulu	48-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	833	833City & County of Honolulu	48-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9City & County of Honolulu	48-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	48-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	48-04	Straight Party			REPUBLICAN PARTY (R)	0	0	128	128City & County of Honolulu	48-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	9	9City & County of Honolulu	48-04	US Representative	2	D	"HIRONO, Mazie"	0	0	667	667City & County of Honolulu	48-04	US Representative	2	R	"EVANS, Roger B."	0	0	121	121City & County of Honolulu	48-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5City & County of Honolulu	48-04	State Representative	48	D	"ITO, Ken"	0	0	659	659City & County of Honolulu	48-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267City & County of Honolulu	48-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	48-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	48-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0City & County of Honolulu	48-05	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48City & County of Honolulu	48-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0City & County of Honolulu	48-05	US Representative	2	D	"HIRONO, Mazie"	0	0	205	205City & County of Honolulu	48-05	US Representative	2	R	"EVANS, Roger B."	0	0	41	41City & County of Honolulu	48-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	48-05	State Senate	23	D	"HEE, Clayton"	0	0	150	150City & County of Honolulu	48-05	State Senate	23	D	"MURAKI, Noel S."	0	0	82	82City & County of Honolulu	48-05	State Senate	23	R	"FALE, Richard"	0	0	35	35City & County of Honolulu	48-05	State Representative	48	D	"ITO, Ken"	0	0	204	204City & County of Honolulu	49-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	513	513City & County of Honolulu	49-01	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15City & County of Honolulu	49-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	49-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	49-01	Straight Party			REPUBLICAN PARTY (R)	0	0	192	192City & County of Honolulu	49-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11City & County of Honolulu	49-01	US Representative	2	D	"HIRONO, Mazie"	0	0	361	361City & County of Honolulu	49-01	US Representative	2	R	"EVANS, Roger B."	0	0	182	182City & County of Honolulu	49-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4City & County of Honolulu	49-01	State Representative	49	D	"CHONG, Pono"	0	0	343	343City & County of Honolulu	49-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	283	283City & County of Honolulu	49-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	49-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	49-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	49-02	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63City & County of Honolulu	49-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	49-02	US Representative	2	D	"HIRONO, Mazie"	0	0	226	226City & County of Honolulu	49-02	US Representative	2	R	"EVANS, Roger B."	0	0	57	57City & County of Honolulu	49-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	49-02	State Representative	49	D	"CHONG, Pono"	0	0	192	192City & County of Honolulu	49-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	578	578City & County of Honolulu	49-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	49-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	49-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	49-03	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154City & County of Honolulu	49-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6City & County of Honolulu	49-03	US Representative	2	D	"HIRONO, Mazie"	0	0	422	422City & County of Honolulu	49-03	US Representative	2	R	"EVANS, Roger B."	0	0	143	143City & County of Honolulu	49-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5City & County of Honolulu	49-03	State Representative	49	D	"CHONG, Pono"	0	0	410	410City & County of Honolulu	49-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	232	232City & County of Honolulu	49-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	49-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	49-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	49-04	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75City & County of Honolulu	49-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	49-04	US Representative	2	D	"HIRONO, Mazie"	0	0	175	175City & County of Honolulu	49-04	US Representative	2	R	"EVANS, Roger B."	0	0	74	74City & County of Honolulu	49-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	49-04	State Representative	49	D	"CHONG, Pono"	0	0	149	149City & County of Honolulu	49-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317City & County of Honolulu	49-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	49-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	49-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	49-05	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105City & County of Honolulu	49-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	49-05	US Representative	2	D	"HIRONO, Mazie"	0	0	235	235City & County of Honolulu	49-05	US Representative	2	R	"EVANS, Roger B."	0	0	103	103City & County of Honolulu	49-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4City & County of Honolulu	49-05	State Representative	49	D	"CHONG, Pono"	0	0	212	212City & County of Honolulu	49-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	417	417City & County of Honolulu	49-06	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11City & County of Honolulu	49-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	49-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	49-06	Straight Party			REPUBLICAN PARTY (R)	0	0	69	69City & County of Honolulu	49-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11City & County of Honolulu	49-06	US Representative	2	D	"HIRONO, Mazie"	0	0	338	338City & County of Honolulu	49-06	US Representative	2	R	"EVANS, Roger B."	0	0	69	69City & County of Honolulu	49-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	49-06	State Representative	49	D	"CHONG, Pono"	0	0	251	251City & County of Honolulu	49-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	575	575City & County of Honolulu	49-07	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8City & County of Honolulu	49-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	49-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4City & County of Honolulu	49-07	Straight Party			REPUBLICAN PARTY (R)	0	0	143	143City & County of Honolulu	49-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6City & County of Honolulu	49-07	US Representative	2	D	"HIRONO, Mazie"	0	0	463	463City & County of Honolulu	49-07	US Representative	2	R	"EVANS, Roger B."	0	0	117	117City & County of Honolulu	49-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4City & County of Honolulu	49-07	State Senate	23	D	"HEE, Clayton"	0	0	319	319City & County of Honolulu	49-07	State Senate	23	D	"MURAKI, Noel S."	0	0	154	154City & County of Honolulu	49-07	State Senate	23	R	"FALE, Richard"	0	0	87	87City & County of Honolulu	49-07	State Representative	49	D	"CHONG, Pono"	0	0	430	430City & County of Honolulu	50-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	275	275City & County of Honolulu	50-01	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14City & County of Honolulu	50-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	50-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6City & County of Honolulu	50-01	Straight Party			REPUBLICAN PARTY (R)	0	0	202	202City & County of Honolulu	50-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11City & County of Honolulu	50-01	US Representative	2	D	"HIRONO, Mazie"	0	0	253	253City & County of Honolulu	50-01	US Representative	2	R	"EVANS, Roger B."	0	0	58	58City & County of Honolulu	50-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	50-01	State Representative	50	R	"THIELEN, Cynthia"	0	0	184	184City & County of Honolulu	50-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311City & County of Honolulu	50-02	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15City & County of Honolulu	50-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	50-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	50-02	Straight Party			REPUBLICAN PARTY (R)	0	0	174	174City & County of Honolulu	50-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	15	15City & County of Honolulu	50-02	US Representative	2	D	"HIRONO, Mazie"	0	0	286	286City & County of Honolulu	50-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54City & County of Honolulu	50-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4City & County of Honolulu	50-02	State Representative	50	R	"THIELEN, Cynthia"	0	0	155	155City & County of Honolulu	50-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	214	214City & County of Honolulu	50-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	50-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	50-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	50-03	Straight Party			REPUBLICAN PARTY (R)	0	0	140	140City & County of Honolulu	50-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	50-03	US Representative	2	D	"HIRONO, Mazie"	0	0	201	201City & County of Honolulu	50-03	US Representative	2	R	"EVANS, Roger B."	0	0	39	39City & County of Honolulu	50-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	50-03	State Representative	50	R	"THIELEN, Cynthia"	0	0	121	121City & County of Honolulu	50-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319City & County of Honolulu	50-04	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10City & County of Honolulu	50-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	50-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7City & County of Honolulu	50-04	Straight Party			REPUBLICAN PARTY (R)	0	0	151	151City & County of Honolulu	50-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10City & County of Honolulu	50-04	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300City & County of Honolulu	50-04	US Representative	2	R	"EVANS, Roger B."	0	0	47	47City & County of Honolulu	50-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	50-04	State Representative	50	R	"THIELEN, Cynthia"	0	0	133	133City & County of Honolulu	50-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313City & County of Honolulu	50-05	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10City & County of Honolulu	50-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	50-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5City & County of Honolulu	50-05	Straight Party			REPUBLICAN PARTY (R)	0	0	270	270City & County of Honolulu	50-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8City & County of Honolulu	50-05	US Representative	2	D	"HIRONO, Mazie"	0	0	296	296City & County of Honolulu	50-05	US Representative	2	R	"EVANS, Roger B."	0	0	83	83City & County of Honolulu	50-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	50-05	State Representative	50	R	"THIELEN, Cynthia"	0	0	244	244City & County of Honolulu	50-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293City & County of Honolulu	50-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7City & County of Honolulu	50-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	50-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11City & County of Honolulu	50-06	Straight Party			REPUBLICAN PARTY (R)	0	0	282	282City & County of Honolulu	50-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7City & County of Honolulu	50-06	US Representative	2	D	"HIRONO, Mazie"	0	0	265	265City & County of Honolulu	50-06	US Representative	2	R	"EVANS, Roger B."	0	0	76	76City & County of Honolulu	50-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	50-06	State Representative	50	R	"THIELEN, Cynthia"	0	0	248	248City & County of Honolulu	50-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	117	117City & County of Honolulu	50-07	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5City & County of Honolulu	50-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2City & County of Honolulu	50-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	50-07	Straight Party			REPUBLICAN PARTY (R)	0	0	137	137City & County of Honolulu	50-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5City & County of Honolulu	50-07	US Representative	2	D	"HIRONO, Mazie"	0	0	106	106City & County of Honolulu	50-07	US Representative	2	R	"EVANS, Roger B."	0	0	42	42City & County of Honolulu	50-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2City & County of Honolulu	50-07	State Representative	50	R	"THIELEN, Cynthia"	0	0	129	129City & County of Honolulu	51-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	327	327City & County of Honolulu	51-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6City & County of Honolulu	51-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4City & County of Honolulu	51-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	51-01	Straight Party			REPUBLICAN PARTY (R)	0	0	161	161City & County of Honolulu	51-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6City & County of Honolulu	51-01	US Representative	2	D	"HIRONO, Mazie"	0	0	195	195City & County of Honolulu	51-01	US Representative	2	R	"EVANS, Roger B."	0	0	65	65City & County of Honolulu	51-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	51-01	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	82	82City & County of Honolulu	51-01	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	12	12City & County of Honolulu	51-01	State Representative	51	D	"LEE, Chris Kalani"	0	0	210	210City & County of Honolulu	51-01	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	149	149City & County of Honolulu	51-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	567	567City & County of Honolulu	51-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	51-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5City & County of Honolulu	51-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	51-02	Straight Party			REPUBLICAN PARTY (R)	0	0	92	92City & County of Honolulu	51-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	51-02	US Representative	2	D	"HIRONO, Mazie"	0	0	381	381City & County of Honolulu	51-02	US Representative	2	R	"EVANS, Roger B."	0	0	42	42City & County of Honolulu	51-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5City & County of Honolulu	51-02	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	304	304City & County of Honolulu	51-02	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	12	12City & County of Honolulu	51-02	State Representative	51	D	"LEE, Chris Kalani"	0	0	225	225City & County of Honolulu	51-02	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	85	85City & County of Honolulu	51-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	663	663City & County of Honolulu	51-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1City & County of Honolulu	51-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	51-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1City & County of Honolulu	51-03	Straight Party			REPUBLICAN PARTY (R)	0	0	82	82City & County of Honolulu	51-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1City & County of Honolulu	51-03	US Representative	2	D	"HIRONO, Mazie"	0	0	423	423City & County of Honolulu	51-03	US Representative	2	R	"EVANS, Roger B."	0	0	27	27City & County of Honolulu	51-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	51-03	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	340	340City & County of Honolulu	51-03	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	21	21City & County of Honolulu	51-03	State Representative	51	D	"LEE, Chris Kalani"	0	0	285	285City & County of Honolulu	51-03	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	78	78City & County of Honolulu	51-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	132	132City & County of Honolulu	51-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2City & County of Honolulu	51-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0City & County of Honolulu	51-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	51-04	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34City & County of Honolulu	51-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2City & County of Honolulu	51-04	US Representative	2	D	"HIRONO, Mazie"	0	0	102	102City & County of Honolulu	51-04	US Representative	2	R	"EVANS, Roger B."	0	0	13	13City & County of Honolulu	51-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0City & County of Honolulu	51-04	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	35	35City & County of Honolulu	51-04	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	7	7City & County of Honolulu	51-04	State Representative	51	D	"LEE, Chris Kalani"	0	0	87	87City & County of Honolulu	51-04	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	32	32City & County of Honolulu	51-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	706	706City & County of Honolulu	51-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4City & County of Honolulu	51-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	51-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	51-05	Straight Party			REPUBLICAN PARTY (R)	0	0	176	176City & County of Honolulu	51-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4City & County of Honolulu	51-05	US Representative	2	D	"HIRONO, Mazie"	0	0	467	467City & County of Honolulu	51-05	US Representative	2	R	"EVANS, Roger B."	0	0	62	62City & County of Honolulu	51-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	51-05	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	241	241City & County of Honolulu	51-05	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	21	21City & County of Honolulu	51-05	State Representative	51	D	"LEE, Chris Kalani"	0	0	414	414City & County of Honolulu	51-05	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	170	170City & County of Honolulu	51-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	360	360City & County of Honolulu	51-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3City & County of Honolulu	51-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3City & County of Honolulu	51-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2City & County of Honolulu	51-06	Straight Party			REPUBLICAN PARTY (R)	0	0	137	137City & County of Honolulu	51-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3City & County of Honolulu	51-06	US Representative	2	D	"HIRONO, Mazie"	0	0	224	224City & County of Honolulu	51-06	US Representative	2	R	"EVANS, Roger B."	0	0	60	60City & County of Honolulu	51-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3City & County of Honolulu	51-06	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	85	85City & County of Honolulu	51-06	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	26	26City & County of Honolulu	51-06	State Representative	51	D	"LEE, Chris Kalani"	0	0	229	229City & County of Honolulu	51-06	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	129	129City & County of Honolulu	51-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	162	162City & County of Honolulu	51-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0City & County of Honolulu	51-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1City & County of Honolulu	51-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3City & County of Honolulu	51-07	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83City & County of Honolulu	51-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0City & County of Honolulu	51-07	US Representative	2	D	"HIRONO, Mazie"	0	0	106	106City & County of Honolulu	51-07	US Representative	2	R	"EVANS, Roger B."	0	0	34	34City & County of Honolulu	51-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1City & County of Honolulu	51-07	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	29	29City & County of Honolulu	51-07	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	6	6City & County of Honolulu	51-07	State Representative	51	D	"LEE, Chris Kalani"	0	0	109	109City & County of Honolulu	51-07	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	69	69	AB-01	Straight Party			DEMOCRATIC PARTY (D)	174	312	0	486	AB-01	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1	AB-01	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2	AB-01	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7	AB-01	Straight Party			REPUBLICAN PARTY (R)	27	27	0	54	AB-01	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1	AB-01	US Representative	2	D	"HIRONO, Mazie"	146	242	0	388	AB-01	US Representative	2	R	"EVANS, Roger B."	22	17	0	39	AB-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2	AB-01	State Senate	3	D	"ISBELL, Virginia"	30	31	0	61	AB-01	State Senate	3	D	"GREEN, Josh"	137	264	0	401	AB-01	State Representative	1	D	"FUJIYAMA, Ken"	12	49	0	61	AB-01	State Representative	1	D	"KIM, Jo"	44	70	0	114	AB-01	State Representative	1	D	"NAKASHIMA, Mark M."	84	146	0	230	AB-01	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	16	11	0	27	AB-01	State Representative	1	R	"OFFENBAKER, Steven A."	14	11	0	25	AB-01	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	8	8	0	16	AB-02	Straight Party			DEMOCRATIC PARTY (D)	721	460	0	1181	AB-02	Straight Party			INDEPENDENT PARTY (I)	2	2	0	4	AB-02	Straight Party			LIBERTARIAN PARTY (L)	2	1	0	3	AB-02	Straight Party			NONPARTISAN BALLOT (N)	1	5	0	6	AB-02	Straight Party			REPUBLICAN PARTY (R)	75	67	0	142	AB-02	US Representative	2	I	"STENSHOL, Shaun"	2	2	0	4	AB-02	US Representative	2	D	"HIRONO, Mazie"	574	360	0	934	AB-02	US Representative	2	R	"EVANS, Roger B."	45	44	0	89	AB-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2	AB-02	State Senate	1	D	"TAKAMINE, Dwight Y."	627	380	0	1007	AB-02	State Senate	1	R	"HONG, Ted H.S."	58	62	0	120	AB-02	State Representative	1	D	"FUJIYAMA, Ken"	75	59	0	134	AB-02	State Representative	1	D	"KIM, Jo"	144	115	0	259	AB-02	State Representative	1	D	"NAKASHIMA, Mark M."	437	230	0	667	AB-02	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	16	17	0	33	AB-02	State Representative	1	R	"OFFENBAKER, Steven A."	37	41	0	78	AB-02	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	15	10	0	25	AB-03	Straight Party			DEMOCRATIC PARTY (D)	23	34	0	57	AB-03	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1	AB-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-03	Straight Party			REPUBLICAN PARTY (R)	12	10	0	22	AB-03	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1	AB-03	US Representative	2	D	"HIRONO, Mazie"	20	25	0	45	AB-03	US Representative	2	R	"EVANS, Roger B."	8	9	0	17	AB-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-03	State Senate	1	D	"TAKAMINE, Dwight Y."	17	23	0	40	AB-03	State Senate	1	R	"HONG, Ted H.S."	10	9	0	19	AB-03	State Representative	1	D	"FUJIYAMA, Ken"	3	7	0	10	AB-03	State Representative	1	D	"KIM, Jo"	3	12	0	15	AB-03	State Representative	1	D	"NAKASHIMA, Mark M."	10	8	0	18	AB-03	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	1	0	0	1	AB-03	State Representative	1	R	"OFFENBAKER, Steven A."	6	6	0	12	AB-03	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	5	1	0	6	AB-04	Straight Party			DEMOCRATIC PARTY (D)	726	830	0	1556	AB-04	Straight Party			INDEPENDENT PARTY (I)	5	7	0	12	AB-04	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3	AB-04	Straight Party			NONPARTISAN BALLOT (N)	7	9	0	16	AB-04	Straight Party			REPUBLICAN PARTY (R)	145	126	0	271	AB-04	US Representative	2	I	"STENSHOL, Shaun"	3	6	0	9	AB-04	US Representative	2	D	"HIRONO, Mazie"	575	593	0	1168	AB-04	US Representative	2	R	"EVANS, Roger B."	86	57	0	143	AB-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2	AB-04	State Senate	1	D	"TAKAMINE, Dwight Y."	568	596	0	1164	AB-04	State Senate	1	R	"HONG, Ted H.S."	132	118	0	250	AB-04	State Representative	2	D	"CHANG, Jerry Leslie"	554	603	0	1157	AB-05	Straight Party			DEMOCRATIC PARTY (D)	283	349	0	632	AB-05	Straight Party			INDEPENDENT PARTY (I)	1	6	0	7	AB-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-05	Straight Party			NONPARTISAN BALLOT (N)	3	3	0	6	AB-05	Straight Party			REPUBLICAN PARTY (R)	39	52	0	91	AB-05	US Representative	2	I	"STENSHOL, Shaun"	1	4	0	5	AB-05	US Representative	2	D	"HIRONO, Mazie"	243	252	0	495	AB-05	US Representative	2	R	"EVANS, Roger B."	17	32	0	49	AB-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-05	State Senate	1	D	"TAKAMINE, Dwight Y."	215	248	0	463	AB-05	State Senate	1	R	"HONG, Ted H.S."	36	48	0	84	AB-05	State Representative	2	D	"CHANG, Jerry Leslie"	215	248	0	463	AB-06	Straight Party			DEMOCRATIC PARTY (D)	854	874	0	1728	AB-06	Straight Party			INDEPENDENT PARTY (I)	5	3	0	8	AB-06	Straight Party			LIBERTARIAN PARTY (L)	3	2	0	5	AB-06	Straight Party			NONPARTISAN BALLOT (N)	5	8	0	13	AB-06	Straight Party			REPUBLICAN PARTY (R)	74	67	0	141	AB-06	US Representative	2	I	"STENSHOL, Shaun"	5	2	0	7	AB-06	US Representative	2	D	"HIRONO, Mazie"	725	710	0	1435	AB-06	US Representative	2	R	"EVANS, Roger B."	53	48	0	101	AB-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	2	0	5	AB-06	State Representative	3	D	"TSUJI, Clifton (Clift)"	713	737	0	1450	AB-06	State Representative	3	R	"TAVARES, Deirdre (Moana)"	54	45	0	99	AB-07	Straight Party			DEMOCRATIC PARTY (D)	67	68	0	135	AB-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-07	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-07	Straight Party			REPUBLICAN PARTY (R)	6	3	0	9	AB-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0	AB-07	US Representative	2	D	"HIRONO, Mazie"	59	57	0	116	AB-07	US Representative	2	R	"EVANS, Roger B."	4	2	0	6	AB-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1	AB-07	State Representative	3	D	"TSUJI, Clifton (Clift)"	55	61	0	116	AB-07	State Representative	3	R	"TAVARES, Deirdre (Moana)"	5	3	0	8	AB-08	Straight Party			DEMOCRATIC PARTY (D)	61	69	0	130	AB-08	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-08	Straight Party			REPUBLICAN PARTY (R)	2	12	0	14	AB-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0	AB-08	US Representative	2	D	"HIRONO, Mazie"	52	56	0	108	AB-08	US Representative	2	R	"EVANS, Roger B."	1	7	0	8	AB-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-08	State Senate	1	D	"TAKAMINE, Dwight Y."	51	47	0	98	AB-08	State Senate	1	R	"HONG, Ted H.S."	2	7	0	9	AB-08	State Representative	3	D	"TSUJI, Clifton (Clift)"	51	57	0	108	AB-08	State Representative	3	R	"TAVARES, Deirdre (Moana)"	1	5	0	6	AB-09	Straight Party			DEMOCRATIC PARTY (D)	273	361	0	634	AB-09	Straight Party			INDEPENDENT PARTY (I)	1	3	0	4	AB-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-09	Straight Party			NONPARTISAN BALLOT (N)	1	6	0	7	AB-09	Straight Party			REPUBLICAN PARTY (R)	38	32	0	70	AB-09	US Representative	2	I	"STENSHOL, Shaun"	1	3	0	4	AB-09	US Representative	2	D	"HIRONO, Mazie"	226	282	0	508	AB-09	US Representative	2	R	"EVANS, Roger B."	21	16	0	37	AB-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-09	State Senate	1	D	"TAKAMINE, Dwight Y."	219	276	0	495	AB-09	State Senate	1	R	"HONG, Ted H.S."	33	26	0	59	AB-09	State Representative	3	D	"TSUJI, Clifton (Clift)"	214	283	0	497	AB-09	State Representative	3	R	"TAVARES, Deirdre (Moana)"	15	14	0	29	AB-10	Straight Party			DEMOCRATIC PARTY (D)	180	225	0	405	AB-10	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2	AB-10	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-10	Straight Party			NONPARTISAN BALLOT (N)	0	4	0	4	AB-10	Straight Party			REPUBLICAN PARTY (R)	15	12	0	27	AB-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0	AB-10	US Representative	2	D	"HIRONO, Mazie"	152	180	0	332	AB-10	US Representative	2	R	"EVANS, Roger B."	11	7	0	18	AB-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1	AB-10	State Representative	3	D	"TSUJI, Clifton (Clift)"	156	170	0	326	AB-10	State Representative	3	R	"TAVARES, Deirdre (Moana)"	7	6	0	13	AB-11	Straight Party			DEMOCRATIC PARTY (D)	59	89	0	148	AB-11	Straight Party			INDEPENDENT PARTY (I)	1	3	0	4	AB-11	Straight Party			LIBERTARIAN PARTY (L)	0	1	0	1	AB-11	Straight Party			NONPARTISAN BALLOT (N)	6	4	0	10	AB-11	Straight Party			REPUBLICAN PARTY (R)	10	17	0	27	AB-11	US Representative	2	I	"STENSHOL, Shaun"	1	3	0	4	AB-11	US Representative	2	D	"HIRONO, Mazie"	47	78	0	125	AB-11	US Representative	2	R	"EVANS, Roger B."	8	10	0	18	AB-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1	AB-11	State Representative	4	D	"HANOHANO, Faye P."	28	37	0	65	AB-11	State Representative	4	D	"MARZI, Anthony (Tony)"	10	17	0	27	AB-11	State Representative	4	D	"SPARKS, Steven B."	7	27	0	34	AB-11	State Representative	4	R	"BLAS, Fred"	9	12	0	21	AB-12	Straight Party			DEMOCRATIC PARTY (D)	73	73	0	146	AB-12	Straight Party			INDEPENDENT PARTY (I)	1	2	0	3	AB-12	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-12	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-12	Straight Party			REPUBLICAN PARTY (R)	15	13	0	28	AB-12	US Representative	2	I	"STENSHOL, Shaun"	1	2	0	3	AB-12	US Representative	2	D	"HIRONO, Mazie"	60	59	0	119	AB-12	US Representative	2	R	"EVANS, Roger B."	13	9	0	22	AB-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1	AB-12	State Representative	4	D	"HANOHANO, Faye P."	30	41	0	71	AB-12	State Representative	4	D	"MARZI, Anthony (Tony)"	13	14	0	27	AB-12	State Representative	4	D	"SPARKS, Steven B."	19	5	0	24	AB-12	State Representative	4	R	"BLAS, Fred"	14	11	0	25	AB-13	Straight Party			DEMOCRATIC PARTY (D)	472	637	0	1109	AB-13	Straight Party			INDEPENDENT PARTY (I)	8	11	0	19	AB-13	Straight Party			LIBERTARIAN PARTY (L)	1	2	0	3	AB-13	Straight Party			NONPARTISAN BALLOT (N)	6	12	0	18	AB-13	Straight Party			REPUBLICAN PARTY (R)	125	145	0	270	AB-13	US Representative	2	I	"STENSHOL, Shaun"	8	9	0	17	AB-13	US Representative	2	D	"HIRONO, Mazie"	356	460	0	816	AB-13	US Representative	2	R	"EVANS, Roger B."	84	78	0	162	AB-13	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	2	0	3	AB-13	State Representative	4	D	"HANOHANO, Faye P."	226	278	0	504	AB-13	State Representative	4	D	"MARZI, Anthony (Tony)"	140	211	0	351	AB-13	State Representative	4	D	"SPARKS, Steven B."	60	100	0	160	AB-13	State Representative	4	R	"BLAS, Fred"	93	114	0	207	AB-14	Straight Party			DEMOCRATIC PARTY (D)	31	27	0	58	AB-14	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-14	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-14	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-14	Straight Party			REPUBLICAN PARTY (R)	7	8	0	15	AB-14	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0	AB-14	US Representative	2	D	"HIRONO, Mazie"	26	23	0	49	AB-14	US Representative	2	R	"EVANS, Roger B."	7	7	0	14	AB-14	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-14	State Representative	5	D	"HERKES, Robert (Bob)"	24	19	0	43	AB-15	Straight Party			DEMOCRATIC PARTY (D)	337	439	0	776	AB-15	Straight Party			INDEPENDENT PARTY (I)	13	11	0	24	AB-15	Straight Party			LIBERTARIAN PARTY (L)	6	3	0	9	AB-15	Straight Party			NONPARTISAN BALLOT (N)	7	12	0	19	AB-15	Straight Party			REPUBLICAN PARTY (R)	37	71	0	108	AB-15	US Representative	2	I	"STENSHOL, Shaun"	11	9	0	20	AB-15	US Representative	2	D	"HIRONO, Mazie"	280	356	0	636	AB-15	US Representative	2	R	"EVANS, Roger B."	34	65	0	99	AB-15	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	6	3	0	9	AB-15	State Representative	5	D	"HERKES, Robert (Bob)"	233	287	0	520	AB-16	Straight Party			DEMOCRATIC PARTY (D)	110	64	0	174	AB-16	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-16	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-16	Straight Party			NONPARTISAN BALLOT (N)	7	0	0	7	AB-16	Straight Party			REPUBLICAN PARTY (R)	12	1	0	13	AB-16	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0	AB-16	US Representative	2	D	"HIRONO, Mazie"	82	49	0	131	AB-16	US Representative	2	R	"EVANS, Roger B."	11	1	0	12	AB-16	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-16	State Senate	3	D	"ISBELL, Virginia"	29	19	0	48	AB-16	State Senate	3	D	"GREEN, Josh"	78	43	0	121	AB-16	State Representative	5	D	"HERKES, Robert (Bob)"	73	41	0	114	AB-17	Straight Party			DEMOCRATIC PARTY (D)	256	203	0	459	AB-17	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7	AB-17	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-17	Straight Party			NONPARTISAN BALLOT (N)	2	2	0	4	AB-17	Straight Party			REPUBLICAN PARTY (R)	23	27	0	50	AB-17	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5	AB-17	US Representative	2	D	"HIRONO, Mazie"	201	156	0	357	AB-17	US Representative	2	R	"EVANS, Roger B."	21	23	0	44	AB-17	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-17	State Senate	3	D	"ISBELL, Virginia"	89	63	0	152	AB-17	State Senate	3	D	"GREEN, Josh"	153	129	0	282	AB-17	State Representative	5	D	"HERKES, Robert (Bob)"	174	134	0	308	AB-18	Straight Party			DEMOCRATIC PARTY (D)	274	471	0	745	AB-18	Straight Party			INDEPENDENT PARTY (I)	3	4	0	7	AB-18	Straight Party			LIBERTARIAN PARTY (L)	0	2	0	2	AB-18	Straight Party			NONPARTISAN BALLOT (N)	4	10	0	14	AB-18	Straight Party			REPUBLICAN PARTY (R)	107	122	0	229	AB-18	US Representative	2	I	"STENSHOL, Shaun"	2	3	0	5	AB-18	US Representative	2	D	"HIRONO, Mazie"	189	345	0	534	AB-18	US Representative	2	R	"EVANS, Roger B."	74	70	0	144	AB-18	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	2	0	2	AB-18	State Senate	3	D	"ISBELL, Virginia"	46	49	0	95	AB-18	State Senate	3	D	"GREEN, Josh"	220	408	0	628	AB-18	State Representative	6	D	"COFFMAN, Denny"	102	232	0	334	AB-18	State Representative	6	D	"LESLIE, Gene (Bucky)"	80	108	0	188	AB-18	State Representative	6	D	"MACGREGOR, Maegan"	37	63	0	100	AB-18	State Representative	6	R	"SMITH, Andy"	100	108	0	208	AB-19	Straight Party			DEMOCRATIC PARTY (D)	215	351	0	566	AB-19	Straight Party			INDEPENDENT PARTY (I)	0	2	0	2	AB-19	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2	AB-19	Straight Party			NONPARTISAN BALLOT (N)	0	9	0	9	AB-19	Straight Party			REPUBLICAN PARTY (R)	81	91	0	172	AB-19	US Representative	2	I	"STENSHOL, Shaun"	0	2	0	2	AB-19	US Representative	2	D	"HIRONO, Mazie"	150	267	0	417	AB-19	US Representative	2	R	"EVANS, Roger B."	54	61	0	115	AB-19	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2	AB-19	State Senate	3	D	"ISBELL, Virginia"	48	63	0	111	AB-19	State Senate	3	D	"GREEN, Josh"	161	276	0	437	AB-19	State Representative	6	D	"COFFMAN, Denny"	69	153	0	222	AB-19	State Representative	6	D	"LESLIE, Gene (Bucky)"	40	95	0	135	AB-19	State Representative	6	D	"MACGREGOR, Maegan"	45	52	0	97	AB-19	State Representative	6	R	"SMITH, Andy"	74	81	0	155	AB-20	Straight Party			DEMOCRATIC PARTY (D)	183	307	0	490	AB-20	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2	AB-20	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2	AB-20	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7	AB-20	Straight Party			REPUBLICAN PARTY (R)	50	56	0	106	AB-20	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2	AB-20	US Representative	2	D	"HIRONO, Mazie"	121	222	0	343	AB-20	US Representative	2	R	"EVANS, Roger B."	48	43	0	91	AB-20	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2	AB-20	State Senate	3	D	"ISBELL, Virginia"	34	62	0	96	AB-20	State Senate	3	D	"GREEN, Josh"	136	234	0	370	AB-20	State Representative	7	D	"EVANS, Cindy"	117	238	0	355	AB-20	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	27	24	0	51	AB-20	State Representative	7	R	"KAILIMAI, B.J."	10	21	0	31	AB-21	Straight Party			DEMOCRATIC PARTY (D)	107	90	0	197	AB-21	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2	AB-21	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4	AB-21	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3	AB-21	Straight Party			REPUBLICAN PARTY (R)	35	24	0	59	AB-21	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2	AB-21	US Representative	2	D	"HIRONO, Mazie"	75	73	0	148	AB-21	US Representative	2	R	"EVANS, Roger B."	32	19	0	51	AB-21	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	1	0	4	AB-21	State Senate	3	D	"ISBELL, Virginia"	22	27	0	49	AB-21	State Senate	3	D	"GREEN, Josh"	74	60	0	134	AB-21	State Representative	7	D	"EVANS, Cindy"	89	78	0	167	AB-21	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	22	13	0	35	AB-21	State Representative	7	R	"KAILIMAI, B.J."	5	9	0	14	AB-22	Straight Party			DEMOCRATIC PARTY (D)	125	452	0	577	AB-22	Straight Party			INDEPENDENT PARTY (I)	4	1	0	5	AB-22	Straight Party			LIBERTARIAN PARTY (L)	0	2	0	2	AB-22	Straight Party			NONPARTISAN BALLOT (N)	1	2	0	3	AB-22	Straight Party			REPUBLICAN PARTY (R)	37	131	0	168	AB-22	US Representative	2	I	"STENSHOL, Shaun"	4	0	0	4	AB-22	US Representative	2	D	"HIRONO, Mazie"	98	331	0	429	AB-22	US Representative	2	R	"EVANS, Roger B."	23	86	0	109	AB-22	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	2	0	2	AB-22	State Senate	1	D	"TAKAMINE, Dwight Y."	103	345	0	448	AB-22	State Senate	1	R	"HONG, Ted H.S."	33	104	0	137	AB-22	State Representative	7	D	"EVANS, Cindy"	95	322	0	417	AB-22	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	17	63	0	80	AB-22	State Representative	7	R	"KAILIMAI, B.J."	11	51	0	62	AB-23	Straight Party			DEMOCRATIC PARTY (D)	33	85	0	118	AB-23	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-23	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-23	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-23	Straight Party			REPUBLICAN PARTY (R)	18	19	0	37	AB-23	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0	AB-23	US Representative	2	D	"HIRONO, Mazie"	24	61	0	85	AB-23	US Representative	2	R	"EVANS, Roger B."	10	12	0	22	AB-23	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-23	State Senate	1	D	"TAKAMINE, Dwight Y."	28	64	0	92	AB-23	State Senate	1	R	"HONG, Ted H.S."	13	11	0	24	AB-23	State Representative	7	D	"EVANS, Cindy"	22	61	0	83	AB-23	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	5	12	0	17	AB-23	State Representative	7	R	"KAILIMAI, B.J."	7	3	0	10	AB-24	Straight Party			DEMOCRATIC PARTY (D)	1077	560	0	1637	AB-24	Straight Party			INDEPENDENT PARTY (I)	7	9	0	16	AB-24	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4	AB-24	Straight Party			NONPARTISAN BALLOT (N)	6	3	0	9	AB-24	Straight Party			REPUBLICAN PARTY (R)	82	62	0	144	AB-24	US Representative	2	I	"STENSHOL, Shaun"	7	8	0	15	AB-24	US Representative	2	D	"HIRONO, Mazie"	888	470	0	1358	AB-24	US Representative	2	R	"EVANS, Roger B."	75	56	0	131	AB-24	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	1	0	4	AB-24	State Representative	8	D	"KAMA, Tasha"	360	200	0	560	AB-24	State Representative	8	D	"SOUKI, Joe"	648	331	0	979	AB-25	Straight Party			DEMOCRATIC PARTY (D)	1034	367	0	1401	AB-25	Straight Party			INDEPENDENT PARTY (I)	6	2	0	8	AB-25	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3	AB-25	Straight Party			NONPARTISAN BALLOT (N)	4	1	0	5	AB-25	Straight Party			REPUBLICAN PARTY (R)	84	47	0	131	AB-25	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5	AB-25	US Representative	2	D	"HIRONO, Mazie"	925	318	0	1243	AB-25	US Representative	2	R	"EVANS, Roger B."	57	31	0	88	AB-25	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3	AB-25	State Representative	9	D	"NAKASONE, Bob"	799	288	0	1087	AB-25	State Representative	9	R	"KAHULA, Henry P., Jr."	55	36	0	91	AB-26	Straight Party			DEMOCRATIC PARTY (D)	332	234	0	566	AB-26	Straight Party			INDEPENDENT PARTY (I)	9	4	0	13	AB-26	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2	AB-26	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6	AB-26	Straight Party			REPUBLICAN PARTY (R)	104	63	0	167	AB-26	US Representative	2	I	"STENSHOL, Shaun"	7	3	0	10	AB-26	US Representative	2	D	"HIRONO, Mazie"	272	167	0	439	AB-26	US Representative	2	R	"EVANS, Roger B."	50	42	0	92	AB-26	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1	AB-26	State Senate	5	D	"BAKER, Roz"	253	157	0	410	AB-26	State Senate	5	D	"MULVIHILL, Bart"	63	63	0	126	AB-26	State Senate	5	R	"SHIELDS, Jan"	93	56	0	149	AB-26	State Representative	10	D	"MCKELVEY, Angus"	260	194	0	454	AB-26	State Representative	10	R	"MADDEN, Ramon K."	51	45	0	96	AB-27	Straight Party			DEMOCRATIC PARTY (D)	366	159	0	525	AB-27	Straight Party			INDEPENDENT PARTY (I)	11	2	0	13	AB-27	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-27	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-27	Straight Party			REPUBLICAN PARTY (R)	214	56	0	270	AB-27	US Representative	2	I	"STENSHOL, Shaun"	8	1	0	9	AB-27	US Representative	2	D	"HIRONO, Mazie"	287	113	0	400	AB-27	US Representative	2	R	"EVANS, Roger B."	134	24	0	158	AB-27	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1	AB-27	State Senate	5	D	"BAKER, Roz"	218	93	0	311	AB-27	State Senate	5	D	"MULVIHILL, Bart"	110	53	0	163	AB-27	State Senate	5	R	"SHIELDS, Jan"	183	44	0	227	AB-27	State Representative	11	D	"GINGERICH, Michael"	97	46	0	143	AB-27	State Representative	11	D	"BERTRAM, Joe, III"	234	100	0	334	AB-27	State Representative	11	R	"FONTAINE, George R."	164	33	0	197	AB-28	Straight Party			DEMOCRATIC PARTY (D)	1051	381	0	1432	AB-28	Straight Party			INDEPENDENT PARTY (I)	9	5	0	14	AB-28	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-28	Straight Party			NONPARTISAN BALLOT (N)	7	1	0	8	AB-28	Straight Party			REPUBLICAN PARTY (R)	150	37	0	187	AB-28	US Representative	2	I	"STENSHOL, Shaun"	3	3	0	6	AB-28	US Representative	2	D	"HIRONO, Mazie"	820	292	0	1112	AB-28	US Representative	2	R	"EVANS, Roger B."	79	15	0	94	AB-28	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-28	State Senate	6	I	"BLUMER-BUELL, John"	6	2	0	8	AB-28	State Senate	6	D	"ENGLISH, J. Kalani"	755	272	0	1027	AB-28	State Representative	12	D	"YAMASHITA, Kyle"	770	250	0	1020	AB-28	State Representative	12	D	"STARR, Summer"	235	118	0	353	AB-28	State Representative	12	R	"VIERRA, Mickey"	127	25	0	152	AB-29	Straight Party			DEMOCRATIC PARTY (D)	488	438	0	926	AB-29	Straight Party			INDEPENDENT PARTY (I)	23	10	0	33	AB-29	Straight Party			LIBERTARIAN PARTY (L)	0	1	0	1	AB-29	Straight Party			NONPARTISAN BALLOT (N)	9	4	0	13	AB-29	Straight Party			REPUBLICAN PARTY (R)	65	60	0	125	AB-29	US Representative	2	I	"STENSHOL, Shaun"	9	5	0	14	AB-29	US Representative	2	D	"HIRONO, Mazie"	379	340	0	719	AB-29	US Representative	2	R	"EVANS, Roger B."	57	57	0	114	AB-29	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1	AB-29	State Senate	6	I	"BLUMER-BUELL, John"	20	9	0	29	AB-29	State Senate	6	D	"ENGLISH, J. Kalani"	340	333	0	673	AB-29	State Representative	13	D	"CARROLL, Mele"	352	334	0	686	AB-30	Straight Party			DEMOCRATIC PARTY (D)	13	0	0	13	AB-30	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2	AB-30	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-30	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-30	Straight Party			REPUBLICAN PARTY (R)	3	0	0	3	AB-30	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2	AB-30	US Representative	2	D	"HIRONO, Mazie"	11	0	0	11	AB-30	US Representative	2	R	"EVANS, Roger B."	3	0	0	3	AB-30	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-30	State Senate	6	I	"BLUMER-BUELL, John"	2	0	0	2	AB-30	State Senate	6	D	"ENGLISH, J. Kalani"	9	0	0	9	AB-30	State Representative	13	D	"CARROLL, Mele"	8	0	0	8	AB-31	Straight Party			DEMOCRATIC PARTY (D)	1291	610	0	1901	AB-31	Straight Party			INDEPENDENT PARTY (I)	15	4	0	19	AB-31	Straight Party			LIBERTARIAN PARTY (L)	8	1	0	9	AB-31	Straight Party			NONPARTISAN BALLOT (N)	20	6	0	26	AB-31	Straight Party			REPUBLICAN PARTY (R)	212	86	0	298	AB-31	US Representative	2	I	"STENSHOL, Shaun"	11	2	0	13	AB-31	US Representative	2	D	"HIRONO, Mazie"	942	408	0	1350	AB-31	US Representative	2	R	"EVANS, Roger B."	146	51	0	197	AB-31	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	8	1	0	9	AB-31	State Senate	7	D	"HOOSER, Gary L."	901	424	0	1325	AB-31	State Senate	7	R	"GEORGI, JoAnne S."	171	63	0	234	AB-31	State Representative	14	D	"MORITA, Hermina (Mina)"	838	368	0	1206	AB-32	Straight Party			DEMOCRATIC PARTY (D)	1692	1167	0	2859	AB-32	Straight Party			INDEPENDENT PARTY (I)	13	12	0	25	AB-32	Straight Party			LIBERTARIAN PARTY (L)	7	6	0	13	AB-32	Straight Party			NONPARTISAN BALLOT (N)	25	13	0	38	AB-32	Straight Party			REPUBLICAN PARTY (R)	260	133	0	393	AB-32	US Representative	2	I	"STENSHOL, Shaun"	10	4	0	14	AB-32	US Representative	2	D	"HIRONO, Mazie"	1260	826	0	2086	AB-32	US Representative	2	R	"EVANS, Roger B."	178	64	0	242	AB-32	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	7	6	0	13	AB-32	State Senate	7	D	"HOOSER, Gary L."	1146	784	0	1930	AB-32	State Senate	7	R	"GEORGI, JoAnne S."	210	85	0	295	AB-32	State Representative	15	D	"TOKIOKA, James Kunane"	1083	737	0	1820	AB-33	Straight Party			DEMOCRATIC PARTY (D)	1327	583	0	1910	AB-33	Straight Party			INDEPENDENT PARTY (I)	14	8	0	22	AB-33	Straight Party			LIBERTARIAN PARTY (L)	2	3	0	5	AB-33	Straight Party			NONPARTISAN BALLOT (N)	16	5	0	21	AB-33	Straight Party			REPUBLICAN PARTY (R)	178	84	0	262	AB-33	US Representative	2	I	"STENSHOL, Shaun"	9	5	0	14	AB-33	US Representative	2	D	"HIRONO, Mazie"	954	400	0	1354	AB-33	US Representative	2	R	"EVANS, Roger B."	124	35	0	159	AB-33	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	3	0	5	AB-33	State Senate	7	D	"HOOSER, Gary L."	826	362	0	1188	AB-33	State Senate	7	R	"GEORGI, JoAnne S."	138	59	0	197	AB-33	State Representative	16	D	"SAGUM, Roland D., III"	778	351	0	1129	AB-34	Straight Party			DEMOCRATIC PARTY (D)	1624	305	0	1929	AB-34	Straight Party			INDEPENDENT PARTY (I)	20	4	0	24	AB-34	Straight Party			LIBERTARIAN PARTY (L)	9	1	0	10	AB-34	Straight Party			NONPARTISAN BALLOT (N)	21	4	0	25	AB-34	Straight Party			REPUBLICAN PARTY (R)	787	99	0	886	AB-34	US Representative	1	D	"ABERCROMBIE, Neil"	1304	246	0	1550	AB-34	US Representative	1	R	"TATAII, Steve"	318	49	0	367	AB-34	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	1	0	4	AB-34	US Representative	1	L	"ZHAO, Li"	6	0	0	6	AB-34	State Representative	17	D	"MONK, Amy Yukiko"	1030	223	0	1253	AB-34	State Representative	17	R	"WARD, Gene"	754	97	0	851	AB-35	Straight Party			DEMOCRATIC PARTY (D)	1606	289	0	1895	AB-35	Straight Party			INDEPENDENT PARTY (I)	21	5	0	26	AB-35	Straight Party			LIBERTARIAN PARTY (L)	13	1	0	14	AB-35	Straight Party			NONPARTISAN BALLOT (N)	30	3	0	33	AB-35	Straight Party			REPUBLICAN PARTY (R)	422	61	0	483	AB-35	US Representative	1	D	"ABERCROMBIE, Neil"	1239	227	0	1466	AB-35	US Representative	1	R	"TATAII, Steve"	370	55	0	425	AB-35	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4	AB-35	US Representative	1	L	"ZHAO, Li"	9	1	0	10	AB-35	State Representative	18	D	"BERG, Lyla B."	1137	212	0	1349	AB-36	Straight Party			DEMOCRATIC PARTY (D)	1357	257	0	1614	AB-36	Straight Party			INDEPENDENT PARTY (I)	7	0	0	7	AB-36	Straight Party			LIBERTARIAN PARTY (L)	8	3	0	11	AB-36	Straight Party			NONPARTISAN BALLOT (N)	18	2	0	20	AB-36	Straight Party			REPUBLICAN PARTY (R)	664	76	0	740	AB-36	US Representative	1	D	"ABERCROMBIE, Neil"	1095	212	0	1307	AB-36	US Representative	1	R	"TATAII, Steve"	226	24	0	250	AB-36	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	2	0	4	AB-36	US Representative	1	L	"ZHAO, Li"	5	1	0	6	AB-36	State Representative	19	D	"ABE, Michael (Mike)"	836	155	0	991	AB-36	State Representative	19	R	"MARUMOTO, Barbara C."	638	68	0	706	AB-37	Straight Party			DEMOCRATIC PARTY (D)	163	19	0	182	AB-37	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-37	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-37	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-37	Straight Party			REPUBLICAN PARTY (R)	51	10	0	61	AB-37	US Representative	1	D	"ABERCROMBIE, Neil"	128	16	0	144	AB-37	US Representative	1	R	"TATAII, Steve"	15	4	0	19	AB-37	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-37	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-37	State Representative	19	D	"ABE, Michael (Mike)"	105	11	0	116	AB-37	State Representative	19	R	"MARUMOTO, Barbara C."	49	8	0	57	AB-38	Straight Party			DEMOCRATIC PARTY (D)	1112	218	0	1330	AB-38	Straight Party			INDEPENDENT PARTY (I)	4	0	0	4	AB-38	Straight Party			LIBERTARIAN PARTY (L)	6	1	0	7	AB-38	Straight Party			NONPARTISAN BALLOT (N)	12	2	0	14	AB-38	Straight Party			REPUBLICAN PARTY (R)	148	30	0	178	AB-38	US Representative	1	D	"ABERCROMBIE, Neil"	901	169	0	1070	AB-38	US Representative	1	R	"TATAII, Steve"	103	25	0	128	AB-38	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	1	0	3	AB-38	US Representative	1	L	"ZHAO, Li"	4	0	0	4	AB-38	State Representative	20	D	"SAY, Calvin K. Y."	976	189	0	1165	AB-38	State Representative	20	R	"ALLEN, Julia E."	131	26	0	157	AB-39	Straight Party			DEMOCRATIC PARTY (D)	420	79	0	499	AB-39	Straight Party			INDEPENDENT PARTY (I)	2	2	0	4	AB-39	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5	AB-39	Straight Party			NONPARTISAN BALLOT (N)	3	3	0	6	AB-39	Straight Party			REPUBLICAN PARTY (R)	89	20	0	109	AB-39	US Representative	1	D	"ABERCROMBIE, Neil"	345	65	0	410	AB-39	US Representative	1	R	"TATAII, Steve"	53	14	0	67	AB-39	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3	AB-39	US Representative	1	L	"ZHAO, Li"	0	1	0	1	AB-39	State Representative	20	D	"SAY, Calvin K. Y."	315	64	0	379	AB-39	State Representative	20	R	"ALLEN, Julia E."	76	17	0	93	AB-40	Straight Party			DEMOCRATIC PARTY (D)	936	202	0	1138	AB-40	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7	AB-40	Straight Party			LIBERTARIAN PARTY (L)	8	1	0	9	AB-40	Straight Party			NONPARTISAN BALLOT (N)	8	1	0	9	AB-40	Straight Party			REPUBLICAN PARTY (R)	125	30	0	155	AB-40	US Representative	1	D	"ABERCROMBIE, Neil"	735	160	0	895	AB-40	US Representative	1	R	"TATAII, Steve"	113	28	0	141	AB-40	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3	AB-40	US Representative	1	L	"ZHAO, Li"	5	1	0	6	AB-40	State Representative	21	D	"NISHIMOTO, Scott Y."	773	168	0	941	AB-41	Straight Party			DEMOCRATIC PARTY (D)	98	17	0	115	AB-41	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2	AB-41	Straight Party			LIBERTARIAN PARTY (L)	6	1	0	7	AB-41	Straight Party			NONPARTISAN BALLOT (N)	2	1	0	3	AB-41	Straight Party			REPUBLICAN PARTY (R)	60	5	0	65	AB-41	US Representative	1	D	"ABERCROMBIE, Neil"	69	14	0	83	AB-41	US Representative	1	R	"TATAII, Steve"	55	5	0	60	AB-41	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	0	0	6	AB-41	US Representative	1	L	"ZHAO, Li"	0	1	0	1	AB-41	State Representative	21	D	"NISHIMOTO, Scott Y."	64	13	0	77	AB-42	Straight Party			DEMOCRATIC PARTY (D)	128	36	0	164	AB-42	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4	AB-42	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4	AB-42	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3	AB-42	Straight Party			REPUBLICAN PARTY (R)	62	15	0	77	AB-42	US Representative	1	D	"ABERCROMBIE, Neil"	113	32	0	145	AB-42	US Representative	1	R	"TATAII, Steve"	43	13	0	56	AB-42	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-42	US Representative	1	L	"ZHAO, Li"	3	0	0	3	AB-42	State Senate	12	D	"GALUTERIA, Brickwood M."	76	16	0	92	AB-42	State Senate	12	D	"MIDDLETON, Carlton N."	30	14	0	44	AB-42	State Senate	12	R	"TRIMBLE, Gordon"	58	13	0	71	AB-42	State Representative	21	D	"NISHIMOTO, Scott Y."	103	32	0	135	AB-43	Straight Party			DEMOCRATIC PARTY (D)	1042	239	0	1281	AB-43	Straight Party			INDEPENDENT PARTY (I)	11	4	0	15	AB-43	Straight Party			LIBERTARIAN PARTY (L)	11	0	0	11	AB-43	Straight Party			NONPARTISAN BALLOT (N)	12	2	0	14	AB-43	Straight Party			REPUBLICAN PARTY (R)	189	30	0	219	AB-43	US Representative	1	D	"ABERCROMBIE, Neil"	861	185	0	1046	AB-43	US Representative	1	R	"TATAII, Steve"	171	24	0	195	AB-43	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4	AB-43	US Representative	1	L	"ZHAO, Li"	6	0	0	6	AB-43	State Representative	22	D	"SAIKI, Scott K."	787	173	0	960	AB-44	Straight Party			DEMOCRATIC PARTY (D)	909	300	0	1209	AB-44	Straight Party			INDEPENDENT PARTY (I)	29	1	0	30	AB-44	Straight Party			LIBERTARIAN PARTY (L)	17	1	0	18	AB-44	Straight Party			NONPARTISAN BALLOT (N)	22	3	0	25	AB-44	Straight Party			REPUBLICAN PARTY (R)	467	107	0	574	AB-44	US Representative	1	D	"ABERCROMBIE, Neil"	792	245	0	1037	AB-44	US Representative	1	R	"TATAII, Steve"	299	57	0	356	AB-44	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	1	0	7	AB-44	US Representative	1	L	"ZHAO, Li"	9	0	0	9	AB-44	State Senate	12	D	"GALUTERIA, Brickwood M."	490	184	0	674	AB-44	State Senate	12	D	"MIDDLETON, Carlton N."	194	51	0	245	AB-44	State Senate	12	R	"TRIMBLE, Gordon"	373	86	0	459	AB-44	State Representative	23	D	"BROWER, Tom"	635	198	0	833	AB-44	State Representative	23	R	"STEVENS, Anne V."	389	81	0	470	AB-45	Straight Party			DEMOCRATIC PARTY (D)	1705	375	0	2080	AB-45	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13	AB-45	Straight Party			LIBERTARIAN PARTY (L)	16	2	0	18	AB-45	Straight Party			NONPARTISAN BALLOT (N)	23	5	0	28	AB-45	Straight Party			REPUBLICAN PARTY (R)	333	65	0	398	AB-45	US Representative	1	D	"ABERCROMBIE, Neil"	1430	312	0	1742	AB-45	US Representative	1	R	"TATAII, Steve"	202	30	0	232	AB-45	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	0	0	6	AB-45	US Representative	1	L	"ZHAO, Li"	10	2	0	12	AB-45	State Representative	24	D	"CHOY, Isaac W."	950	256	0	1206	AB-45	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	270	52	0	322	AB-46	Straight Party			DEMOCRATIC PARTY (D)	808	230	0	1038	AB-46	Straight Party			INDEPENDENT PARTY (I)	11	3	0	14	AB-46	Straight Party			LIBERTARIAN PARTY (L)	16	5	0	21	AB-46	Straight Party			NONPARTISAN BALLOT (N)	9	3	0	12	AB-46	Straight Party			REPUBLICAN PARTY (R)	163	52	0	215	AB-46	US Representative	1	D	"ABERCROMBIE, Neil"	648	181	0	829	AB-46	US Representative	1	R	"TATAII, Steve"	151	43	0	194	AB-46	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	9	4	0	13	AB-46	US Representative	1	L	"ZHAO, Li"	7	1	0	8	AB-46	State Representative	25	D	"BELATTI, Della A."	553	152	0	705	AB-47	Straight Party			DEMOCRATIC PARTY (D)	593	120	0	713	AB-47	Straight Party			INDEPENDENT PARTY (I)	8	2	0	10	AB-47	Straight Party			LIBERTARIAN PARTY (L)	6	4	0	10	AB-47	Straight Party			NONPARTISAN BALLOT (N)	9	0	0	9	AB-47	Straight Party			REPUBLICAN PARTY (R)	105	21	0	126	AB-47	US Representative	1	D	"ABERCROMBIE, Neil"	485	98	0	583	AB-47	US Representative	1	R	"TATAII, Steve"	95	18	0	113	AB-47	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	3	0	5	AB-47	US Representative	1	L	"ZHAO, Li"	4	1	0	5	AB-47	State Representative	25	D	"BELATTI, Della A."	346	77	0	423	AB-48	Straight Party			DEMOCRATIC PARTY (D)	1546	434	0	1980	AB-48	Straight Party			INDEPENDENT PARTY (I)	21	8	0	29	AB-48	Straight Party			LIBERTARIAN PARTY (L)	17	6	0	23	AB-48	Straight Party			NONPARTISAN BALLOT (N)	19	7	0	26	AB-48	Straight Party			REPUBLICAN PARTY (R)	275	67	0	342	AB-48	US Representative	1	D	"ABERCROMBIE, Neil"	1259	355	0	1614	AB-48	US Representative	1	R	"TATAII, Steve"	248	55	0	303	AB-48	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	10	1	0	11	AB-48	US Representative	1	L	"ZHAO, Li"	7	4	0	11	AB-48	State Representative	26	D	"LUKE, Sylvia"	1140	341	0	1481	AB-49	Straight Party			DEMOCRATIC PARTY (D)	1059	238	0	1297	AB-49	Straight Party			INDEPENDENT PARTY (I)	2	1	0	3	AB-49	Straight Party			LIBERTARIAN PARTY (L)	5	0	0	5	AB-49	Straight Party			NONPARTISAN BALLOT (N)	13	4	0	17	AB-49	Straight Party			REPUBLICAN PARTY (R)	313	65	0	378	AB-49	US Representative	1	D	"ABERCROMBIE, Neil"	904	195	0	1099	AB-49	US Representative	1	R	"TATAII, Steve"	128	33	0	161	AB-49	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3	AB-49	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-49	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	577	140	0	717	AB-49	State Representative	27	R	"CHING, Corinne Wei Lan"	296	58	0	354	AB-50	Straight Party			DEMOCRATIC PARTY (D)	68	15	0	83	AB-50	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1	AB-50	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-50	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-50	Straight Party			REPUBLICAN PARTY (R)	31	4	0	35	AB-50	US Representative	1	D	"ABERCROMBIE, Neil"	57	12	0	69	AB-50	US Representative	1	R	"TATAII, Steve"	18	1	0	19	AB-50	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-50	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-50	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	35	8	0	43	AB-50	State Representative	27	R	"CHING, Corinne Wei Lan"	29	4	0	33	AB-51	Straight Party			DEMOCRATIC PARTY (D)	133	41	0	174	AB-51	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-51	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-51	Straight Party			NONPARTISAN BALLOT (N)	0	1	0	1	AB-51	Straight Party			REPUBLICAN PARTY (R)	18	6	0	24	AB-51	US Representative	1	D	"ABERCROMBIE, Neil"	101	38	0	139	AB-51	US Representative	1	R	"TATAII, Steve"	9	5	0	14	AB-51	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-51	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-51	State Representative	28	D	"RHOADS, Karl"	89	20	0	109	AB-52	Straight Party			DEMOCRATIC PARTY (D)	158	33	0	191	AB-52	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4	AB-52	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-52	Straight Party			NONPARTISAN BALLOT (N)	3	5	0	8	AB-52	Straight Party			REPUBLICAN PARTY (R)	18	5	0	23	AB-52	US Representative	1	D	"ABERCROMBIE, Neil"	134	27	0	161	AB-52	US Representative	1	R	"TATAII, Steve"	15	5	0	20	AB-52	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-52	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-52	State Representative	28	D	"RHOADS, Karl"	90	20	0	110	AB-53	Straight Party			DEMOCRATIC PARTY (D)	545	207	0	752	AB-53	Straight Party			INDEPENDENT PARTY (I)	8	1	0	9	AB-53	Straight Party			LIBERTARIAN PARTY (L)	10	0	0	10	AB-53	Straight Party			NONPARTISAN BALLOT (N)	11	4	0	15	AB-53	Straight Party			REPUBLICAN PARTY (R)	163	59	0	222	AB-53	US Representative	1	D	"ABERCROMBIE, Neil"	446	166	0	612	AB-53	US Representative	1	R	"TATAII, Steve"	112	36	0	148	AB-53	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3	AB-53	US Representative	1	L	"ZHAO, Li"	7	0	0	7	AB-53	State Senate	12	D	"GALUTERIA, Brickwood M."	302	133	0	435	AB-53	State Senate	12	D	"MIDDLETON, Carlton N."	116	32	0	148	AB-53	State Senate	12	R	"TRIMBLE, Gordon"	150	55	0	205	AB-53	State Representative	28	D	"RHOADS, Karl"	403	160	0	563	AB-54	Straight Party			DEMOCRATIC PARTY (D)	177	40	0	217	AB-54	Straight Party			INDEPENDENT PARTY (I)	0	2	0	2	AB-54	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-54	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-54	Straight Party			REPUBLICAN PARTY (R)	38	11	0	49	AB-54	US Representative	1	D	"ABERCROMBIE, Neil"	152	34	0	186	AB-54	US Representative	1	R	"TATAII, Steve"	28	4	0	32	AB-54	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-54	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-54	State Senate	12	D	"GALUTERIA, Brickwood M."	121	22	0	143	AB-54	State Senate	12	D	"MIDDLETON, Carlton N."	34	9	0	43	AB-54	State Senate	12	R	"TRIMBLE, Gordon"	33	10	0	43	AB-54	State Representative	28	D	"RHOADS, Karl"	143	33	0	176	AB-55	Straight Party			DEMOCRATIC PARTY (D)	714	126	0	840	AB-55	Straight Party			INDEPENDENT PARTY (I)	2	3	0	5	AB-55	Straight Party			LIBERTARIAN PARTY (L)	6	0	0	6	AB-55	Straight Party			NONPARTISAN BALLOT (N)	6	0	0	6	AB-55	Straight Party			REPUBLICAN PARTY (R)	100	23	0	123	AB-55	US Representative	1	D	"ABERCROMBIE, Neil"	603	106	0	709	AB-55	US Representative	1	R	"TATAII, Steve"	71	17	0	88	AB-55	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-55	US Representative	1	L	"ZHAO, Li"	5	0	0	5	AB-55	State Representative	29	D	"MANAHAN, Joey"	558	84	0	642	AB-55	State Representative	29	R	"YAW, Shane D. K."	81	16	0	97	AB-56	Straight Party			DEMOCRATIC PARTY (D)	567	122	0	689	AB-56	Straight Party			INDEPENDENT PARTY (I)	7	1	0	8	AB-56	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5	AB-56	Straight Party			NONPARTISAN BALLOT (N)	6	1	0	7	AB-56	Straight Party			REPUBLICAN PARTY (R)	74	18	0	92	AB-56	US Representative	1	D	"ABERCROMBIE, Neil"	476	102	0	578	AB-56	US Representative	1	R	"TATAII, Steve"	61	17	0	78	AB-56	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-56	US Representative	1	L	"ZHAO, Li"	4	1	0	5	AB-56	State Representative	30	D	"MIZUNO, John"	460	87	0	547	AB-57	Straight Party			DEMOCRATIC PARTY (D)	257	47	0	304	AB-57	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1	AB-57	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-57	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2	AB-57	Straight Party			REPUBLICAN PARTY (R)	17	8	0	25	AB-57	US Representative	1	D	"ABERCROMBIE, Neil"	235	35	0	270	AB-57	US Representative	1	R	"TATAII, Steve"	12	5	0	17	AB-57	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-57	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-57	State Representative	30	D	"MIZUNO, John"	203	39	0	242	AB-58	Straight Party			DEMOCRATIC PARTY (D)	295	71	0	366	AB-58	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-58	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-58	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2	AB-58	Straight Party			REPUBLICAN PARTY (R)	22	10	0	32	AB-58	US Representative	1	D	"ABERCROMBIE, Neil"	241	59	0	300	AB-58	US Representative	1	R	"TATAII, Steve"	18	6	0	24	AB-58	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-58	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-58	State Representative	31	D	"WAKAI, Glenn"	260	59	0	319	AB-59	Straight Party			DEMOCRATIC PARTY (D)	982	213	0	1195	AB-59	Straight Party			INDEPENDENT PARTY (I)	9	2	0	11	AB-59	Straight Party			LIBERTARIAN PARTY (L)	14	1	0	15	AB-59	Straight Party			NONPARTISAN BALLOT (N)	13	2	0	15	AB-59	Straight Party			REPUBLICAN PARTY (R)	186	31	0	217	AB-59	US Representative	1	D	"ABERCROMBIE, Neil"	807	168	0	975	AB-59	US Representative	1	R	"TATAII, Steve"	176	23	0	199	AB-59	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	1	0	7	AB-59	US Representative	1	L	"ZHAO, Li"	8	0	0	8	AB-59	State Representative	31	D	"WAKAI, Glenn"	792	159	0	951	AB-60	Straight Party			DEMOCRATIC PARTY (D)	418	114	0	532	AB-60	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4	AB-60	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4	AB-60	Straight Party			NONPARTISAN BALLOT (N)	6	0	0	6	AB-60	Straight Party			REPUBLICAN PARTY (R)	124	28	0	152	AB-60	US Representative	1	D	"ABERCROMBIE, Neil"	387	102	0	489	AB-60	US Representative	1	R	"TATAII, Steve"	55	12	0	67	AB-60	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	1	0	2	AB-60	US Representative	1	L	"ZHAO, Li"	2	0	0	2	AB-60	State Representative	32	R	"FINNEGAN, Lynn"	115	24	0	139	AB-61	Straight Party			DEMOCRATIC PARTY (D)	327	93	0	420	AB-61	Straight Party			INDEPENDENT PARTY (I)	6	2	0	8	AB-61	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3	AB-61	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3	AB-61	Straight Party			REPUBLICAN PARTY (R)	204	20	0	224	AB-61	US Representative	1	D	"ABERCROMBIE, Neil"	302	86	0	388	AB-61	US Representative	1	R	"TATAII, Steve"	101	4	0	105	AB-61	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-61	US Representative	1	L	"ZHAO, Li"	2	0	0	2	AB-61	State Representative	32	R	"FINNEGAN, Lynn"	197	19	0	216	AB-62	Straight Party			DEMOCRATIC PARTY (D)	437	161	0	598	AB-62	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4	AB-62	Straight Party			LIBERTARIAN PARTY (L)	5	2	0	7	AB-62	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6	AB-62	Straight Party			REPUBLICAN PARTY (R)	62	19	0	81	AB-62	US Representative	1	D	"ABERCROMBIE, Neil"	364	130	0	494	AB-62	US Representative	1	R	"TATAII, Steve"	51	13	0	64	AB-62	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	0	0	2	AB-62	US Representative	1	L	"ZHAO, Li"	3	1	0	4	AB-62	State Representative	33	D	"OSHIRO, Blake K."	333	119	0	452	AB-63	Straight Party			DEMOCRATIC PARTY (D)	927	385	0	1312	AB-63	Straight Party			INDEPENDENT PARTY (I)	7	4	0	11	AB-63	Straight Party			LIBERTARIAN PARTY (L)	10	1	0	11	AB-63	Straight Party			NONPARTISAN BALLOT (N)	10	2	0	12	AB-63	Straight Party			REPUBLICAN PARTY (R)	162	53	0	215	AB-63	US Representative	1	D	"ABERCROMBIE, Neil"	750	309	0	1059	AB-63	US Representative	1	R	"TATAII, Steve"	155	36	0	191	AB-63	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	0	0	2	AB-63	US Representative	1	L	"ZHAO, Li"	8	0	0	8	AB-63	State Senate	16	D	"IGE, David Y."	593	265	0	858	AB-63	State Representative	33	D	"OSHIRO, Blake K."	655	297	0	952	AB-64	Straight Party			DEMOCRATIC PARTY (D)	1681	458	0	2139	AB-64	Straight Party			INDEPENDENT PARTY (I)	8	2	0	10	AB-64	Straight Party			LIBERTARIAN PARTY (L)	10	1	0	11	AB-64	Straight Party			NONPARTISAN BALLOT (N)	15	1	0	16	AB-64	Straight Party			REPUBLICAN PARTY (R)	205	44	0	249	AB-64	US Representative	1	D	"ABERCROMBIE, Neil"	1354	372	0	1726	AB-64	US Representative	1	R	"TATAII, Steve"	182	37	0	219	AB-64	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	7	0	0	7	AB-64	US Representative	1	L	"ZHAO, Li"	3	1	0	4	AB-64	State Senate	16	D	"IGE, David Y."	1236	349	0	1585	AB-64	State Representative	34	D	"TAKAI, K. Mark"	1376	374	0	1750	AB-65	Straight Party			DEMOCRATIC PARTY (D)	78	10	0	88	AB-65	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1	AB-65	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-65	Straight Party			NONPARTISAN BALLOT (N)	1	1	0	2	AB-65	Straight Party			REPUBLICAN PARTY (R)	13	1	0	14	AB-65	US Representative	1	D	"ABERCROMBIE, Neil"	63	9	0	72	AB-65	US Representative	1	R	"TATAII, Steve"	13	0	0	13	AB-65	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-65	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-65	State Senate	18	D	"SONSON, Alex M."	37	5	0	42	AB-65	State Senate	18	D	"NISHIHARA, Clarence"	34	4	0	38	AB-65	State Representative	34	D	"TAKAI, K. Mark"	63	7	0	70	AB-66	Straight Party			DEMOCRATIC PARTY (D)	230	43	0	273	AB-66	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2	AB-66	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-66	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-66	Straight Party			REPUBLICAN PARTY (R)	16	11	0	27	AB-66	US Representative	1	D	"ABERCROMBIE, Neil"	186	37	0	223	AB-66	US Representative	1	R	"TATAII, Steve"	9	7	0	16	AB-66	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-66	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-66	State Senate	18	D	"SONSON, Alex M."	74	19	0	93	AB-66	State Senate	18	D	"NISHIHARA, Clarence"	147	23	0	170	AB-66	State Representative	35	D	"AQUINO, Henry James C."	98	21	0	119	AB-66	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	77	13	0	90	AB-66	State Representative	35	D	"VERDADERO, Dante M."	3	1	0	4	AB-66	State Representative	35	D	"DOMINGO, Constante A."	9	2	0	11	AB-66	State Representative	35	D	"PARAYNO, Ilalo"	18	1	0	19	AB-66	State Representative	35	R	"ANTONIO, Steven Bolosan"	15	7	0	22	AB-67	Straight Party			DEMOCRATIC PARTY (D)	1020	141	0	1161	AB-67	Straight Party			INDEPENDENT PARTY (I)	3	0	0	3	AB-67	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2	AB-67	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2	AB-67	Straight Party			REPUBLICAN PARTY (R)	56	11	0	67	AB-67	US Representative	1	D	"ABERCROMBIE, Neil"	865	123	0	988	AB-67	US Representative	1	R	"TATAII, Steve"	37	7	0	44	AB-67	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-67	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-67	State Senate	18	D	"SONSON, Alex M."	593	61	0	654	AB-67	State Senate	18	D	"NISHIHARA, Clarence"	397	73	0	470	AB-67	State Representative	35	D	"AQUINO, Henry James C."	571	79	0	650	AB-67	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	233	21	0	254	AB-67	State Representative	35	D	"VERDADERO, Dante M."	54	10	0	64	AB-67	State Representative	35	D	"DOMINGO, Constante A."	66	8	0	74	AB-67	State Representative	35	D	"PARAYNO, Ilalo"	46	12	0	58	AB-67	State Representative	35	R	"ANTONIO, Steven Bolosan"	48	10	0	58	AB-68	Straight Party			DEMOCRATIC PARTY (D)	952	220	0	1172	AB-68	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7	AB-68	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2	AB-68	Straight Party			NONPARTISAN BALLOT (N)	18	2	0	20	AB-68	Straight Party			REPUBLICAN PARTY (R)	89	17	0	106	AB-68	US Representative	1	D	"ABERCROMBIE, Neil"	764	182	0	946	AB-68	US Representative	1	R	"TATAII, Steve"	75	14	0	89	AB-68	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-68	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-68	State Senate	16	D	"IGE, David Y."	681	164	0	845	AB-68	State Representative	36	D	"TAKUMI, Roy M."	702	171	0	873	AB-68	State Representative	36	N	"LUM LEE, Christopher-Travis"	15	1	0	16	AB-69	Straight Party			DEMOCRATIC PARTY (D)	563	107	0	670	AB-69	Straight Party			INDEPENDENT PARTY (I)	4	3	0	7	AB-69	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-69	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6	AB-69	Straight Party			REPUBLICAN PARTY (R)	42	10	0	52	AB-69	US Representative	1	D	"ABERCROMBIE, Neil"	464	80	0	544	AB-69	US Representative	1	R	"TATAII, Steve"	38	6	0	44	AB-69	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-69	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-69	State Senate	18	D	"SONSON, Alex M."	146	26	0	172	AB-69	State Senate	18	D	"NISHIHARA, Clarence"	371	72	0	443	AB-69	State Representative	36	D	"TAKUMI, Roy M."	456	88	0	544	AB-69	State Representative	36	N	"LUM LEE, Christopher-Travis"	2	2	0	4	AB-70	Straight Party			DEMOCRATIC PARTY (D)	12	5	0	17	AB-70	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-70	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-70	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-70	Straight Party			REPUBLICAN PARTY (R)	2	0	0	2	AB-70	US Representative	1	D	"ABERCROMBIE, Neil"	11	5	0	16	AB-70	US Representative	1	R	"TATAII, Steve"	2	0	0	2	AB-70	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-70	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-70	State Senate	18	D	"SONSON, Alex M."	1	1	0	2	AB-70	State Senate	18	D	"NISHIHARA, Clarence"	11	3	0	14	AB-70	State Representative	36	D	"TAKUMI, Roy M."	12	4	0	16	AB-70	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0	AB-71	Straight Party			DEMOCRATIC PARTY (D)	400	84	0	484	AB-71	Straight Party			INDEPENDENT PARTY (I)	3	2	0	5	AB-71	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2	AB-71	Straight Party			NONPARTISAN BALLOT (N)	0	1	0	1	AB-71	Straight Party			REPUBLICAN PARTY (R)	56	9	0	65	AB-71	US Representative	1	D	"ABERCROMBIE, Neil"	341	77	0	418	AB-71	US Representative	1	R	"TATAII, Steve"	50	7	0	57	AB-71	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-71	US Representative	1	L	"ZHAO, Li"	2	0	0	2	AB-71	State Senate	17	D	"KIDANI, Michelle"	162	42	0	204	AB-71	State Senate	17	D	"MENOR, Ron"	151	30	0	181	AB-71	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	52	8	0	60	AB-71	State Representative	37	D	"YAMANE, Ryan I."	339	75	0	414	AB-72	Straight Party			DEMOCRATIC PARTY (D)	1004	201	0	1205	AB-72	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2	AB-72	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4	AB-72	Straight Party			NONPARTISAN BALLOT (N)	1	2	0	3	AB-72	Straight Party			REPUBLICAN PARTY (R)	116	18	0	134	AB-72	US Representative	1	D	"ABERCROMBIE, Neil"	784	165	0	949	AB-72	US Representative	1	R	"TATAII, Steve"	107	14	0	121	AB-72	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4	AB-72	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-72	State Senate	17	D	"KIDANI, Michelle"	427	82	0	509	AB-72	State Senate	17	D	"MENOR, Ron"	431	83	0	514	AB-72	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	105	28	0	133	AB-72	State Representative	37	D	"YAMANE, Ryan I."	825	171	0	996	AB-73	Straight Party			DEMOCRATIC PARTY (D)	447	90	0	537	AB-73	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4	AB-73	Straight Party			LIBERTARIAN PARTY (L)	6	0	0	6	AB-73	Straight Party			NONPARTISAN BALLOT (N)	9	1	0	10	AB-73	Straight Party			REPUBLICAN PARTY (R)	74	14	0	88	AB-73	US Representative	1	D	"ABERCROMBIE, Neil"	372	70	0	442	AB-73	US Representative	1	R	"TATAII, Steve"	51	9	0	60	AB-73	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-73	US Representative	1	L	"ZHAO, Li"	5	0	0	5	AB-73	State Senate	22	D	"BUNDA, Robert (Bobby)"	283	64	0	347	AB-73	State Representative	38	D	"LEE, Marilyn B."	315	70	0	385	AB-73	State Representative	38	R	"APANA, Melvin K."	65	13	0	78	AB-74	Straight Party			DEMOCRATIC PARTY (D)	513	85	0	598	AB-74	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2	AB-74	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2	AB-74	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3	AB-74	Straight Party			REPUBLICAN PARTY (R)	57	11	0	68	AB-74	US Representative	1	D	"ABERCROMBIE, Neil"	413	76	0	489	AB-74	US Representative	1	R	"TATAII, Steve"	42	7	0	49	AB-74	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-74	US Representative	1	L	"ZHAO, Li"	1	1	0	2	AB-74	State Senate	17	D	"KIDANI, Michelle"	227	33	0	260	AB-74	State Senate	17	D	"MENOR, Ron"	193	36	0	229	AB-74	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	58	9	0	67	AB-74	State Representative	38	D	"LEE, Marilyn B."	412	67	0	479	AB-74	State Representative	38	R	"APANA, Melvin K."	48	8	0	56	AB-75	Straight Party			DEMOCRATIC PARTY (D)	829	170	0	999	AB-75	Straight Party			INDEPENDENT PARTY (I)	5	1	0	6	AB-75	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5	AB-75	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-75	Straight Party			REPUBLICAN PARTY (R)	113	20	0	133	AB-75	US Representative	1	D	"ABERCROMBIE, Neil"	666	134	0	800	AB-75	US Representative	1	R	"TATAII, Steve"	87	17	0	104	AB-75	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	1	0	2	AB-75	US Representative	1	L	"ZHAO, Li"	3	0	0	3	AB-75	State Senate	17	D	"KIDANI, Michelle"	320	61	0	381	AB-75	State Senate	17	D	"MENOR, Ron"	337	68	0	405	AB-75	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	131	30	0	161	AB-75	State Representative	38	D	"LEE, Marilyn B."	657	140	0	797	AB-75	State Representative	38	R	"APANA, Melvin K."	101	16	0	117	AB-76	Straight Party			DEMOCRATIC PARTY (D)	859	89	0	948	AB-76	Straight Party			INDEPENDENT PARTY (I)	9	0	0	9	AB-76	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2	AB-76	Straight Party			NONPARTISAN BALLOT (N)	15	1	0	16	AB-76	Straight Party			REPUBLICAN PARTY (R)	132	14	0	146	AB-76	US Representative	2	I	"STENSHOL, Shaun"	7	0	0	7	AB-76	US Representative	2	D	"HIRONO, Mazie"	706	71	0	777	AB-76	US Representative	2	R	"EVANS, Roger B."	122	12	0	134	AB-76	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1	AB-76	State Senate	22	D	"BUNDA, Robert (Bobby)"	634	71	0	705	AB-76	State Representative	39	D	"OSHIRO, Marcus R."	641	74	0	715	AB-77	Straight Party			DEMOCRATIC PARTY (D)	48	8	0	56	AB-77	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-77	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-77	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-77	Straight Party			REPUBLICAN PARTY (R)	16	2	0	18	AB-77	US Representative	1	D	"ABERCROMBIE, Neil"	33	7	0	40	AB-77	US Representative	1	R	"TATAII, Steve"	16	1	0	17	AB-77	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-77	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-77	State Senate	17	D	"KIDANI, Michelle"	19	6	0	25	AB-77	State Senate	17	D	"MENOR, Ron"	22	0	0	22	AB-77	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	4	1	0	5	AB-77	State Representative	39	D	"OSHIRO, Marcus R."	29	6	0	35	AB-78	Straight Party			DEMOCRATIC PARTY (D)	512	243	0	755	AB-78	Straight Party			INDEPENDENT PARTY (I)	8	3	0	11	AB-78	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4	AB-78	Straight Party			NONPARTISAN BALLOT (N)	10	3	0	13	AB-78	Straight Party			REPUBLICAN PARTY (R)	184	57	0	241	AB-78	US Representative	2	I	"STENSHOL, Shaun"	6	1	0	7	AB-78	US Representative	2	D	"HIRONO, Mazie"	379	200	0	579	AB-78	US Representative	2	R	"EVANS, Roger B."	136	44	0	180	AB-78	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3	AB-78	State Representative	40	D	"HAR, Sharon E."	435	212	0	647	AB-78	State Representative	40	R	"LEGAL,  Jack M."	166	52	0	218	AB-79	Straight Party			DEMOCRATIC PARTY (D)	301	128	0	429	AB-79	Straight Party			INDEPENDENT PARTY (I)	4	0	0	4	AB-79	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2	AB-79	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3	AB-79	Straight Party			REPUBLICAN PARTY (R)	97	40	0	137	AB-79	US Representative	2	I	"STENSHOL, Shaun"	3	0	0	3	AB-79	US Representative	2	D	"HIRONO, Mazie"	242	99	0	341	AB-79	US Representative	2	R	"EVANS, Roger B."	75	28	0	103	AB-79	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1	AB-79	State Representative	40	D	"HAR, Sharon E."	232	109	0	341	AB-79	State Representative	40	R	"LEGAL,  Jack M."	84	32	0	116	AB-80	Straight Party			DEMOCRATIC PARTY (D)	351	89	0	440	AB-80	Straight Party			INDEPENDENT PARTY (I)	4	2	0	6	AB-80	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-80	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-80	Straight Party			REPUBLICAN PARTY (R)	75	7	0	82	AB-80	US Representative	1	D	"ABERCROMBIE, Neil"	287	80	0	367	AB-80	US Representative	1	R	"TATAII, Steve"	48	5	0	53	AB-80	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-80	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-80	State Representative	41	D	"CULLEN, Ty Diaz"	83	26	0	109	AB-80	State Representative	41	D	"KARAMATSU, Jon Riki"	225	58	0	283	AB-80	State Representative	41	R	"SANIATAN, Rito C."	63	6	0	69	AB-81	Straight Party			DEMOCRATIC PARTY (D)	174	27	0	201	AB-81	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-81	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-81	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-81	Straight Party			REPUBLICAN PARTY (R)	17	0	0	17	AB-81	US Representative	1	D	"ABERCROMBIE, Neil"	158	21	0	179	AB-81	US Representative	1	R	"TATAII, Steve"	8	0	0	8	AB-81	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-81	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-81	State Senate	18	D	"SONSON, Alex M."	57	7	0	64	AB-81	State Senate	18	D	"NISHIHARA, Clarence"	113	19	0	132	AB-81	State Representative	41	D	"CULLEN, Ty Diaz"	58	10	0	68	AB-81	State Representative	41	D	"KARAMATSU, Jon Riki"	113	15	0	128	AB-81	State Representative	41	R	"SANIATAN, Rito C."	13	0	0	13	AB-82	Straight Party			DEMOCRATIC PARTY (D)	311	79	0	390	AB-82	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1	AB-82	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-82	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3	AB-82	Straight Party			REPUBLICAN PARTY (R)	91	12	0	103	AB-82	US Representative	2	I	"STENSHOL, Shaun"	1	0	0	1	AB-82	US Representative	2	D	"HIRONO, Mazie"	270	66	0	336	AB-82	US Representative	2	R	"EVANS, Roger B."	60	5	0	65	AB-82	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-82	State Representative	41	D	"CULLEN, Ty Diaz"	114	27	0	141	AB-82	State Representative	41	D	"KARAMATSU, Jon Riki"	167	48	0	215	AB-82	State Representative	41	R	"SANIATAN, Rito C."	79	7	0	86	AB-83	Straight Party			DEMOCRATIC PARTY (D)	148	13	0	161	AB-83	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-83	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-83	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-83	Straight Party			REPUBLICAN PARTY (R)	5	0	0	5	AB-83	US Representative	1	D	"ABERCROMBIE, Neil"	120	7	0	127	AB-83	US Representative	1	R	"TATAII, Steve"	2	0	0	2	AB-83	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-83	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-83	State Senate	18	D	"SONSON, Alex M."	55	4	0	59	AB-83	State Senate	18	D	"NISHIHARA, Clarence"	88	8	0	96	AB-83	State Representative	42	D	"RODRIGUEZ, Rey R."	11	1	0	12	AB-83	State Representative	42	D	"SCHULTZ, Mike P."	52	7	0	59	AB-83	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	73	4	0	77	AB-83	State Representative	42	R	"BERG, Tom"	4	0	0	4	AB-83	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0	AB-84	Straight Party			DEMOCRATIC PARTY (D)	31	8	0	39	AB-84	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0	AB-84	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-84	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-84	Straight Party			REPUBLICAN PARTY (R)	1	1	0	2	AB-84	US Representative	1	D	"ABERCROMBIE, Neil"	28	6	0	34	AB-84	US Representative	1	R	"TATAII, Steve"	1	0	0	1	AB-84	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0	AB-84	US Representative	1	L	"ZHAO, Li"	0	0	0	0	AB-84	State Representative	42	D	"RODRIGUEZ, Rey R."	4	1	0	5	AB-84	State Representative	42	D	"SCHULTZ, Mike P."	12	2	0	14	AB-84	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	11	4	0	15	AB-84	State Representative	42	R	"BERG, Tom"	1	1	0	2	AB-84	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0	AB-85	Straight Party			DEMOCRATIC PARTY (D)	499	115	0	614	AB-85	Straight Party			INDEPENDENT PARTY (I)	2	1	0	3	AB-85	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2	AB-85	Straight Party			NONPARTISAN BALLOT (N)	4	0	0	4	AB-85	Straight Party			REPUBLICAN PARTY (R)	86	21	0	107	AB-85	US Representative	1	D	"ABERCROMBIE, Neil"	433	98	0	531	AB-85	US Representative	1	R	"TATAII, Steve"	47	16	0	63	AB-85	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-85	US Representative	1	L	"ZHAO, Li"	1	0	0	1	AB-85	State Representative	42	D	"RODRIGUEZ, Rey R."	34	14	0	48	AB-85	State Representative	42	D	"SCHULTZ, Mike P."	216	48	0	264	AB-85	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	217	48	0	265	AB-85	State Representative	42	R	"BERG, Tom"	76	21	0	97	AB-85	State Representative	42	N	"BIMBO, Genaro Q."	3	0	0	3	AB-86	Straight Party			DEMOCRATIC PARTY (D)	660	165	0	825	AB-86	Straight Party			INDEPENDENT PARTY (I)	12	5	0	17	AB-86	Straight Party			LIBERTARIAN PARTY (L)	2	1	0	3	AB-86	Straight Party			NONPARTISAN BALLOT (N)	8	2	0	10	AB-86	Straight Party			REPUBLICAN PARTY (R)	385	84	0	469	AB-86	US Representative	1	D	"ABERCROMBIE, Neil"	606	145	0	751	AB-86	US Representative	1	R	"TATAII, Steve"	154	47	0	201	AB-86	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	AB-86	US Representative	1	L	"ZHAO, Li"	1	1	0	2	AB-86	State Representative	43	D	"FEVELLA, Kurt"	317	108	0	425	AB-86	State Representative	43	R	"PINE, Kymberly (Marcos)"	368	79	0	447	AB-87	Straight Party			DEMOCRATIC PARTY (D)	36	11	0	47	AB-87	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1	AB-87	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-87	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	AB-87	Straight Party			REPUBLICAN PARTY (R)	13	4	0	17	AB-87	US Representative	2	I	"STENSHOL, Shaun"	1	0	0	1	AB-87	US Representative	2	D	"HIRONO, Mazie"	35	9	0	44	AB-87	US Representative	2	R	"EVANS, Roger B."	11	4	0	15	AB-87	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-87	State Representative	44	D	"AWANA, Karen Leinani"	18	8	0	26	AB-87	State Representative	44	D	"AIPOALANI, Hanalei Y."	9	2	0	11	AB-87	State Representative	44	R	"KU, Tercia L."	9	3	0	12	AB-88	Straight Party			DEMOCRATIC PARTY (D)	480	164	0	644	AB-88	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7	AB-88	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3	AB-88	Straight Party			NONPARTISAN BALLOT (N)	3	1	0	4	AB-88	Straight Party			REPUBLICAN PARTY (R)	92	28	0	120	AB-88	US Representative	2	I	"STENSHOL, Shaun"	5	2	0	7	AB-88	US Representative	2	D	"HIRONO, Mazie"	373	131	0	504	AB-88	US Representative	2	R	"EVANS, Roger B."	65	24	0	89	AB-88	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3	AB-88	State Senate	21	D	"HANABUSA, Colleen"	379	131	0	510	AB-88	State Senate	21	R	"JOHNSON, Dickyj"	65	19	0	84	AB-88	State Representative	44	D	"AWANA, Karen Leinani"	243	75	0	318	AB-88	State Representative	44	D	"AIPOALANI, Hanalei Y."	198	78	0	276	AB-88	State Representative	44	R	"KU, Tercia L."	71	20	0	91	AB-89	Straight Party			DEMOCRATIC PARTY (D)	562	135	0	697	AB-89	Straight Party			INDEPENDENT PARTY (I)	9	1	0	10	AB-89	Straight Party			LIBERTARIAN PARTY (L)	1	2	0	3	AB-89	Straight Party			NONPARTISAN BALLOT (N)	2	1	0	3	AB-89	Straight Party			REPUBLICAN PARTY (R)	95	21	0	116	AB-89	US Representative	2	I	"STENSHOL, Shaun"	5	1	0	6	AB-89	US Representative	2	D	"HIRONO, Mazie"	441	109	0	550	AB-89	US Representative	2	R	"EVANS, Roger B."	65	14	0	79	AB-89	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	2	0	3	AB-89	State Senate	21	D	"HANABUSA, Colleen"	451	113	0	564	AB-89	State Senate	21	R	"JOHNSON, Dickyj"	66	14	0	80	AB-89	State Representative	45	D	"SHIMABUKURO, Maile S. L."	432	99	0	531	AB-89	State Representative	45	D	"SAYLORS, Denise"	94	30	0	124	AB-89	State Representative	45	R	"GAPOL, Derek A."	73	13	0	86	AB-90	Straight Party			DEMOCRATIC PARTY (D)	58	21	0	79	AB-90	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2	AB-90	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-90	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-90	Straight Party			REPUBLICAN PARTY (R)	36	15	0	51	AB-90	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2	AB-90	US Representative	2	D	"HIRONO, Mazie"	51	12	0	63	AB-90	US Representative	2	R	"EVANS, Roger B."	25	11	0	36	AB-90	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-90	State Senate	23	D	"HEE, Clayton"	39	14	0	53	AB-90	State Senate	23	D	"MURAKI, Noel S."	16	5	0	21	AB-90	State Senate	23	R	"FALE, Richard"	26	13	0	39	AB-90	State Representative	46	D	"LUNASCO, Ollie"	5	6	0	11	AB-90	State Representative	46	D	"MAGAOAY, Michael Y."	35	11	0	46	AB-90	State Representative	46	D	"WASSON, Dawn K."	12	4	0	16	AB-90	State Representative	46	R	"PHILIPS, Carol"	20	9	0	29	AB-90	State Representative	46	R	"RIVIERE, Gil"	16	4	0	20	AB-91	Straight Party			DEMOCRATIC PARTY (D)	479	51	0	530	AB-91	Straight Party			INDEPENDENT PARTY (I)	5	1	0	6	AB-91	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4	AB-91	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-91	Straight Party			REPUBLICAN PARTY (R)	193	16	0	209	AB-91	US Representative	2	I	"STENSHOL, Shaun"	5	1	0	6	AB-91	US Representative	2	D	"HIRONO, Mazie"	383	40	0	423	AB-91	US Representative	2	R	"EVANS, Roger B."	93	9	0	102	AB-91	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4	AB-91	State Senate	22	D	"BUNDA, Robert (Bobby)"	380	36	0	416	AB-91	State Representative	46	D	"LUNASCO, Ollie"	90	11	0	101	AB-91	State Representative	46	D	"MAGAOAY, Michael Y."	309	33	0	342	AB-91	State Representative	46	D	"WASSON, Dawn K."	55	4	0	59	AB-91	State Representative	46	R	"PHILIPS, Carol"	95	3	0	98	AB-91	State Representative	46	R	"RIVIERE, Gil"	92	13	0	105	AB-92	Straight Party			DEMOCRATIC PARTY (D)	891	497	0	1388	AB-92	Straight Party			INDEPENDENT PARTY (I)	12	2	0	14	AB-92	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4	AB-92	Straight Party			NONPARTISAN BALLOT (N)	3	2	0	5	AB-92	Straight Party			REPUBLICAN PARTY (R)	260	140	0	400	AB-92	US Representative	2	I	"STENSHOL, Shaun"	10	2	0	12	AB-92	US Representative	2	D	"HIRONO, Mazie"	714	404	0	1118	AB-92	US Representative	2	R	"EVANS, Roger B."	128	64	0	192	AB-92	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3	AB-92	State Senate	23	D	"HEE, Clayton"	562	314	0	876	AB-92	State Senate	23	D	"MURAKI, Noel S."	256	148	0	404	AB-92	State Senate	23	R	"FALE, Richard"	126	62	0	188	AB-92	State Representative	47	D	"PACHECO, Maria"	162	97	0	259	AB-92	State Representative	47	D	"WOOLEY, Jessica"	601	352	0	953	AB-92	State Representative	47	R	"MEYER, Colleen"	236	132	0	368	AB-93	Straight Party			DEMOCRATIC PARTY (D)	51	55	0	106	AB-93	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1	AB-93	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0	AB-93	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	AB-93	Straight Party			REPUBLICAN PARTY (R)	21	10	0	31	AB-93	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1	AB-93	US Representative	2	D	"HIRONO, Mazie"	45	49	0	94	AB-93	US Representative	2	R	"EVANS, Roger B."	15	2	0	17	AB-93	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0	AB-93	State Senate	23	D	"HEE, Clayton"	36	24	0	60	AB-93	State Senate	23	D	"MURAKI, Noel S."	10	23	0	33	AB-93	State Senate	23	R	"FALE, Richard"	16	2	0	18	AB-93	State Representative	47	D	"PACHECO, Maria"	4	11	0	15	AB-93	State Representative	47	D	"WOOLEY, Jessica"	37	35	0	72	AB-93	State Representative	47	R	"MEYER, Colleen"	21	8	0	29	AB-94	Straight Party			DEMOCRATIC PARTY (D)	345	218	0	563	AB-94	Straight Party			INDEPENDENT PARTY (I)	4	1	0	5	AB-94	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1	AB-94	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7	AB-94	Straight Party			REPUBLICAN PARTY (R)	50	35	0	85	AB-94	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5	AB-94	US Representative	2	D	"HIRONO, Mazie"	292	185	0	477	AB-94	US Representative	2	R	"EVANS, Roger B."	44	30	0	74	AB-94	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1	AB-94	State Senate	23	D	"HEE, Clayton"	200	125	0	325	AB-94	State Senate	23	D	"MURAKI, Noel S."	107	59	0	166	AB-94	State Senate	23	R	"FALE, Richard"	41	23	0	64	AB-94	State Representative	48	D	"ITO, Ken"	296	190	0	486	AB-95	Straight Party			DEMOCRATIC PARTY (D)	1164	573	0	1737	AB-95	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13	AB-95	Straight Party			LIBERTARIAN PARTY (L)	5	2	0	7	AB-95	Straight Party			NONPARTISAN BALLOT (N)	12	3	0	15	AB-95	Straight Party			REPUBLICAN PARTY (R)	170	65	0	235	AB-95	US Representative	2	I	"STENSHOL, Shaun"	8	1	0	9	AB-95	US Representative	2	D	"HIRONO, Mazie"	990	486	0	1476	AB-95	US Representative	2	R	"EVANS, Roger B."	160	60	0	220	AB-95	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	5	2	0	7	AB-95	State Representative	48	D	"ITO, Ken"	928	451	0	1379	AB-96	Straight Party			DEMOCRATIC PARTY (D)	909	318	0	1227	AB-96	Straight Party			INDEPENDENT PARTY (I)	11	5	0	16	AB-96	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4	AB-96	Straight Party			NONPARTISAN BALLOT (N)	14	6	0	20	AB-96	Straight Party			REPUBLICAN PARTY (R)	226	65	0	291	AB-96	US Representative	2	I	"STENSHOL, Shaun"	11	4	0	15	AB-96	US Representative	2	D	"HIRONO, Mazie"	758	258	0	1016	AB-96	US Representative	2	R	"EVANS, Roger B."	214	60	0	274	AB-96	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4	AB-96	State Representative	49	D	"CHONG, Pono"	653	226	0	879	AB-97	Straight Party			DEMOCRATIC PARTY (D)	286	180	0	466	AB-97	Straight Party			INDEPENDENT PARTY (I)	3	2	0	5	AB-97	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2	AB-97	Straight Party			NONPARTISAN BALLOT (N)	5	4	0	9	AB-97	Straight Party			REPUBLICAN PARTY (R)	73	56	0	129	AB-97	US Representative	2	I	"STENSHOL, Shaun"	3	2	0	5	AB-97	US Representative	2	D	"HIRONO, Mazie"	237	144	0	381	AB-97	US Representative	2	R	"EVANS, Roger B."	63	45	0	108	AB-97	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2	AB-97	State Senate	23	D	"HEE, Clayton"	160	96	0	256	AB-97	State Senate	23	D	"MURAKI, Noel S."	81	62	0	143	AB-97	State Senate	23	R	"FALE, Richard"	61	42	0	103	AB-97	State Representative	49	D	"CHONG, Pono"	233	140	0	373	AB-98	Straight Party			DEMOCRATIC PARTY (D)	628	292	0	920	AB-98	Straight Party			INDEPENDENT PARTY (I)	17	5	0	22	AB-98	Straight Party			LIBERTARIAN PARTY (L)	8	2	0	10	AB-98	Straight Party			NONPARTISAN BALLOT (N)	11	1	0	12	AB-98	Straight Party			REPUBLICAN PARTY (R)	554	138	0	692	AB-98	US Representative	2	I	"STENSHOL, Shaun"	13	2	0	15	AB-98	US Representative	2	D	"HIRONO, Mazie"	583	263	0	846	AB-98	US Representative	2	R	"EVANS, Roger B."	218	58	0	276	AB-98	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	8	2	0	10	AB-98	State Representative	50	R	"THIELEN, Cynthia"	511	122	0	633	AB-99	Straight Party			DEMOCRATIC PARTY (D)	985	338	0	1323	AB-99	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13	AB-99	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2	AB-99	Straight Party			NONPARTISAN BALLOT (N)	4	1	0	5	AB-99	Straight Party			REPUBLICAN PARTY (R)	237	71	0	308	AB-99	US Representative	2	I	"STENSHOL, Shaun"	7	2	0	9	AB-99	US Representative	2	D	"HIRONO, Mazie"	753	265	0	1018	AB-99	US Representative	2	R	"EVANS, Roger B."	118	32	0	150	AB-99	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2	AB-99	State Representative	51	D	"ANDERSON, J. Ikaika"	326	135	0	461	AB-99	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	27	6	0	33	AB-99	State Representative	51	D	"LEE, Chris Kalani"	563	170	0	733	AB-99	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	229	57	0	286	Overseas 100	Straight Party			DEMOCRATIC PARTY (D)	97	0	0	97	Overseas 100	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1	Overseas 100	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4	Overseas 100	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1	Overseas 100	Straight Party			REPUBLICAN PARTY (R)	19	0	0	19	Overseas 100	US Representative	1	D	"ABERCROMBIE, Neil"	96	0	0	96	Overseas 100	US Representative	1	R	"TATAII, Steve"	19	0	0	19	Overseas 100	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1	Overseas 100	US Representative	1	L	"ZHAO, Li"	3	0	0	3	Overseas 101	Straight Party			DEMOCRATIC PARTY (D)	80	0	0	80	Overseas 101	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2	Overseas 101	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4	Overseas 101	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0	Overseas 101	Straight Party			REPUBLICAN PARTY (R)	18	0	0	18	Overseas 101	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2	Overseas 101	US Representative	2	D	"HIRONO, Mazie"	80	0	0	80	Overseas 101	US Representative	2	R	"EVANS, Roger B."	18	0	0	18	Overseas 101	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4
+county	precinct	office	district	party	candidate	absentee	early_votes	election_day	votes
+County of Hawaii	01-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427
+County of Hawaii	01-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Hawaii	01-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	01-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	01-01	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
+County of Hawaii	01-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	01-01	US Representative	2	D	"HIRONO, Mazie"	0	0	321	321
+County of Hawaii	01-01	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
+County of Hawaii	01-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	01-01	State Senate	3	D	"ISBELL, Virginia"	0	0	60	60
+County of Hawaii	01-01	State Senate	3	D	"GREEN, Josh"	0	0	344	344
+County of Hawaii	01-01	State Representative	1	D	"FUJIYAMA, Ken"	0	0	53	53
+County of Hawaii	01-01	State Representative	1	D	"KIM, Jo"	0	0	91	91
+County of Hawaii	01-01	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	219	219
+County of Hawaii	01-01	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	17	17
+County of Hawaii	01-01	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	22	22
+County of Hawaii	01-01	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	17	17
+County of Hawaii	01-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	241	241
+County of Hawaii	01-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	01-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	01-02	Straight Party			REPUBLICAN PARTY (R)	0	0	29	29
+County of Hawaii	01-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	01-02	US Representative	2	D	"HIRONO, Mazie"	0	0	171	171
+County of Hawaii	01-02	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
+County of Hawaii	01-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-02	State Senate	3	D	"ISBELL, Virginia"	0	0	36	36
+County of Hawaii	01-02	State Senate	3	D	"GREEN, Josh"	0	0	195	195
+County of Hawaii	01-02	State Representative	1	D	"FUJIYAMA, Ken"	0	0	35	35
+County of Hawaii	01-02	State Representative	1	D	"KIM, Jo"	0	0	72	72
+County of Hawaii	01-02	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	86	86
+County of Hawaii	01-02	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	14	14
+County of Hawaii	01-02	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	13	13
+County of Hawaii	01-02	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	10	10
+County of Hawaii	01-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	82	82
+County of Hawaii	01-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Hawaii	01-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	01-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	01-03	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
+County of Hawaii	01-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	01-03	US Representative	2	D	"HIRONO, Mazie"	0	0	55	55
+County of Hawaii	01-03	US Representative	2	R	"EVANS, Roger B."	0	0	6	6
+County of Hawaii	01-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	01-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	61	61
+County of Hawaii	01-03	State Senate	1	R	"HONG, Ted H.S."	0	0	9	9
+County of Hawaii	01-03	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7
+County of Hawaii	01-03	State Representative	1	D	"KIM, Jo"	0	0	32	32
+County of Hawaii	01-03	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	24	24
+County of Hawaii	01-03	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6
+County of Hawaii	01-03	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	7	7
+County of Hawaii	01-03	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	0	0
+County of Hawaii	01-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	582	582
+County of Hawaii	01-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	01-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	01-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	01-04	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
+County of Hawaii	01-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	01-04	US Representative	2	D	"HIRONO, Mazie"	0	0	401	401
+County of Hawaii	01-04	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
+County of Hawaii	01-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	01-04	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	472	472
+County of Hawaii	01-04	State Senate	1	R	"HONG, Ted H.S."	0	0	50	50
+County of Hawaii	01-04	State Representative	1	D	"FUJIYAMA, Ken"	0	0	30	30
+County of Hawaii	01-04	State Representative	1	D	"KIM, Jo"	0	0	252	252
+County of Hawaii	01-04	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	250	250
+County of Hawaii	01-04	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	13	13
+County of Hawaii	01-04	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	39	39
+County of Hawaii	01-04	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	10	10
+County of Hawaii	01-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	246	246
+County of Hawaii	01-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	01-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Hawaii	01-05	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
+County of Hawaii	01-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	01-05	US Representative	2	D	"HIRONO, Mazie"	0	0	162	162
+County of Hawaii	01-05	US Representative	2	R	"EVANS, Roger B."	0	0	13	13
+County of Hawaii	01-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	01-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	191	191
+County of Hawaii	01-05	State Senate	1	R	"HONG, Ted H.S."	0	0	22	22
+County of Hawaii	01-05	State Representative	1	D	"FUJIYAMA, Ken"	0	0	22	22
+County of Hawaii	01-05	State Representative	1	D	"KIM, Jo"	0	0	121	121
+County of Hawaii	01-05	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	79	79
+County of Hawaii	01-05	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6
+County of Hawaii	01-05	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	12	12
+County of Hawaii	01-05	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	4	4
+County of Hawaii	01-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	56	56
+County of Hawaii	01-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Hawaii	01-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	01-06	Straight Party			REPUBLICAN PARTY (R)	0	0	10	10
+County of Hawaii	01-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	01-06	US Representative	2	D	"HIRONO, Mazie"	0	0	42	42
+County of Hawaii	01-06	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
+County of Hawaii	01-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	42	42
+County of Hawaii	01-06	State Senate	1	R	"HONG, Ted H.S."	0	0	8	8
+County of Hawaii	01-06	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7
+County of Hawaii	01-06	State Representative	1	D	"KIM, Jo"	0	0	12	12
+County of Hawaii	01-06	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	33	33
+County of Hawaii	01-06	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	1	1
+County of Hawaii	01-06	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	8	8
+County of Hawaii	01-06	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	1	1
+County of Hawaii	01-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	185	185
+County of Hawaii	01-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Hawaii	01-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	01-07	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
+County of Hawaii	01-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	01-07	US Representative	2	D	"HIRONO, Mazie"	0	0	132	132
+County of Hawaii	01-07	US Representative	2	R	"EVANS, Roger B."	0	0	20	20
+County of Hawaii	01-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	161	161
+County of Hawaii	01-07	State Senate	1	R	"HONG, Ted H.S."	0	0	25	25
+County of Hawaii	01-07	State Representative	1	D	"FUJIYAMA, Ken"	0	0	29	29
+County of Hawaii	01-07	State Representative	1	D	"KIM, Jo"	0	0	61	61
+County of Hawaii	01-07	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	58	58
+County of Hawaii	01-07	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	8	8
+County of Hawaii	01-07	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	19	19
+County of Hawaii	01-07	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	4	4
+County of Hawaii	01-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	73	73
+County of Hawaii	01-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	01-08	Straight Party			REPUBLICAN PARTY (R)	0	0	21	21
+County of Hawaii	01-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	01-08	US Representative	2	D	"HIRONO, Mazie"	0	0	51	51
+County of Hawaii	01-08	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Hawaii	01-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-08	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	55	55
+County of Hawaii	01-08	State Senate	1	R	"HONG, Ted H.S."	0	0	19	19
+County of Hawaii	01-08	State Representative	1	D	"FUJIYAMA, Ken"	0	0	8	8
+County of Hawaii	01-08	State Representative	1	D	"KIM, Jo"	0	0	20	20
+County of Hawaii	01-08	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	28	28
+County of Hawaii	01-08	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	6	6
+County of Hawaii	01-08	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	15	15
+County of Hawaii	01-08	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	2	2
+County of Hawaii	01-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	74	74
+County of Hawaii	01-09	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	01-09	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
+County of Hawaii	01-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	01-09	US Representative	2	D	"HIRONO, Mazie"	0	0	56	56
+County of Hawaii	01-09	US Representative	2	R	"EVANS, Roger B."	0	0	5	5
+County of Hawaii	01-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-09	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	63	63
+County of Hawaii	01-09	State Senate	1	R	"HONG, Ted H.S."	0	0	6	6
+County of Hawaii	01-09	State Representative	1	D	"FUJIYAMA, Ken"	0	0	24	24
+County of Hawaii	01-09	State Representative	1	D	"KIM, Jo"	0	0	18	18
+County of Hawaii	01-09	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	25	25
+County of Hawaii	01-09	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	2	2
+County of Hawaii	01-09	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	5	5
+County of Hawaii	01-09	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	3	3
+County of Hawaii	01-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	116	116
+County of Hawaii	01-10	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	01-10	Straight Party			REPUBLICAN PARTY (R)	0	0	18	18
+County of Hawaii	01-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	01-10	US Representative	2	D	"HIRONO, Mazie"	0	0	77	77
+County of Hawaii	01-10	US Representative	2	R	"EVANS, Roger B."	0	0	9	9
+County of Hawaii	01-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-10	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	99	99
+County of Hawaii	01-10	State Senate	1	R	"HONG, Ted H.S."	0	0	17	17
+County of Hawaii	01-10	State Representative	1	D	"FUJIYAMA, Ken"	0	0	22	22
+County of Hawaii	01-10	State Representative	1	D	"KIM, Jo"	0	0	22	22
+County of Hawaii	01-10	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	43	43
+County of Hawaii	01-10	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	4	4
+County of Hawaii	01-10	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	8	8
+County of Hawaii	01-10	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	3	3
+County of Hawaii	01-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313
+County of Hawaii	01-11	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+County of Hawaii	01-11	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
+County of Hawaii	01-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	01-11	US Representative	2	D	"HIRONO, Mazie"	0	0	247	247
+County of Hawaii	01-11	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Hawaii	01-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-11	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	283	283
+County of Hawaii	01-11	State Senate	1	R	"HONG, Ted H.S."	0	0	15	15
+County of Hawaii	01-11	State Representative	1	D	"FUJIYAMA, Ken"	0	0	52	52
+County of Hawaii	01-11	State Representative	1	D	"KIM, Jo"	0	0	51	51
+County of Hawaii	01-11	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	170	170
+County of Hawaii	01-11	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	12	12
+County of Hawaii	01-11	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	11	11
+County of Hawaii	01-11	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	2	2
+County of Hawaii	01-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	228	228
+County of Hawaii	01-12	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	01-12	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56
+County of Hawaii	01-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	01-12	US Representative	2	D	"HIRONO, Mazie"	0	0	170	170
+County of Hawaii	01-12	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
+County of Hawaii	01-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-12	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	176	176
+County of Hawaii	01-12	State Senate	1	R	"HONG, Ted H.S."	0	0	43	43
+County of Hawaii	01-12	State Representative	1	D	"FUJIYAMA, Ken"	0	0	64	64
+County of Hawaii	01-12	State Representative	1	D	"KIM, Jo"	0	0	39	39
+County of Hawaii	01-12	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	91	91
+County of Hawaii	01-12	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	8	8
+County of Hawaii	01-12	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	20	20
+County of Hawaii	01-12	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	19	19
+County of Hawaii	01-13	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317
+County of Hawaii	01-13	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-13	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	01-13	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	01-13	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47
+County of Hawaii	01-13	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	01-13	US Representative	2	D	"HIRONO, Mazie"	0	0	213	213
+County of Hawaii	01-13	US Representative	2	R	"EVANS, Roger B."	0	0	26	26
+County of Hawaii	01-13	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	01-13	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	231	231
+County of Hawaii	01-13	State Senate	1	R	"HONG, Ted H.S."	0	0	42	42
+County of Hawaii	01-13	State Representative	1	D	"FUJIYAMA, Ken"	0	0	81	81
+County of Hawaii	01-13	State Representative	1	D	"KIM, Jo"	0	0	63	63
+County of Hawaii	01-13	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	114	114
+County of Hawaii	01-13	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	17	17
+County of Hawaii	01-13	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	10	10
+County of Hawaii	01-13	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	14	14
+County of Hawaii	01-14	Straight Party			DEMOCRATIC PARTY (D)	0	0	97	97
+County of Hawaii	01-14	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	01-14	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	01-14	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	01-14	Straight Party			REPUBLICAN PARTY (R)	0	0	16	16
+County of Hawaii	01-14	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	01-14	US Representative	2	D	"HIRONO, Mazie"	0	0	81	81
+County of Hawaii	01-14	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Hawaii	01-14	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	01-14	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	72	72
+County of Hawaii	01-14	State Senate	1	R	"HONG, Ted H.S."	0	0	14	14
+County of Hawaii	01-14	State Representative	1	D	"FUJIYAMA, Ken"	0	0	29	29
+County of Hawaii	01-14	State Representative	1	D	"KIM, Jo"	0	0	23	23
+County of Hawaii	01-14	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	16	16
+County of Hawaii	01-14	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	11	11
+County of Hawaii	01-14	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	9	9
+County of Hawaii	01-14	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	6	6
+County of Hawaii	01-15	Straight Party			DEMOCRATIC PARTY (D)	0	0	95	95
+County of Hawaii	01-15	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Hawaii	01-15	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	01-15	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	01-15	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
+County of Hawaii	01-15	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	01-15	US Representative	2	D	"HIRONO, Mazie"	0	0	82	82
+County of Hawaii	01-15	US Representative	2	R	"EVANS, Roger B."	0	0	23	23
+County of Hawaii	01-15	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Hawaii	01-15	State Senate	3	D	"ISBELL, Virginia"	0	0	14	14
+County of Hawaii	01-15	State Senate	3	D	"GREEN, Josh"	0	0	73	73
+County of Hawaii	01-15	State Representative	1	D	"FUJIYAMA, Ken"	0	0	7	7
+County of Hawaii	01-15	State Representative	1	D	"KIM, Jo"	0	0	30	30
+County of Hawaii	01-15	State Representative	1	D	"NAKASHIMA, Mark M."	0	0	30	30
+County of Hawaii	01-15	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	0	0	12	12
+County of Hawaii	01-15	State Representative	1	R	"OFFENBAKER, Steven A."	0	0	7	7
+County of Hawaii	01-15	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	0	0	12	12
+County of Hawaii	02-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	683	683
+County of Hawaii	02-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+County of Hawaii	02-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	02-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	02-01	Straight Party			REPUBLICAN PARTY (R)	0	0	135	135
+County of Hawaii	02-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	02-01	US Representative	2	D	"HIRONO, Mazie"	0	0	480	480
+County of Hawaii	02-01	US Representative	2	R	"EVANS, Roger B."	0	0	44	44
+County of Hawaii	02-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	02-01	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	476	476
+County of Hawaii	02-01	State Senate	1	R	"HONG, Ted H.S."	0	0	124	124
+County of Hawaii	02-01	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	420	420
+County of Hawaii	02-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	367	367
+County of Hawaii	02-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	02-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	02-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Hawaii	02-02	Straight Party			REPUBLICAN PARTY (R)	0	0	77	77
+County of Hawaii	02-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	02-02	US Representative	2	D	"HIRONO, Mazie"	0	0	264	264
+County of Hawaii	02-02	US Representative	2	R	"EVANS, Roger B."	0	0	29	29
+County of Hawaii	02-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	02-02	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	252	252
+County of Hawaii	02-02	State Senate	1	R	"HONG, Ted H.S."	0	0	72	72
+County of Hawaii	02-02	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	253	253
+County of Hawaii	02-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	520	520
+County of Hawaii	02-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Hawaii	02-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	02-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Hawaii	02-03	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
+County of Hawaii	02-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Hawaii	02-03	US Representative	2	D	"HIRONO, Mazie"	0	0	390	390
+County of Hawaii	02-03	US Representative	2	R	"EVANS, Roger B."	0	0	49	49
+County of Hawaii	02-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	02-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	367	367
+County of Hawaii	02-03	State Senate	1	R	"HONG, Ted H.S."	0	0	96	96
+County of Hawaii	02-03	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	352	352
+County of Hawaii	02-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129
+County of Hawaii	02-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	02-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	02-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	02-04	Straight Party			REPUBLICAN PARTY (R)	0	0	30	30
+County of Hawaii	02-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	02-04	US Representative	2	D	"HIRONO, Mazie"	0	0	92	92
+County of Hawaii	02-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17
+County of Hawaii	02-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	02-04	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	85	85
+County of Hawaii	02-04	State Senate	1	R	"HONG, Ted H.S."	0	0	25	25
+County of Hawaii	02-04	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	73	73
+County of Hawaii	02-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	224	224
+County of Hawaii	02-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	02-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+County of Hawaii	02-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	02-05	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32
+County of Hawaii	02-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	02-05	US Representative	2	D	"HIRONO, Mazie"	0	0	169	169
+County of Hawaii	02-05	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Hawaii	02-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+County of Hawaii	02-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	136	136
+County of Hawaii	02-05	State Senate	1	R	"HONG, Ted H.S."	0	0	26	26
+County of Hawaii	02-05	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	125	125
+County of Hawaii	02-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	335	335
+County of Hawaii	02-06	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+County of Hawaii	02-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	02-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	02-06	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
+County of Hawaii	02-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Hawaii	02-06	US Representative	2	D	"HIRONO, Mazie"	0	0	227	227
+County of Hawaii	02-06	US Representative	2	R	"EVANS, Roger B."	0	0	19	19
+County of Hawaii	02-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	02-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	223	223
+County of Hawaii	02-06	State Senate	1	R	"HONG, Ted H.S."	0	0	41	41
+County of Hawaii	02-06	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	214	214
+County of Hawaii	02-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	148	148
+County of Hawaii	02-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	02-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	02-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	02-07	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
+County of Hawaii	02-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	02-07	US Representative	2	D	"HIRONO, Mazie"	0	0	104	104
+County of Hawaii	02-07	US Representative	2	R	"EVANS, Roger B."	0	0	6	6
+County of Hawaii	02-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	02-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	112	112
+County of Hawaii	02-07	State Senate	1	R	"HONG, Ted H.S."	0	0	16	16
+County of Hawaii	02-07	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	106	106
+County of Hawaii	02-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	259	259
+County of Hawaii	02-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Hawaii	02-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	02-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	02-08	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
+County of Hawaii	02-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	02-08	US Representative	2	D	"HIRONO, Mazie"	0	0	183	183
+County of Hawaii	02-08	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
+County of Hawaii	02-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	02-08	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	185	185
+County of Hawaii	02-08	State Senate	1	R	"HONG, Ted H.S."	0	0	33	33
+County of Hawaii	02-08	State Representative	2	D	"CHANG, Jerry Leslie"	0	0	167	167
+County of Hawaii	03-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	493	493
+County of Hawaii	03-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Hawaii	03-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	03-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Hawaii	03-01	Straight Party			REPUBLICAN PARTY (R)	0	0	41	41
+County of Hawaii	03-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	03-01	US Representative	2	D	"HIRONO, Mazie"	0	0	351	351
+County of Hawaii	03-01	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
+County of Hawaii	03-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	03-01	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	362	362
+County of Hawaii	03-01	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	23	23
+County of Hawaii	03-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	127	127
+County of Hawaii	03-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	03-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	03-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+County of Hawaii	03-02	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
+County of Hawaii	03-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	03-02	US Representative	2	D	"HIRONO, Mazie"	0	0	91	91
+County of Hawaii	03-02	US Representative	2	R	"EVANS, Roger B."	0	0	9	9
+County of Hawaii	03-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	03-02	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	111	111
+County of Hawaii	03-02	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	8	8
+County of Hawaii	03-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129
+County of Hawaii	03-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Hawaii	03-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	03-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	03-03	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
+County of Hawaii	03-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	03-03	US Representative	2	D	"HIRONO, Mazie"	0	0	97	97
+County of Hawaii	03-03	US Representative	2	R	"EVANS, Roger B."	0	0	4	4
+County of Hawaii	03-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	03-03	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	101	101
+County of Hawaii	03-03	State Senate	1	R	"HONG, Ted H.S."	0	0	19	19
+County of Hawaii	03-03	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	101	101
+County of Hawaii	03-03	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	4	4
+County of Hawaii	03-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	499	499
+County of Hawaii	03-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	03-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	03-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Hawaii	03-04	Straight Party			REPUBLICAN PARTY (R)	0	0	46	46
+County of Hawaii	03-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	03-04	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380
+County of Hawaii	03-04	US Representative	2	R	"EVANS, Roger B."	0	0	32	32
+County of Hawaii	03-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	03-04	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	392	392
+County of Hawaii	03-04	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	23	23
+County of Hawaii	03-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	490	490
+County of Hawaii	03-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Hawaii	03-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	03-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	03-05	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
+County of Hawaii	03-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+County of Hawaii	03-05	US Representative	2	D	"HIRONO, Mazie"	0	0	400	400
+County of Hawaii	03-05	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
+County of Hawaii	03-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	03-05	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	362	362
+County of Hawaii	03-05	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	44	44
+County of Hawaii	03-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	709	709
+County of Hawaii	03-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Hawaii	03-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	03-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	15	15
+County of Hawaii	03-06	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
+County of Hawaii	03-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Hawaii	03-06	US Representative	2	D	"HIRONO, Mazie"	0	0	499	499
+County of Hawaii	03-06	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
+County of Hawaii	03-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	03-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	509	509
+County of Hawaii	03-06	State Senate	1	R	"HONG, Ted H.S."	0	0	65	65
+County of Hawaii	03-06	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	499	499
+County of Hawaii	03-06	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	28	28
+County of Hawaii	03-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	401	401
+County of Hawaii	03-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Hawaii	03-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	03-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Hawaii	03-07	Straight Party			REPUBLICAN PARTY (R)	0	0	37	37
+County of Hawaii	03-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	03-07	US Representative	2	D	"HIRONO, Mazie"	0	0	316	316
+County of Hawaii	03-07	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
+County of Hawaii	03-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Hawaii	03-07	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	310	310
+County of Hawaii	03-07	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	16	16
+County of Hawaii	03-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	601	601
+County of Hawaii	03-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Hawaii	03-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	03-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Hawaii	03-08	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54
+County of Hawaii	03-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Hawaii	03-08	US Representative	2	D	"HIRONO, Mazie"	0	0	469	469
+County of Hawaii	03-08	US Representative	2	R	"EVANS, Roger B."	0	0	35	35
+County of Hawaii	03-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Hawaii	03-08	State Representative	3	D	"TSUJI, Clifton (Clift)"	0	0	447	447
+County of Hawaii	03-08	State Representative	3	R	"TAVARES, Deirdre (Moana)"	0	0	38	38
+County of Hawaii	04-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	406	406
+County of Hawaii	04-01	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+County of Hawaii	04-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+County of Hawaii	04-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+County of Hawaii	04-01	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
+County of Hawaii	04-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+County of Hawaii	04-01	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305
+County of Hawaii	04-01	US Representative	2	R	"EVANS, Roger B."	0	0	49	49
+County of Hawaii	04-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+County of Hawaii	04-01	State Representative	4	D	"HANOHANO, Faye P."	0	0	184	184
+County of Hawaii	04-01	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	76	76
+County of Hawaii	04-01	State Representative	4	D	"SPARKS, Steven B."	0	0	92	92
+County of Hawaii	04-01	State Representative	4	R	"BLAS, Fred"	0	0	56	56
+County of Hawaii	04-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	306	306
+County of Hawaii	04-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+County of Hawaii	04-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	04-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
+County of Hawaii	04-02	Straight Party			REPUBLICAN PARTY (R)	0	0	52	52
+County of Hawaii	04-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Hawaii	04-02	US Representative	2	D	"HIRONO, Mazie"	0	0	234	234
+County of Hawaii	04-02	US Representative	2	R	"EVANS, Roger B."	0	0	38	38
+County of Hawaii	04-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	04-02	State Representative	4	D	"HANOHANO, Faye P."	0	0	144	144
+County of Hawaii	04-02	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	66	66
+County of Hawaii	04-02	State Representative	4	D	"SPARKS, Steven B."	0	0	58	58
+County of Hawaii	04-02	State Representative	4	R	"BLAS, Fred"	0	0	38	38
+County of Hawaii	04-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	517	517
+County of Hawaii	04-03	Straight Party			INDEPENDENT PARTY (I)	0	0	12	12
+County of Hawaii	04-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
+County of Hawaii	04-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Hawaii	04-03	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108
+County of Hawaii	04-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
+County of Hawaii	04-03	US Representative	2	D	"HIRONO, Mazie"	0	0	354	354
+County of Hawaii	04-03	US Representative	2	R	"EVANS, Roger B."	0	0	67	67
+County of Hawaii	04-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	10	10
+County of Hawaii	04-03	State Representative	4	D	"HANOHANO, Faye P."	0	0	186	186
+County of Hawaii	04-03	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	159	159
+County of Hawaii	04-03	State Representative	4	D	"SPARKS, Steven B."	0	0	109	109
+County of Hawaii	04-03	State Representative	4	R	"BLAS, Fred"	0	0	74	74
+County of Hawaii	04-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	396	396
+County of Hawaii	04-04	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+County of Hawaii	04-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	04-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	04-04	Straight Party			REPUBLICAN PARTY (R)	0	0	126	126
+County of Hawaii	04-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Hawaii	04-04	US Representative	2	D	"HIRONO, Mazie"	0	0	284	284
+County of Hawaii	04-04	US Representative	2	R	"EVANS, Roger B."	0	0	50	50
+County of Hawaii	04-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Hawaii	04-04	State Representative	4	D	"HANOHANO, Faye P."	0	0	213	213
+County of Hawaii	04-04	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	90	90
+County of Hawaii	04-04	State Representative	4	D	"SPARKS, Steven B."	0	0	45	45
+County of Hawaii	04-04	State Representative	4	R	"BLAS, Fred"	0	0	116	116
+County of Hawaii	04-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	677	677
+County of Hawaii	04-05	Straight Party			INDEPENDENT PARTY (I)	0	0	18	18
+County of Hawaii	04-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+County of Hawaii	04-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
+County of Hawaii	04-05	Straight Party			REPUBLICAN PARTY (R)	0	0	94	94
+County of Hawaii	04-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	14	14
+County of Hawaii	04-05	US Representative	2	D	"HIRONO, Mazie"	0	0	410	410
+County of Hawaii	04-05	US Representative	2	R	"EVANS, Roger B."	0	0	52	52
+County of Hawaii	04-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6
+County of Hawaii	04-05	State Representative	4	D	"HANOHANO, Faye P."	0	0	199	199
+County of Hawaii	04-05	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	264	264
+County of Hawaii	04-05	State Representative	4	D	"SPARKS, Steven B."	0	0	161	161
+County of Hawaii	04-05	State Representative	4	R	"BLAS, Fred"	0	0	67	67
+County of Hawaii	04-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421
+County of Hawaii	04-06	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
+County of Hawaii	04-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+County of Hawaii	04-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
+County of Hawaii	04-06	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
+County of Hawaii	04-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+County of Hawaii	04-06	US Representative	2	D	"HIRONO, Mazie"	0	0	317	317
+County of Hawaii	04-06	US Representative	2	R	"EVANS, Roger B."	0	0	75	75
+County of Hawaii	04-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+County of Hawaii	04-06	State Representative	4	D	"HANOHANO, Faye P."	0	0	208	208
+County of Hawaii	04-06	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	105	105
+County of Hawaii	04-06	State Representative	4	D	"SPARKS, Steven B."	0	0	61	61
+County of Hawaii	04-06	State Representative	4	R	"BLAS, Fred"	0	0	69	69
+County of Hawaii	04-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	166	166
+County of Hawaii	04-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	04-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	04-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	04-07	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19
+County of Hawaii	04-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	04-07	US Representative	2	D	"HIRONO, Mazie"	0	0	85	85
+County of Hawaii	04-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
+County of Hawaii	04-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	04-07	State Representative	4	D	"HANOHANO, Faye P."	0	0	44	44
+County of Hawaii	04-07	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	46	46
+County of Hawaii	04-07	State Representative	4	D	"SPARKS, Steven B."	0	0	58	58
+County of Hawaii	04-07	State Representative	4	R	"BLAS, Fred"	0	0	16	16
+County of Hawaii	04-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236
+County of Hawaii	04-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	04-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	04-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	04-08	Straight Party			REPUBLICAN PARTY (R)	0	0	62	62
+County of Hawaii	04-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	04-08	US Representative	2	D	"HIRONO, Mazie"	0	0	175	175
+County of Hawaii	04-08	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
+County of Hawaii	04-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	04-08	State Representative	4	D	"HANOHANO, Faye P."	0	0	116	116
+County of Hawaii	04-08	State Representative	4	D	"MARZI, Anthony (Tony)"	0	0	69	69
+County of Hawaii	04-08	State Representative	4	D	"SPARKS, Steven B."	0	0	25	25
+County of Hawaii	04-08	State Representative	4	R	"BLAS, Fred"	0	0	47	47
+County of Hawaii	05-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	142	142
+County of Hawaii	05-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Hawaii	05-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	05-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Hawaii	05-01	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24
+County of Hawaii	05-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+County of Hawaii	05-01	US Representative	2	D	"HIRONO, Mazie"	0	0	112	112
+County of Hawaii	05-01	US Representative	2	R	"EVANS, Roger B."	0	0	23	23
+County of Hawaii	05-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Hawaii	05-01	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	83	83
+County of Hawaii	05-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	298	298
+County of Hawaii	05-02	Straight Party			INDEPENDENT PARTY (I)	0	0	16	16
+County of Hawaii	05-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	05-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
+County of Hawaii	05-02	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
+County of Hawaii	05-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	16	16
+County of Hawaii	05-02	US Representative	2	D	"HIRONO, Mazie"	0	0	244	244
+County of Hawaii	05-02	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
+County of Hawaii	05-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Hawaii	05-02	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	152	152
+County of Hawaii	05-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	469	469
+County of Hawaii	05-03	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15
+County of Hawaii	05-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	19	19
+County of Hawaii	05-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
+County of Hawaii	05-03	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101
+County of Hawaii	05-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	13	13
+County of Hawaii	05-03	US Representative	2	D	"HIRONO, Mazie"	0	0	370	370
+County of Hawaii	05-03	US Representative	2	R	"EVANS, Roger B."	0	0	96	96
+County of Hawaii	05-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	19	19
+County of Hawaii	05-03	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	280	280
+County of Hawaii	05-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	205	205
+County of Hawaii	05-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	05-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	05-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Hawaii	05-04	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
+County of Hawaii	05-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	05-04	US Representative	2	D	"HIRONO, Mazie"	0	0	169	169
+County of Hawaii	05-04	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
+County of Hawaii	05-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	05-04	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	122	122
+County of Hawaii	05-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267
+County of Hawaii	05-05	Straight Party			INDEPENDENT PARTY (I)	0	0	21	21
+County of Hawaii	05-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	05-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
+County of Hawaii	05-05	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53
+County of Hawaii	05-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	19	19
+County of Hawaii	05-05	US Representative	2	D	"HIRONO, Mazie"	0	0	203	203
+County of Hawaii	05-05	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
+County of Hawaii	05-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Hawaii	05-05	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	171	171
+County of Hawaii	05-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	343	343
+County of Hawaii	05-06	Straight Party			INDEPENDENT PARTY (I)	0	0	12	12
+County of Hawaii	05-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	12	12
+County of Hawaii	05-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
+County of Hawaii	05-06	Straight Party			REPUBLICAN PARTY (R)	0	0	97	97
+County of Hawaii	05-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10
+County of Hawaii	05-06	US Representative	2	D	"HIRONO, Mazie"	0	0	268	268
+County of Hawaii	05-06	US Representative	2	R	"EVANS, Roger B."	0	0	94	94
+County of Hawaii	05-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	11	11
+County of Hawaii	05-06	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	190	190
+County of Hawaii	05-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	115	115
+County of Hawaii	05-07	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	05-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	05-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	05-07	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
+County of Hawaii	05-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	05-07	US Representative	2	D	"HIRONO, Mazie"	0	0	67	67
+County of Hawaii	05-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
+County of Hawaii	05-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	05-07	State Senate	3	D	"ISBELL, Virginia"	0	0	30	30
+County of Hawaii	05-07	State Senate	3	D	"GREEN, Josh"	0	0	77	77
+County of Hawaii	05-07	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	66	66
+County of Hawaii	05-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	130	130
+County of Hawaii	05-08	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	05-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	05-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	05-08	Straight Party			REPUBLICAN PARTY (R)	0	0	9	9
+County of Hawaii	05-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	05-08	US Representative	2	D	"HIRONO, Mazie"	0	0	80	80
+County of Hawaii	05-08	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
+County of Hawaii	05-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	05-08	State Senate	3	D	"ISBELL, Virginia"	0	0	43	43
+County of Hawaii	05-08	State Senate	3	D	"GREEN, Josh"	0	0	81	81
+County of Hawaii	05-08	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	68	68
+County of Hawaii	05-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	280	280
+County of Hawaii	05-09	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	05-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Hawaii	05-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	05-09	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15
+County of Hawaii	05-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	05-09	US Representative	2	D	"HIRONO, Mazie"	0	0	177	177
+County of Hawaii	05-09	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Hawaii	05-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	05-09	State Senate	3	D	"ISBELL, Virginia"	0	0	94	94
+County of Hawaii	05-09	State Senate	3	D	"GREEN, Josh"	0	0	174	174
+County of Hawaii	05-09	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	160	160
+County of Hawaii	05-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	119	119
+County of Hawaii	05-10	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	05-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	05-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	05-10	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
+County of Hawaii	05-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	05-10	US Representative	2	D	"HIRONO, Mazie"	0	0	86	86
+County of Hawaii	05-10	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
+County of Hawaii	05-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	05-10	State Senate	3	D	"ISBELL, Virginia"	0	0	36	36
+County of Hawaii	05-10	State Senate	3	D	"GREEN, Josh"	0	0	77	77
+County of Hawaii	05-10	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	76	76
+County of Hawaii	05-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	481	481
+County of Hawaii	05-11	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	05-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	05-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+County of Hawaii	05-11	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43
+County of Hawaii	05-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	05-11	US Representative	2	D	"HIRONO, Mazie"	0	0	331	331
+County of Hawaii	05-11	US Representative	2	R	"EVANS, Roger B."	0	0	39	39
+County of Hawaii	05-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	05-11	State Senate	3	D	"ISBELL, Virginia"	0	0	144	144
+County of Hawaii	05-11	State Senate	3	D	"GREEN, Josh"	0	0	312	312
+County of Hawaii	05-11	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	267	267
+County of Hawaii	05-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	412	412
+County of Hawaii	05-12	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Hawaii	05-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	05-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	05-12	Straight Party			REPUBLICAN PARTY (R)	0	0	60	60
+County of Hawaii	05-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Hawaii	05-12	US Representative	2	D	"HIRONO, Mazie"	0	0	278	278
+County of Hawaii	05-12	US Representative	2	R	"EVANS, Roger B."	0	0	56	56
+County of Hawaii	05-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	05-12	State Senate	3	D	"ISBELL, Virginia"	0	0	122	122
+County of Hawaii	05-12	State Senate	3	D	"GREEN, Josh"	0	0	277	277
+County of Hawaii	05-12	State Representative	5	D	"HERKES, Robert (Bob)"	0	0	255	255
+County of Hawaii	06-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	301	301
+County of Hawaii	06-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+County of Hawaii	06-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	06-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+County of Hawaii	06-01	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
+County of Hawaii	06-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	06-01	US Representative	2	D	"HIRONO, Mazie"	0	0	205	205
+County of Hawaii	06-01	US Representative	2	R	"EVANS, Roger B."	0	0	33	33
+County of Hawaii	06-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	06-01	State Senate	3	D	"ISBELL, Virginia"	0	0	69	69
+County of Hawaii	06-01	State Senate	3	D	"GREEN, Josh"	0	0	224	224
+County of Hawaii	06-01	State Representative	6	D	"COFFMAN, Denny"	0	0	101	101
+County of Hawaii	06-01	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	88	88
+County of Hawaii	06-01	State Representative	6	D	"MACGREGOR, Maegan"	0	0	47	47
+County of Hawaii	06-01	State Representative	6	R	"SMITH, Andy"	0	0	49	49
+County of Hawaii	06-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	554	554
+County of Hawaii	06-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+County of Hawaii	06-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	06-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	06-02	Straight Party			REPUBLICAN PARTY (R)	0	0	152	152
+County of Hawaii	06-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+County of Hawaii	06-02	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380
+County of Hawaii	06-02	US Representative	2	R	"EVANS, Roger B."	0	0	84	84
+County of Hawaii	06-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	06-02	State Senate	3	D	"ISBELL, Virginia"	0	0	86	86
+County of Hawaii	06-02	State Senate	3	D	"GREEN, Josh"	0	0	458	458
+County of Hawaii	06-02	State Representative	6	D	"COFFMAN, Denny"	0	0	287	287
+County of Hawaii	06-02	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	106	106
+County of Hawaii	06-02	State Representative	6	D	"MACGREGOR, Maegan"	0	0	74	74
+County of Hawaii	06-02	State Representative	6	R	"SMITH, Andy"	0	0	129	129
+County of Hawaii	06-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	214	214
+County of Hawaii	06-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	06-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	06-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Hawaii	06-03	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
+County of Hawaii	06-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	06-03	US Representative	2	D	"HIRONO, Mazie"	0	0	145	145
+County of Hawaii	06-03	US Representative	2	R	"EVANS, Roger B."	0	0	43	43
+County of Hawaii	06-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	06-03	State Senate	3	D	"ISBELL, Virginia"	0	0	32	32
+County of Hawaii	06-03	State Senate	3	D	"GREEN, Josh"	0	0	179	179
+County of Hawaii	06-03	State Representative	6	D	"COFFMAN, Denny"	0	0	98	98
+County of Hawaii	06-03	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	30	30
+County of Hawaii	06-03	State Representative	6	D	"MACGREGOR, Maegan"	0	0	32	32
+County of Hawaii	06-03	State Representative	6	R	"SMITH, Andy"	0	0	73	73
+County of Hawaii	06-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	282	282
+County of Hawaii	06-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Hawaii	06-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	06-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	06-04	Straight Party			REPUBLICAN PARTY (R)	0	0	95	95
+County of Hawaii	06-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Hawaii	06-04	US Representative	2	D	"HIRONO, Mazie"	0	0	180	180
+County of Hawaii	06-04	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
+County of Hawaii	06-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	06-04	State Senate	3	D	"ISBELL, Virginia"	0	0	49	49
+County of Hawaii	06-04	State Senate	3	D	"GREEN, Josh"	0	0	223	223
+County of Hawaii	06-04	State Representative	6	D	"COFFMAN, Denny"	0	0	74	74
+County of Hawaii	06-04	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	119	119
+County of Hawaii	06-04	State Representative	6	D	"MACGREGOR, Maegan"	0	0	34	34
+County of Hawaii	06-04	State Representative	6	R	"SMITH, Andy"	0	0	76	76
+County of Hawaii	06-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	286	286
+County of Hawaii	06-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Hawaii	06-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	06-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Hawaii	06-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
+County of Hawaii	06-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Hawaii	06-05	US Representative	2	D	"HIRONO, Mazie"	0	0	187	187
+County of Hawaii	06-05	US Representative	2	R	"EVANS, Roger B."	0	0	43	43
+County of Hawaii	06-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	06-05	State Senate	3	D	"ISBELL, Virginia"	0	0	65	65
+County of Hawaii	06-05	State Senate	3	D	"GREEN, Josh"	0	0	210	210
+County of Hawaii	06-05	State Representative	6	D	"COFFMAN, Denny"	0	0	81	81
+County of Hawaii	06-05	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	88	88
+County of Hawaii	06-05	State Representative	6	D	"MACGREGOR, Maegan"	0	0	45	45
+County of Hawaii	06-05	State Representative	6	R	"SMITH, Andy"	0	0	69	69
+County of Hawaii	06-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	216	216
+County of Hawaii	06-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	06-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	06-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Hawaii	06-06	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
+County of Hawaii	06-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	06-06	US Representative	2	D	"HIRONO, Mazie"	0	0	162	162
+County of Hawaii	06-06	US Representative	2	R	"EVANS, Roger B."	0	0	34	34
+County of Hawaii	06-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	06-06	State Senate	3	D	"ISBELL, Virginia"	0	0	51	51
+County of Hawaii	06-06	State Senate	3	D	"GREEN, Josh"	0	0	153	153
+County of Hawaii	06-06	State Representative	6	D	"COFFMAN, Denny"	0	0	73	73
+County of Hawaii	06-06	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	68	68
+County of Hawaii	06-06	State Representative	6	D	"MACGREGOR, Maegan"	0	0	38	38
+County of Hawaii	06-06	State Representative	6	R	"SMITH, Andy"	0	0	60	60
+County of Hawaii	06-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	183	183
+County of Hawaii	06-07	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+County of Hawaii	06-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	06-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
+County of Hawaii	06-07	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54
+County of Hawaii	06-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	06-07	US Representative	2	D	"HIRONO, Mazie"	0	0	129	129
+County of Hawaii	06-07	US Representative	2	R	"EVANS, Roger B."	0	0	33	33
+County of Hawaii	06-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	06-07	State Senate	3	D	"ISBELL, Virginia"	0	0	24	24
+County of Hawaii	06-07	State Senate	3	D	"GREEN, Josh"	0	0	155	155
+County of Hawaii	06-07	State Representative	6	D	"COFFMAN, Denny"	0	0	79	79
+County of Hawaii	06-07	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	42	42
+County of Hawaii	06-07	State Representative	6	D	"MACGREGOR, Maegan"	0	0	25	25
+County of Hawaii	06-07	State Representative	6	R	"SMITH, Andy"	0	0	49	49
+County of Hawaii	06-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	291	291
+County of Hawaii	06-08	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Hawaii	06-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	06-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+County of Hawaii	06-08	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
+County of Hawaii	06-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	06-08	US Representative	2	D	"HIRONO, Mazie"	0	0	206	206
+County of Hawaii	06-08	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
+County of Hawaii	06-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	06-08	State Senate	3	D	"ISBELL, Virginia"	0	0	75	75
+County of Hawaii	06-08	State Senate	3	D	"GREEN, Josh"	0	0	200	200
+County of Hawaii	06-08	State Representative	6	D	"COFFMAN, Denny"	0	0	77	77
+County of Hawaii	06-08	State Representative	6	D	"LESLIE, Gene (Bucky)"	0	0	93	93
+County of Hawaii	06-08	State Representative	6	D	"MACGREGOR, Maegan"	0	0	56	56
+County of Hawaii	06-08	State Representative	6	R	"SMITH, Andy"	0	0	39	39
+County of Hawaii	07-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	240	240
+County of Hawaii	07-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	07-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Hawaii	07-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+County of Hawaii	07-01	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
+County of Hawaii	07-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Hawaii	07-01	US Representative	2	D	"HIRONO, Mazie"	0	0	158	158
+County of Hawaii	07-01	US Representative	2	R	"EVANS, Roger B."	0	0	45	45
+County of Hawaii	07-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Hawaii	07-01	State Senate	3	D	"ISBELL, Virginia"	0	0	40	40
+County of Hawaii	07-01	State Senate	3	D	"GREEN, Josh"	0	0	182	182
+County of Hawaii	07-01	State Representative	7	D	"EVANS, Cindy"	0	0	162	162
+County of Hawaii	07-01	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	32	32
+County of Hawaii	07-01	State Representative	7	R	"KAILIMAI, B.J."	0	0	17	17
+County of Hawaii	07-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	593	593
+County of Hawaii	07-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Hawaii	07-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	07-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
+County of Hawaii	07-02	Straight Party			REPUBLICAN PARTY (R)	0	0	139	139
+County of Hawaii	07-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Hawaii	07-02	US Representative	2	D	"HIRONO, Mazie"	0	0	368	368
+County of Hawaii	07-02	US Representative	2	R	"EVANS, Roger B."	0	0	107	107
+County of Hawaii	07-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	07-02	State Senate	3	D	"ISBELL, Virginia"	0	0	142	142
+County of Hawaii	07-02	State Senate	3	D	"GREEN, Josh"	0	0	410	410
+County of Hawaii	07-02	State Representative	7	D	"EVANS, Cindy"	0	0	379	379
+County of Hawaii	07-02	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	62	62
+County of Hawaii	07-02	State Representative	7	R	"KAILIMAI, B.J."	0	0	36	36
+County of Hawaii	07-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	498	498
+County of Hawaii	07-03	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
+County of Hawaii	07-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+County of Hawaii	07-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
+County of Hawaii	07-03	Straight Party			REPUBLICAN PARTY (R)	0	0	166	166
+County of Hawaii	07-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10
+County of Hawaii	07-03	US Representative	2	D	"HIRONO, Mazie"	0	0	346	346
+County of Hawaii	07-03	US Representative	2	R	"EVANS, Roger B."	0	0	121	121
+County of Hawaii	07-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	7	7
+County of Hawaii	07-03	State Senate	3	D	"ISBELL, Virginia"	0	0	81	81
+County of Hawaii	07-03	State Senate	3	D	"GREEN, Josh"	0	0	348	348
+County of Hawaii	07-03	State Representative	7	D	"EVANS, Cindy"	0	0	401	401
+County of Hawaii	07-03	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	86	86
+County of Hawaii	07-03	State Representative	7	R	"KAILIMAI, B.J."	0	0	61	61
+County of Hawaii	07-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	70	70
+County of Hawaii	07-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	07-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	07-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	07-04	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
+County of Hawaii	07-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	07-04	US Representative	2	D	"HIRONO, Mazie"	0	0	53	53
+County of Hawaii	07-04	US Representative	2	R	"EVANS, Roger B."	0	0	18	18
+County of Hawaii	07-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	07-04	State Senate	3	D	"ISBELL, Virginia"	0	0	9	9
+County of Hawaii	07-04	State Senate	3	D	"GREEN, Josh"	0	0	51	51
+County of Hawaii	07-04	State Representative	7	D	"EVANS, Cindy"	0	0	52	52
+County of Hawaii	07-04	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	13	13
+County of Hawaii	07-04	State Representative	7	R	"KAILIMAI, B.J."	0	0	6	6
+County of Hawaii	07-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	329	329
+County of Hawaii	07-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	07-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+County of Hawaii	07-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+County of Hawaii	07-05	Straight Party			REPUBLICAN PARTY (R)	0	0	131	131
+County of Hawaii	07-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	07-05	US Representative	2	D	"HIRONO, Mazie"	0	0	216	216
+County of Hawaii	07-05	US Representative	2	R	"EVANS, Roger B."	0	0	84	84
+County of Hawaii	07-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+County of Hawaii	07-05	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	223	223
+County of Hawaii	07-05	State Senate	1	R	"HONG, Ted H.S."	0	0	94	94
+County of Hawaii	07-05	State Representative	7	D	"EVANS, Cindy"	0	0	210	210
+County of Hawaii	07-05	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	48	48
+County of Hawaii	07-05	State Representative	7	R	"KAILIMAI, B.J."	0	0	64	64
+County of Hawaii	07-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
+County of Hawaii	07-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	07-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	07-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+County of Hawaii	07-06	Straight Party			REPUBLICAN PARTY (R)	0	0	104	104
+County of Hawaii	07-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	07-06	US Representative	2	D	"HIRONO, Mazie"	0	0	204	204
+County of Hawaii	07-06	US Representative	2	R	"EVANS, Roger B."	0	0	55	55
+County of Hawaii	07-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	07-06	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	214	214
+County of Hawaii	07-06	State Senate	1	R	"HONG, Ted H.S."	0	0	65	65
+County of Hawaii	07-06	State Representative	7	D	"EVANS, Cindy"	0	0	207	207
+County of Hawaii	07-06	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	32	32
+County of Hawaii	07-06	State Representative	7	R	"KAILIMAI, B.J."	0	0	56	56
+County of Hawaii	07-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	161	161
+County of Hawaii	07-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Hawaii	07-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Hawaii	07-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Hawaii	07-07	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
+County of Hawaii	07-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Hawaii	07-07	US Representative	2	D	"HIRONO, Mazie"	0	0	99	99
+County of Hawaii	07-07	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
+County of Hawaii	07-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Hawaii	07-07	State Senate	1	D	"TAKAMINE, Dwight Y."	0	0	109	109
+County of Hawaii	07-07	State Senate	1	R	"HONG, Ted H.S."	0	0	43	43
+County of Hawaii	07-07	State Representative	7	D	"EVANS, Cindy"	0	0	92	92
+County of Hawaii	07-07	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	19	19
+County of Hawaii	07-07	State Representative	7	R	"KAILIMAI, B.J."	0	0	38	38
+County of Hawaii	07-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	33	33
+County of Hawaii	07-08	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Hawaii	07-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Hawaii	07-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Hawaii	07-08	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
+County of Hawaii	07-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Hawaii	07-08	US Representative	2	D	"HIRONO, Mazie"	0	0	20	20
+County of Hawaii	07-08	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
+County of Hawaii	07-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Hawaii	07-08	State Senate	3	D	"ISBELL, Virginia"	0	0	2	2
+County of Hawaii	07-08	State Senate	3	D	"GREEN, Josh"	0	0	26	26
+County of Hawaii	07-08	State Representative	7	D	"EVANS, Cindy"	0	0	25	25
+County of Hawaii	07-08	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	0	0	3	3
+County of Hawaii	07-08	State Representative	7	R	"KAILIMAI, B.J."	0	0	6	6
+County of Maui	08-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	264	264
+County of Maui	08-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	08-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	08-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	08-01	Straight Party			REPUBLICAN PARTY (R)	0	0	27	27
+County of Maui	08-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Maui	08-01	US Representative	2	D	"HIRONO, Mazie"	0	0	193	193
+County of Maui	08-01	US Representative	2	R	"EVANS, Roger B."	0	0	24	24
+County of Maui	08-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	08-01	State Representative	8	D	"KAMA, Tasha"	0	0	160	160
+County of Maui	08-01	State Representative	8	D	"SOUKI, Joe"	0	0	93	93
+County of Maui	08-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	452	452
+County of Maui	08-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	08-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	08-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+County of Maui	08-02	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
+County of Maui	08-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Maui	08-02	US Representative	2	D	"HIRONO, Mazie"	0	0	338	338
+County of Maui	08-02	US Representative	2	R	"EVANS, Roger B."	0	0	38	38
+County of Maui	08-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	08-02	State Representative	8	D	"KAMA, Tasha"	0	0	234	234
+County of Maui	08-02	State Representative	8	D	"SOUKI, Joe"	0	0	192	192
+County of Maui	08-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	213	213
+County of Maui	08-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Maui	08-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	08-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	08-03	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
+County of Maui	08-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	08-03	US Representative	2	D	"HIRONO, Mazie"	0	0	168	168
+County of Maui	08-03	US Representative	2	R	"EVANS, Roger B."	0	0	24	24
+County of Maui	08-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	08-03	State Representative	8	D	"KAMA, Tasha"	0	0	69	69
+County of Maui	08-03	State Representative	8	D	"SOUKI, Joe"	0	0	127	127
+County of Maui	08-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	209	209
+County of Maui	08-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Maui	08-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	08-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+County of Maui	08-04	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14
+County of Maui	08-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	08-04	US Representative	2	D	"HIRONO, Mazie"	0	0	158	158
+County of Maui	08-04	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Maui	08-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	08-04	State Representative	8	D	"KAMA, Tasha"	0	0	92	92
+County of Maui	08-04	State Representative	8	D	"SOUKI, Joe"	0	0	95	95
+County of Maui	08-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	426	426
+County of Maui	08-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	08-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	08-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+County of Maui	08-05	Straight Party			REPUBLICAN PARTY (R)	0	0	70	70
+County of Maui	08-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	08-05	US Representative	2	D	"HIRONO, Mazie"	0	0	333	333
+County of Maui	08-05	US Representative	2	R	"EVANS, Roger B."	0	0	61	61
+County of Maui	08-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	08-05	State Representative	8	D	"KAMA, Tasha"	0	0	178	178
+County of Maui	08-05	State Representative	8	D	"SOUKI, Joe"	0	0	216	216
+County of Maui	08-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223
+County of Maui	08-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	08-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	08-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	08-06	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15
+County of Maui	08-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	08-06	US Representative	2	D	"HIRONO, Mazie"	0	0	181	181
+County of Maui	08-06	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Maui	08-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Maui	08-06	State Representative	8	D	"KAMA, Tasha"	0	0	85	85
+County of Maui	08-06	State Representative	8	D	"SOUKI, Joe"	0	0	118	118
+County of Maui	08-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	141	141
+County of Maui	08-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	08-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	08-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	08-07	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
+County of Maui	08-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	08-07	US Representative	2	D	"HIRONO, Mazie"	0	0	115	115
+County of Maui	08-07	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
+County of Maui	08-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	08-07	State Representative	8	D	"KAMA, Tasha"	0	0	61	61
+County of Maui	08-07	State Representative	8	D	"SOUKI, Joe"	0	0	71	71
+County of Maui	09-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	192	192
+County of Maui	09-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	09-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	09-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Maui	09-01	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
+County of Maui	09-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	09-01	US Representative	2	D	"HIRONO, Mazie"	0	0	148	148
+County of Maui	09-01	US Representative	2	R	"EVANS, Roger B."	0	0	20	20
+County of Maui	09-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	09-01	State Representative	9	D	"NAKASONE, Bob"	0	0	123	123
+County of Maui	09-01	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	21	21
+County of Maui	09-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392
+County of Maui	09-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	09-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	09-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	09-02	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56
+County of Maui	09-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	09-02	US Representative	2	D	"HIRONO, Mazie"	0	0	337	337
+County of Maui	09-02	US Representative	2	R	"EVANS, Roger B."	0	0	31	31
+County of Maui	09-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Maui	09-02	State Representative	9	D	"NAKASONE, Bob"	0	0	268	268
+County of Maui	09-02	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	34	34
+County of Maui	09-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	338	338
+County of Maui	09-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	09-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	09-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Maui	09-03	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
+County of Maui	09-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	09-03	US Representative	2	D	"HIRONO, Mazie"	0	0	287	287
+County of Maui	09-03	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
+County of Maui	09-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	09-03	State Representative	9	D	"NAKASONE, Bob"	0	0	246	246
+County of Maui	09-03	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	24	24
+County of Maui	09-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	299	299
+County of Maui	09-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Maui	09-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	09-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	09-04	Straight Party			REPUBLICAN PARTY (R)	0	0	33	33
+County of Maui	09-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	09-04	US Representative	2	D	"HIRONO, Mazie"	0	0	249	249
+County of Maui	09-04	US Representative	2	R	"EVANS, Roger B."	0	0	14	14
+County of Maui	09-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	09-04	State Representative	9	D	"NAKASONE, Bob"	0	0	183	183
+County of Maui	09-04	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	24	24
+County of Maui	09-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	381	381
+County of Maui	09-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Maui	09-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	09-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	09-05	Straight Party			REPUBLICAN PARTY (R)	0	0	30	30
+County of Maui	09-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Maui	09-05	US Representative	2	D	"HIRONO, Mazie"	0	0	312	312
+County of Maui	09-05	US Representative	2	R	"EVANS, Roger B."	0	0	24	24
+County of Maui	09-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	09-05	State Representative	9	D	"NAKASONE, Bob"	0	0	256	256
+County of Maui	09-05	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	18	18
+County of Maui	09-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	22	22
+County of Maui	09-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	09-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	09-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	09-06	Straight Party			REPUBLICAN PARTY (R)	0	0	2	2
+County of Maui	09-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	09-06	US Representative	2	D	"HIRONO, Mazie"	0	0	17	17
+County of Maui	09-06	US Representative	2	R	"EVANS, Roger B."	0	0	1	1
+County of Maui	09-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	09-06	State Representative	9	D	"NAKASONE, Bob"	0	0	11	11
+County of Maui	09-06	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	1	1
+County of Maui	09-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	120	120
+County of Maui	09-07	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Maui	09-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Maui	09-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Maui	09-07	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
+County of Maui	09-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Maui	09-07	US Representative	2	D	"HIRONO, Mazie"	0	0	98	98
+County of Maui	09-07	US Representative	2	R	"EVANS, Roger B."	0	0	12	12
+County of Maui	09-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Maui	09-07	State Representative	9	D	"NAKASONE, Bob"	0	0	60	60
+County of Maui	09-07	State Representative	9	R	"KAHULA, Henry P., Jr."	0	0	19	19
+County of Maui	10-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	114	114
+County of Maui	10-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Maui	10-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	10-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	10-01	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24
+County of Maui	10-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+County of Maui	10-01	US Representative	2	D	"HIRONO, Mazie"	0	0	90	90
+County of Maui	10-01	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
+County of Maui	10-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	10-01	State Senate	5	D	"BAKER, Roz"	0	0	89	89
+County of Maui	10-01	State Senate	5	D	"MULVIHILL, Bart"	0	0	13	13
+County of Maui	10-01	State Senate	5	R	"SHIELDS, Jan"	0	0	17	17
+County of Maui	10-01	State Representative	10	D	"MCKELVEY, Angus"	0	0	76	76
+County of Maui	10-01	State Representative	10	R	"MADDEN, Ramon K."	0	0	14	14
+County of Maui	10-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
+County of Maui	10-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	10-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	10-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	10-02	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
+County of Maui	10-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	10-02	US Representative	2	D	"HIRONO, Mazie"	0	0	125	125
+County of Maui	10-02	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
+County of Maui	10-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	10-02	State Senate	5	D	"BAKER, Roz"	0	0	112	112
+County of Maui	10-02	State Senate	5	D	"MULVIHILL, Bart"	0	0	42	42
+County of Maui	10-02	State Senate	5	R	"SHIELDS, Jan"	0	0	52	52
+County of Maui	10-02	State Representative	10	D	"MCKELVEY, Angus"	0	0	136	136
+County of Maui	10-02	State Representative	10	R	"MADDEN, Ramon K."	0	0	26	26
+County of Maui	10-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	246	246
+County of Maui	10-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Maui	10-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	10-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	10-03	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
+County of Maui	10-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Maui	10-03	US Representative	2	D	"HIRONO, Mazie"	0	0	206	206
+County of Maui	10-03	US Representative	2	R	"EVANS, Roger B."	0	0	12	12
+County of Maui	10-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	10-03	State Senate	5	D	"BAKER, Roz"	0	0	194	194
+County of Maui	10-03	State Senate	5	D	"MULVIHILL, Bart"	0	0	37	37
+County of Maui	10-03	State Senate	5	R	"SHIELDS, Jan"	0	0	22	22
+County of Maui	10-03	State Representative	10	D	"MCKELVEY, Angus"	0	0	191	191
+County of Maui	10-03	State Representative	10	R	"MADDEN, Ramon K."	0	0	15	15
+County of Maui	10-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
+County of Maui	10-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	10-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	10-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Maui	10-04	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
+County of Maui	10-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	10-04	US Representative	2	D	"HIRONO, Mazie"	0	0	145	145
+County of Maui	10-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17
+County of Maui	10-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Maui	10-04	State Senate	5	D	"BAKER, Roz"	0	0	132	132
+County of Maui	10-04	State Senate	5	D	"MULVIHILL, Bart"	0	0	31	31
+County of Maui	10-04	State Senate	5	R	"SHIELDS, Jan"	0	0	37	37
+County of Maui	10-04	State Representative	10	D	"MCKELVEY, Angus"	0	0	151	151
+County of Maui	10-04	State Representative	10	R	"MADDEN, Ramon K."	0	0	22	22
+County of Maui	10-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	162	162
+County of Maui	10-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	10-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	10-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	10-05	Straight Party			REPUBLICAN PARTY (R)	0	0	87	87
+County of Maui	10-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	10-05	US Representative	2	D	"HIRONO, Mazie"	0	0	111	111
+County of Maui	10-05	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
+County of Maui	10-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	10-05	State Senate	5	D	"BAKER, Roz"	0	0	105	105
+County of Maui	10-05	State Senate	5	D	"MULVIHILL, Bart"	0	0	46	46
+County of Maui	10-05	State Senate	5	R	"SHIELDS, Jan"	0	0	74	74
+County of Maui	10-05	State Representative	10	D	"MCKELVEY, Angus"	0	0	125	125
+County of Maui	10-05	State Representative	10	R	"MADDEN, Ramon K."	0	0	39	39
+County of Maui	10-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200
+County of Maui	10-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Maui	10-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	10-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Maui	10-06	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
+County of Maui	10-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	10-06	US Representative	2	D	"HIRONO, Mazie"	0	0	142	142
+County of Maui	10-06	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
+County of Maui	10-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	10-06	State Senate	5	D	"BAKER, Roz"	0	0	129	129
+County of Maui	10-06	State Senate	5	D	"MULVIHILL, Bart"	0	0	52	52
+County of Maui	10-06	State Senate	5	R	"SHIELDS, Jan"	0	0	74	74
+County of Maui	10-06	State Representative	10	D	"MCKELVEY, Angus"	0	0	153	153
+County of Maui	10-06	State Representative	10	R	"MADDEN, Ramon K."	0	0	35	35
+County of Maui	11-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	299	299
+County of Maui	11-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Maui	11-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	11-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	11-01	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
+County of Maui	11-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+County of Maui	11-01	US Representative	2	D	"HIRONO, Mazie"	0	0	239	239
+County of Maui	11-01	US Representative	2	R	"EVANS, Roger B."	0	0	26	26
+County of Maui	11-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	11-01	State Senate	5	D	"BAKER, Roz"	0	0	217	217
+County of Maui	11-01	State Senate	5	D	"MULVIHILL, Bart"	0	0	55	55
+County of Maui	11-01	State Senate	5	R	"SHIELDS, Jan"	0	0	47	47
+County of Maui	11-01	State Representative	11	D	"GINGERICH, Michael"	0	0	86	86
+County of Maui	11-01	State Representative	11	D	"BERTRAM, Joe, III"	0	0	175	175
+County of Maui	11-01	State Representative	11	R	"FONTAINE, George R."	0	0	35	35
+County of Maui	11-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	462	462
+County of Maui	11-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+County of Maui	11-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	11-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Maui	11-02	Straight Party			REPUBLICAN PARTY (R)	0	0	159	159
+County of Maui	11-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Maui	11-02	US Representative	2	D	"HIRONO, Mazie"	0	0	342	342
+County of Maui	11-02	US Representative	2	R	"EVANS, Roger B."	0	0	77	77
+County of Maui	11-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Maui	11-02	State Senate	5	D	"BAKER, Roz"	0	0	270	270
+County of Maui	11-02	State Senate	5	D	"MULVIHILL, Bart"	0	0	153	153
+County of Maui	11-02	State Senate	5	R	"SHIELDS, Jan"	0	0	135	135
+County of Maui	11-02	State Representative	11	D	"GINGERICH, Michael"	0	0	131	131
+County of Maui	11-02	State Representative	11	D	"BERTRAM, Joe, III"	0	0	296	296
+County of Maui	11-02	State Representative	11	R	"FONTAINE, George R."	0	0	108	108
+County of Maui	11-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	272	272
+County of Maui	11-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+County of Maui	11-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	11-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Maui	11-03	Straight Party			REPUBLICAN PARTY (R)	0	0	116	116
+County of Maui	11-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Maui	11-03	US Representative	2	D	"HIRONO, Mazie"	0	0	196	196
+County of Maui	11-03	US Representative	2	R	"EVANS, Roger B."	0	0	45	45
+County of Maui	11-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	11-03	State Senate	5	D	"BAKER, Roz"	0	0	175	175
+County of Maui	11-03	State Senate	5	D	"MULVIHILL, Bart"	0	0	84	84
+County of Maui	11-03	State Senate	5	R	"SHIELDS, Jan"	0	0	97	97
+County of Maui	11-03	State Representative	11	D	"GINGERICH, Michael"	0	0	61	61
+County of Maui	11-03	State Representative	11	D	"BERTRAM, Joe, III"	0	0	183	183
+County of Maui	11-03	State Representative	11	R	"FONTAINE, George R."	0	0	67	67
+County of Maui	11-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293
+County of Maui	11-04	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+County of Maui	11-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	11-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+County of Maui	11-04	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112
+County of Maui	11-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Maui	11-04	US Representative	2	D	"HIRONO, Mazie"	0	0	218	218
+County of Maui	11-04	US Representative	2	R	"EVANS, Roger B."	0	0	62	62
+County of Maui	11-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	11-04	State Senate	5	D	"BAKER, Roz"	0	0	202	202
+County of Maui	11-04	State Senate	5	D	"MULVIHILL, Bart"	0	0	73	73
+County of Maui	11-04	State Senate	5	R	"SHIELDS, Jan"	0	0	85	85
+County of Maui	11-04	State Representative	11	D	"GINGERICH, Michael"	0	0	81	81
+County of Maui	11-04	State Representative	11	D	"BERTRAM, Joe, III"	0	0	180	180
+County of Maui	11-04	State Representative	11	R	"FONTAINE, George R."	0	0	75	75
+County of Maui	12-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	516	516
+County of Maui	12-01	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+County of Maui	12-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	12-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	12-01	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
+County of Maui	12-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+County of Maui	12-01	US Representative	2	D	"HIRONO, Mazie"	0	0	367	367
+County of Maui	12-01	US Representative	2	R	"EVANS, Roger B."	0	0	29	29
+County of Maui	12-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Maui	12-01	State Senate	6	I	"BLUMER-BUELL, John"	0	0	6	6
+County of Maui	12-01	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	344	344
+County of Maui	12-01	State Representative	12	D	"YAMASHITA, Kyle"	0	0	300	300
+County of Maui	12-01	State Representative	12	D	"STARR, Summer"	0	0	195	195
+County of Maui	12-01	State Representative	12	R	"VIERRA, Mickey"	0	0	49	49
+County of Maui	12-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	403	403
+County of Maui	12-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	12-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	12-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	12-02	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36
+County of Maui	12-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	12-02	US Representative	2	D	"HIRONO, Mazie"	0	0	247	247
+County of Maui	12-02	US Representative	2	R	"EVANS, Roger B."	0	0	15	15
+County of Maui	12-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Maui	12-02	State Senate	6	I	"BLUMER-BUELL, John"	0	0	3	3
+County of Maui	12-02	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	249	249
+County of Maui	12-02	State Representative	12	D	"YAMASHITA, Kyle"	0	0	191	191
+County of Maui	12-02	State Representative	12	D	"STARR, Summer"	0	0	203	203
+County of Maui	12-02	State Representative	12	R	"VIERRA, Mickey"	0	0	27	27
+County of Maui	12-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	532	532
+County of Maui	12-03	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Maui	12-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	12-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Maui	12-03	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
+County of Maui	12-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	12-03	US Representative	2	D	"HIRONO, Mazie"	0	0	344	344
+County of Maui	12-03	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
+County of Maui	12-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	12-03	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2
+County of Maui	12-03	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	319	319
+County of Maui	12-03	State Representative	12	D	"YAMASHITA, Kyle"	0	0	275	275
+County of Maui	12-03	State Representative	12	D	"STARR, Summer"	0	0	239	239
+County of Maui	12-03	State Representative	12	R	"VIERRA, Mickey"	0	0	51	51
+County of Maui	12-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	679	679
+County of Maui	12-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Maui	12-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	12-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	12-04	Straight Party			REPUBLICAN PARTY (R)	0	0	90	90
+County of Maui	12-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	12-04	US Representative	2	D	"HIRONO, Mazie"	0	0	492	492
+County of Maui	12-04	US Representative	2	R	"EVANS, Roger B."	0	0	32	32
+County of Maui	12-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	12-04	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2
+County of Maui	12-04	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	448	448
+County of Maui	12-04	State Representative	12	D	"YAMASHITA, Kyle"	0	0	444	444
+County of Maui	12-04	State Representative	12	D	"STARR, Summer"	0	0	211	211
+County of Maui	12-04	State Representative	12	R	"VIERRA, Mickey"	0	0	72	72
+County of Maui	12-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	306	306
+County of Maui	12-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Maui	12-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	12-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Maui	12-05	Straight Party			REPUBLICAN PARTY (R)	0	0	46	46
+County of Maui	12-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	12-05	US Representative	2	D	"HIRONO, Mazie"	0	0	208	208
+County of Maui	12-05	US Representative	2	R	"EVANS, Roger B."	0	0	16	16
+County of Maui	12-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	12-05	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
+County of Maui	12-05	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	204	204
+County of Maui	12-05	State Representative	12	D	"YAMASHITA, Kyle"	0	0	149	149
+County of Maui	12-05	State Representative	12	D	"STARR, Summer"	0	0	141	141
+County of Maui	12-05	State Representative	12	R	"VIERRA, Mickey"	0	0	34	34
+County of Maui	12-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	524	524
+County of Maui	12-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+County of Maui	12-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Maui	12-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	12-06	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
+County of Maui	12-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	12-06	US Representative	2	D	"HIRONO, Mazie"	0	0	324	324
+County of Maui	12-06	US Representative	2	R	"EVANS, Roger B."	0	0	34	34
+County of Maui	12-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Maui	12-06	State Senate	6	I	"BLUMER-BUELL, John"	0	0	2	2
+County of Maui	12-06	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	331	331
+County of Maui	12-06	State Representative	12	D	"YAMASHITA, Kyle"	0	0	220	220
+County of Maui	12-06	State Representative	12	D	"STARR, Summer"	0	0	288	288
+County of Maui	12-06	State Representative	12	R	"VIERRA, Mickey"	0	0	49	49
+County of Maui	12-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	33	33
+County of Maui	12-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	12-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	12-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	12-07	Straight Party			REPUBLICAN PARTY (R)	0	0	5	5
+County of Maui	12-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	12-07	US Representative	2	D	"HIRONO, Mazie"	0	0	17	17
+County of Maui	12-07	US Representative	2	R	"EVANS, Roger B."	0	0	3	3
+County of Maui	12-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	12-07	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
+County of Maui	12-07	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	25	25
+County of Maui	12-07	State Representative	12	D	"YAMASHITA, Kyle"	0	0	6	6
+County of Maui	12-07	State Representative	12	D	"STARR, Summer"	0	0	27	27
+County of Maui	12-07	State Representative	12	R	"VIERRA, Mickey"	0	0	4	4
+County of Maui	13-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	151	151
+County of Maui	13-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Maui	13-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	13-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Maui	13-01	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19
+County of Maui	13-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	13-01	US Representative	2	D	"HIRONO, Mazie"	0	0	103	103
+County of Maui	13-01	US Representative	2	R	"EVANS, Roger B."	0	0	18	18
+County of Maui	13-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	13-01	State Senate	6	I	"BLUMER-BUELL, John"	0	0	1	1
+County of Maui	13-01	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	104	104
+County of Maui	13-01	State Representative	13	D	"CARROLL, Mele"	0	0	94	94
+County of Maui	13-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	358	358
+County of Maui	13-02	Straight Party			INDEPENDENT PARTY (I)	0	0	13	13
+County of Maui	13-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Maui	13-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	13-02	Straight Party			REPUBLICAN PARTY (R)	0	0	56	56
+County of Maui	13-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Maui	13-02	US Representative	2	D	"HIRONO, Mazie"	0	0	208	208
+County of Maui	13-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54
+County of Maui	13-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Maui	13-02	State Senate	6	I	"BLUMER-BUELL, John"	0	0	10	10
+County of Maui	13-02	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	230	230
+County of Maui	13-02	State Representative	13	D	"CARROLL, Mele"	0	0	213	213
+County of Maui	13-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	389	389
+County of Maui	13-03	Straight Party			INDEPENDENT PARTY (I)	0	0	21	21
+County of Maui	13-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+County of Maui	13-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Maui	13-03	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32
+County of Maui	13-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+County of Maui	13-03	US Representative	2	D	"HIRONO, Mazie"	0	0	254	254
+County of Maui	13-03	US Representative	2	R	"EVANS, Roger B."	0	0	30	30
+County of Maui	13-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6
+County of Maui	13-03	State Senate	6	I	"BLUMER-BUELL, John"	0	0	19	19
+County of Maui	13-03	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	261	261
+County of Maui	13-03	State Representative	13	D	"CARROLL, Mele"	0	0	253	253
+County of Maui	13-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	95	95
+County of Maui	13-04	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Maui	13-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	13-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	13-04	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
+County of Maui	13-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	13-04	US Representative	2	D	"HIRONO, Mazie"	0	0	54	54
+County of Maui	13-04	US Representative	2	R	"EVANS, Roger B."	0	0	8	8
+County of Maui	13-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	13-04	State Senate	6	I	"BLUMER-BUELL, John"	0	0	7	7
+County of Maui	13-04	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	67	67
+County of Maui	13-04	State Representative	13	D	"CARROLL, Mele"	0	0	68	68
+County of Maui	13-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	19	19
+County of Maui	13-05	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+County of Maui	13-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	13-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	13-05	Straight Party			REPUBLICAN PARTY (R)	0	0	7	7
+County of Maui	13-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Maui	13-05	US Representative	2	D	"HIRONO, Mazie"	0	0	12	12
+County of Maui	13-05	US Representative	2	R	"EVANS, Roger B."	0	0	6	6
+County of Maui	13-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	13-05	State Senate	6	I	"BLUMER-BUELL, John"	0	0	5	5
+County of Maui	13-05	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	13	13
+County of Maui	13-05	State Representative	13	D	"CARROLL, Mele"	0	0	11	11
+County of Maui	13-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	192	192
+County of Maui	13-06	Straight Party			INDEPENDENT PARTY (I)	0	0	23	23
+County of Maui	13-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	13-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	13-06	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
+County of Maui	13-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Maui	13-06	US Representative	2	D	"HIRONO, Mazie"	0	0	109	109
+County of Maui	13-06	US Representative	2	R	"EVANS, Roger B."	0	0	15	15
+County of Maui	13-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	13-06	State Senate	6	I	"BLUMER-BUELL, John"	0	0	23	23
+County of Maui	13-06	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	160	160
+County of Maui	13-06	State Representative	13	D	"CARROLL, Mele"	0	0	108	108
+County of Maui	13-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	362	362
+County of Maui	13-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+County of Maui	13-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Maui	13-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	13-07	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47
+County of Maui	13-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Maui	13-07	US Representative	2	D	"HIRONO, Mazie"	0	0	259	259
+County of Maui	13-07	US Representative	2	R	"EVANS, Roger B."	0	0	43	43
+County of Maui	13-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	13-07	State Senate	6	I	"BLUMER-BUELL, John"	0	0	4	4
+County of Maui	13-07	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	184	184
+County of Maui	13-07	State Representative	13	D	"CARROLL, Mele"	0	0	177	177
+County of Maui	13-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	59	59
+County of Maui	13-08	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	13-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	13-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	13-08	Straight Party			REPUBLICAN PARTY (R)	0	0	12	12
+County of Maui	13-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	13-08	US Representative	2	D	"HIRONO, Mazie"	0	0	32	32
+County of Maui	13-08	US Representative	2	R	"EVANS, Roger B."	0	0	10	10
+County of Maui	13-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	13-08	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
+County of Maui	13-08	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	43	43
+County of Maui	13-08	State Representative	13	D	"CARROLL, Mele"	0	0	37	37
+County of Maui	13-09	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223
+County of Maui	13-09	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	13-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	13-09	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+County of Maui	13-09	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
+County of Maui	13-09	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	13-09	US Representative	2	D	"HIRONO, Mazie"	0	0	155	155
+County of Maui	13-09	US Representative	2	R	"EVANS, Roger B."	0	0	20	20
+County of Maui	13-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	13-09	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
+County of Maui	13-09	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	150	150
+County of Maui	13-09	State Representative	13	D	"CARROLL, Mele"	0	0	124	124
+County of Maui	13-10	Straight Party			DEMOCRATIC PARTY (D)	0	0	25	25
+County of Maui	13-10	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	13-10	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	13-10	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	13-10	Straight Party			REPUBLICAN PARTY (R)	0	0	9	9
+County of Maui	13-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	13-10	US Representative	2	D	"HIRONO, Mazie"	0	0	18	18
+County of Maui	13-10	US Representative	2	R	"EVANS, Roger B."	0	0	9	9
+County of Maui	13-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	13-10	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
+County of Maui	13-10	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	17	17
+County of Maui	13-10	State Representative	13	D	"CARROLL, Mele"	0	0	16	16
+County of Maui	13-11	Straight Party			DEMOCRATIC PARTY (D)	0	0	172	172
+County of Maui	13-11	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	13-11	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Maui	13-11	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	13-11	Straight Party			REPUBLICAN PARTY (R)	0	0	12	12
+County of Maui	13-11	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	13-11	US Representative	2	D	"HIRONO, Mazie"	0	0	109	109
+County of Maui	13-11	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
+County of Maui	13-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Maui	13-11	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
+County of Maui	13-11	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	116	116
+County of Maui	13-11	State Representative	13	D	"CARROLL, Mele"	0	0	103	103
+County of Maui	13-12	Straight Party			DEMOCRATIC PARTY (D)	0	0	0	0
+County of Maui	13-12	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Maui	13-12	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Maui	13-12	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Maui	13-12	Straight Party			REPUBLICAN PARTY (R)	0	0	0	0
+County of Maui	13-12	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Maui	13-12	US Representative	2	D	"HIRONO, Mazie"	0	0	0	0
+County of Maui	13-12	US Representative	2	R	"EVANS, Roger B."	0	0	0	0
+County of Maui	13-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Maui	13-12	State Senate	6	I	"BLUMER-BUELL, John"	0	0	0	0
+County of Maui	13-12	State Senate	6	D	"ENGLISH, J. Kalani"	0	0	0	0
+County of Maui	13-12	State Representative	13	D	"CARROLL, Mele"	0	0	0	0
+County of Kauai	14-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	442	442
+County of Kauai	14-01	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
+County of Kauai	14-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+County of Kauai	14-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Kauai	14-01	Straight Party			REPUBLICAN PARTY (R)	0	0	134	134
+County of Kauai	14-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+County of Kauai	14-01	US Representative	2	D	"HIRONO, Mazie"	0	0	232	232
+County of Kauai	14-01	US Representative	2	R	"EVANS, Roger B."	0	0	82	82
+County of Kauai	14-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
+County of Kauai	14-01	State Senate	7	D	"HOOSER, Gary L."	0	0	324	324
+County of Kauai	14-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	101	101
+County of Kauai	14-01	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	323	323
+County of Kauai	14-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	525	525
+County of Kauai	14-02	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14
+County of Kauai	14-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Kauai	14-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
+County of Kauai	14-02	Straight Party			REPUBLICAN PARTY (R)	0	0	88	88
+County of Kauai	14-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
+County of Kauai	14-02	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305
+County of Kauai	14-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54
+County of Kauai	14-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Kauai	14-02	State Senate	7	D	"HOOSER, Gary L."	0	0	390	390
+County of Kauai	14-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	61	61
+County of Kauai	14-02	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	355	355
+County of Kauai	14-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	321	321
+County of Kauai	14-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+County of Kauai	14-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Kauai	14-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Kauai	14-03	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43
+County of Kauai	14-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Kauai	14-03	US Representative	2	D	"HIRONO, Mazie"	0	0	149	149
+County of Kauai	14-03	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
+County of Kauai	14-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Kauai	14-03	State Senate	7	D	"HOOSER, Gary L."	0	0	197	197
+County of Kauai	14-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	27	27
+County of Kauai	14-03	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	173	173
+County of Kauai	14-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	1079	1079
+County of Kauai	14-04	Straight Party			INDEPENDENT PARTY (I)	0	0	19	19
+County of Kauai	14-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Kauai	14-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
+County of Kauai	14-04	Straight Party			REPUBLICAN PARTY (R)	0	0	180	180
+County of Kauai	14-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	13	13
+County of Kauai	14-04	US Representative	2	D	"HIRONO, Mazie"	0	0	595	595
+County of Kauai	14-04	US Representative	2	R	"EVANS, Roger B."	0	0	100	100
+County of Kauai	14-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Kauai	14-04	State Senate	7	D	"HOOSER, Gary L."	0	0	773	773
+County of Kauai	14-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	117	117
+County of Kauai	14-04	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	539	539
+County of Kauai	14-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311
+County of Kauai	14-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+County of Kauai	14-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Kauai	14-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+County of Kauai	14-05	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53
+County of Kauai	14-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+County of Kauai	14-05	US Representative	2	D	"HIRONO, Mazie"	0	0	161	161
+County of Kauai	14-05	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
+County of Kauai	14-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Kauai	14-05	State Senate	7	D	"HOOSER, Gary L."	0	0	202	202
+County of Kauai	14-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	43	43
+County of Kauai	14-05	State Representative	14	D	"MORITA, Hermina (Mina)"	0	0	140	140
+County of Kauai	15-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	722	722
+County of Kauai	15-01	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
+County of Kauai	15-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Kauai	15-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Kauai	15-01	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136
+County of Kauai	15-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8
+County of Kauai	15-01	US Representative	2	D	"HIRONO, Mazie"	0	0	405	405
+County of Kauai	15-01	US Representative	2	R	"EVANS, Roger B."	0	0	74	74
+County of Kauai	15-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Kauai	15-01	State Senate	7	D	"HOOSER, Gary L."	0	0	529	529
+County of Kauai	15-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	96	96
+County of Kauai	15-01	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	366	366
+County of Kauai	15-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	463	463
+County of Kauai	15-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Kauai	15-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Kauai	15-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Kauai	15-02	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
+County of Kauai	15-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Kauai	15-02	US Representative	2	D	"HIRONO, Mazie"	0	0	298	298
+County of Kauai	15-02	US Representative	2	R	"EVANS, Roger B."	0	0	21	21
+County of Kauai	15-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Kauai	15-02	State Senate	7	D	"HOOSER, Gary L."	0	0	270	270
+County of Kauai	15-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	24	24
+County of Kauai	15-02	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	244	244
+County of Kauai	15-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	537	537
+County of Kauai	15-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+County of Kauai	15-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+County of Kauai	15-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Kauai	15-03	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
+County of Kauai	15-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+County of Kauai	15-03	US Representative	2	D	"HIRONO, Mazie"	0	0	327	327
+County of Kauai	15-03	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
+County of Kauai	15-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+County of Kauai	15-03	State Senate	7	D	"HOOSER, Gary L."	0	0	323	323
+County of Kauai	15-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	56	56
+County of Kauai	15-03	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	302	302
+County of Kauai	15-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	624	624
+County of Kauai	15-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
+County of Kauai	15-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
+County of Kauai	15-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
+County of Kauai	15-04	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101
+County of Kauai	15-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+County of Kauai	15-04	US Representative	2	D	"HIRONO, Mazie"	0	0	373	373
+County of Kauai	15-04	US Representative	2	R	"EVANS, Roger B."	0	0	60	60
+County of Kauai	15-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	6	6
+County of Kauai	15-04	State Senate	7	D	"HOOSER, Gary L."	0	0	399	399
+County of Kauai	15-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	71	71
+County of Kauai	15-04	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	364	364
+County of Kauai	15-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	257	257
+County of Kauai	15-05	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
+County of Kauai	15-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Kauai	15-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+County of Kauai	15-05	Straight Party			REPUBLICAN PARTY (R)	0	0	50	50
+County of Kauai	15-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+County of Kauai	15-05	US Representative	2	D	"HIRONO, Mazie"	0	0	137	137
+County of Kauai	15-05	US Representative	2	R	"EVANS, Roger B."	0	0	23	23
+County of Kauai	15-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Kauai	15-05	State Senate	7	D	"HOOSER, Gary L."	0	0	169	169
+County of Kauai	15-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	33	33
+County of Kauai	15-05	State Representative	15	D	"TOKIOKA, James Kunane"	0	0	107	107
+County of Kauai	16-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	385	385
+County of Kauai	16-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Kauai	16-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+County of Kauai	16-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+County of Kauai	16-01	Straight Party			REPUBLICAN PARTY (R)	0	0	85	85
+County of Kauai	16-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+County of Kauai	16-01	US Representative	2	D	"HIRONO, Mazie"	0	0	245	245
+County of Kauai	16-01	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
+County of Kauai	16-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Kauai	16-01	State Senate	7	D	"HOOSER, Gary L."	0	0	253	253
+County of Kauai	16-01	State Senate	7	R	"GEORGI, JoAnne S."	0	0	60	60
+County of Kauai	16-01	State Representative	16	D	"SAGUM, Roland D., III"	0	0	181	181
+County of Kauai	16-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	807	807
+County of Kauai	16-02	Straight Party			INDEPENDENT PARTY (I)	0	0	13	13
+County of Kauai	16-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+County of Kauai	16-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+County of Kauai	16-02	Straight Party			REPUBLICAN PARTY (R)	0	0	165	165
+County of Kauai	16-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	12	12
+County of Kauai	16-02	US Representative	2	D	"HIRONO, Mazie"	0	0	448	448
+County of Kauai	16-02	US Representative	2	R	"EVANS, Roger B."	0	0	90	90
+County of Kauai	16-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+County of Kauai	16-02	State Senate	7	D	"HOOSER, Gary L."	0	0	549	549
+County of Kauai	16-02	State Senate	7	R	"GEORGI, JoAnne S."	0	0	128	128
+County of Kauai	16-02	State Representative	16	D	"SAGUM, Roland D., III"	0	0	349	349
+County of Kauai	16-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	590	590
+County of Kauai	16-03	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
+County of Kauai	16-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Kauai	16-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13
+County of Kauai	16-03	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
+County of Kauai	16-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8
+County of Kauai	16-03	US Representative	2	D	"HIRONO, Mazie"	0	0	377	377
+County of Kauai	16-03	US Representative	2	R	"EVANS, Roger B."	0	0	31	31
+County of Kauai	16-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Kauai	16-03	State Senate	7	D	"HOOSER, Gary L."	0	0	372	372
+County of Kauai	16-03	State Senate	7	R	"GEORGI, JoAnne S."	0	0	64	64
+County of Kauai	16-03	State Representative	16	D	"SAGUM, Roland D., III"	0	0	285	285
+County of Kauai	16-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	79	79
+County of Kauai	16-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+County of Kauai	16-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Kauai	16-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Kauai	16-04	Straight Party			REPUBLICAN PARTY (R)	0	0	4	4
+County of Kauai	16-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+County of Kauai	16-04	US Representative	2	D	"HIRONO, Mazie"	0	0	52	52
+County of Kauai	16-04	US Representative	2	R	"EVANS, Roger B."	0	0	3	3
+County of Kauai	16-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Kauai	16-04	State Senate	7	D	"HOOSER, Gary L."	0	0	45	45
+County of Kauai	16-04	State Senate	7	R	"GEORGI, JoAnne S."	0	0	2	2
+County of Kauai	16-04	State Representative	16	D	"SAGUM, Roland D., III"	0	0	43	43
+County of Kauai	16-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	373	373
+County of Kauai	16-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+County of Kauai	16-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+County of Kauai	16-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+County of Kauai	16-05	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42
+County of Kauai	16-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+County of Kauai	16-05	US Representative	2	D	"HIRONO, Mazie"	0	0	256	256
+County of Kauai	16-05	US Representative	2	R	"EVANS, Roger B."	0	0	25	25
+County of Kauai	16-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+County of Kauai	16-05	State Senate	7	D	"HOOSER, Gary L."	0	0	203	203
+County of Kauai	16-05	State Senate	7	R	"GEORGI, JoAnne S."	0	0	32	32
+County of Kauai	16-05	State Representative	16	D	"SAGUM, Roland D., III"	0	0	203	203
+County of Kauai	16-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	484	484
+County of Kauai	16-06	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
+County of Kauai	16-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+County of Kauai	16-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13
+County of Kauai	16-06	Straight Party			REPUBLICAN PARTY (R)	0	0	68	68
+County of Kauai	16-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	9	9
+County of Kauai	16-06	US Representative	2	D	"HIRONO, Mazie"	0	0	306	306
+County of Kauai	16-06	US Representative	2	R	"EVANS, Roger B."	0	0	36	36
+County of Kauai	16-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+County of Kauai	16-06	State Senate	7	D	"HOOSER, Gary L."	0	0	276	276
+County of Kauai	16-06	State Senate	7	R	"GEORGI, JoAnne S."	0	0	51	51
+County of Kauai	16-06	State Representative	16	D	"SAGUM, Roland D., III"	0	0	240	240
+County of Kauai	16-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	24	24
+County of Kauai	16-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+County of Kauai	16-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+County of Kauai	16-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+County of Kauai	16-07	Straight Party			REPUBLICAN PARTY (R)	0	0	6	6
+County of Kauai	16-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+County of Kauai	16-07	US Representative	2	D	"HIRONO, Mazie"	0	0	6	6
+County of Kauai	16-07	US Representative	2	R	"EVANS, Roger B."	0	0	2	2
+County of Kauai	16-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+County of Kauai	16-07	State Senate	7	D	"HOOSER, Gary L."	0	0	17	17
+County of Kauai	16-07	State Senate	7	R	"GEORGI, JoAnne S."	0	0	4	4
+County of Kauai	16-07	State Representative	16	D	"SAGUM, Roland D., III"	0	0	1	1
+City & County of Honolulu	17-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	433	433
+City & County of Honolulu	17-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	17-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	17-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	17-01	Straight Party			REPUBLICAN PARTY (R)	0	0	167	167
+City & County of Honolulu	17-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	334	334
+City & County of Honolulu	17-01	US Representative	1	R	"TATAII, Steve"	0	0	60	60
+City & County of Honolulu	17-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	17-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	17-01	State Representative	17	D	"MONK, Amy Yukiko"	0	0	281	281
+City & County of Honolulu	17-01	State Representative	17	R	"WARD, Gene"	0	0	153	153
+City & County of Honolulu	17-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317
+City & County of Honolulu	17-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	17-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	17-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	17-02	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
+City & County of Honolulu	17-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	236	236
+City & County of Honolulu	17-02	US Representative	1	R	"TATAII, Steve"	0	0	22	22
+City & County of Honolulu	17-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	17-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	17-02	State Representative	17	D	"MONK, Amy Yukiko"	0	0	191	191
+City & County of Honolulu	17-02	State Representative	17	R	"WARD, Gene"	0	0	79	79
+City & County of Honolulu	17-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	391	391
+City & County of Honolulu	17-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	17-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
+City & County of Honolulu	17-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	17-03	Straight Party			REPUBLICAN PARTY (R)	0	0	292	292
+City & County of Honolulu	17-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	273	273
+City & County of Honolulu	17-03	US Representative	1	R	"TATAII, Steve"	0	0	94	94
+City & County of Honolulu	17-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
+City & County of Honolulu	17-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	17-03	State Representative	17	D	"MONK, Amy Yukiko"	0	0	251	251
+City & County of Honolulu	17-03	State Representative	17	R	"WARD, Gene"	0	0	272	272
+City & County of Honolulu	17-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	168	168
+City & County of Honolulu	17-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	17-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	17-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	17-04	Straight Party			REPUBLICAN PARTY (R)	0	0	132	132
+City & County of Honolulu	17-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	130	130
+City & County of Honolulu	17-04	US Representative	1	R	"TATAII, Steve"	0	0	62	62
+City & County of Honolulu	17-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	17-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	17-04	State Representative	17	D	"MONK, Amy Yukiko"	0	0	120	120
+City & County of Honolulu	17-04	State Representative	17	R	"WARD, Gene"	0	0	130	130
+City & County of Honolulu	17-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	459	459
+City & County of Honolulu	17-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	17-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	17-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
+City & County of Honolulu	17-05	Straight Party			REPUBLICAN PARTY (R)	0	0	282	282
+City & County of Honolulu	17-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	359	359
+City & County of Honolulu	17-05	US Representative	1	R	"TATAII, Steve"	0	0	82	82
+City & County of Honolulu	17-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	17-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	17-05	State Representative	17	D	"MONK, Amy Yukiko"	0	0	264	264
+City & County of Honolulu	17-05	State Representative	17	R	"WARD, Gene"	0	0	274	274
+City & County of Honolulu	17-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	350	350
+City & County of Honolulu	17-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	17-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	17-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	17-06	Straight Party			REPUBLICAN PARTY (R)	0	0	151	151
+City & County of Honolulu	17-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	258	258
+City & County of Honolulu	17-06	US Representative	1	R	"TATAII, Steve"	0	0	34	34
+City & County of Honolulu	17-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	17-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	17-06	State Representative	17	D	"MONK, Amy Yukiko"	0	0	235	235
+City & County of Honolulu	17-06	State Representative	17	R	"WARD, Gene"	0	0	146	146
+City & County of Honolulu	17-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	494	494
+City & County of Honolulu	17-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	17-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	17-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	17-07	Straight Party			REPUBLICAN PARTY (R)	0	0	243	243
+City & County of Honolulu	17-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	382	382
+City & County of Honolulu	17-07	US Representative	1	R	"TATAII, Steve"	0	0	74	74
+City & County of Honolulu	17-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	17-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	17-07	State Representative	17	D	"MONK, Amy Yukiko"	0	0	332	332
+City & County of Honolulu	17-07	State Representative	17	R	"WARD, Gene"	0	0	236	236
+City & County of Honolulu	18-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	156	156
+City & County of Honolulu	18-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	18-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	18-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	18-01	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
+City & County of Honolulu	18-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	120	120
+City & County of Honolulu	18-01	US Representative	1	R	"TATAII, Steve"	0	0	51	51
+City & County of Honolulu	18-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	18-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	18-01	State Representative	18	D	"BERG, Lyla B."	0	0	112	112
+City & County of Honolulu	18-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	420	420
+City & County of Honolulu	18-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	18-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
+City & County of Honolulu	18-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
+City & County of Honolulu	18-02	Straight Party			REPUBLICAN PARTY (R)	0	0	133	133
+City & County of Honolulu	18-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	316	316
+City & County of Honolulu	18-02	US Representative	1	R	"TATAII, Steve"	0	0	121	121
+City & County of Honolulu	18-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5
+City & County of Honolulu	18-02	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	18-02	State Representative	18	D	"BERG, Lyla B."	0	0	277	277
+City & County of Honolulu	18-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	346	346
+City & County of Honolulu	18-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	18-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	18-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	18-03	Straight Party			REPUBLICAN PARTY (R)	0	0	98	98
+City & County of Honolulu	18-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	254	254
+City & County of Honolulu	18-03	US Representative	1	R	"TATAII, Steve"	0	0	87	87
+City & County of Honolulu	18-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	18-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	18-03	State Representative	18	D	"BERG, Lyla B."	0	0	241	241
+City & County of Honolulu	18-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427
+City & County of Honolulu	18-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	18-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+City & County of Honolulu	18-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
+City & County of Honolulu	18-04	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112
+City & County of Honolulu	18-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	308	308
+City & County of Honolulu	18-04	US Representative	1	R	"TATAII, Steve"	0	0	91	91
+City & County of Honolulu	18-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
+City & County of Honolulu	18-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	18-04	State Representative	18	D	"BERG, Lyla B."	0	0	325	325
+City & County of Honolulu	18-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	542	542
+City & County of Honolulu	18-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	18-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
+City & County of Honolulu	18-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	18-05	Straight Party			REPUBLICAN PARTY (R)	0	0	156	156
+City & County of Honolulu	18-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	414	414
+City & County of Honolulu	18-05	US Representative	1	R	"TATAII, Steve"	0	0	146	146
+City & County of Honolulu	18-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	18-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	18-05	State Representative	18	D	"BERG, Lyla B."	0	0	368	368
+City & County of Honolulu	18-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	321	321
+City & County of Honolulu	18-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	18-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
+City & County of Honolulu	18-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	18-06	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48
+City & County of Honolulu	18-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	236	236
+City & County of Honolulu	18-06	US Representative	1	R	"TATAII, Steve"	0	0	42	42
+City & County of Honolulu	18-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	18-06	US Representative	1	L	"ZHAO, Li"	0	0	5	5
+City & County of Honolulu	18-06	State Representative	18	D	"BERG, Lyla B."	0	0	230	230
+City & County of Honolulu	18-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	570	570
+City & County of Honolulu	18-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	18-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
+City & County of Honolulu	18-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	18-07	Straight Party			REPUBLICAN PARTY (R)	0	0	146	146
+City & County of Honolulu	18-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	417	417
+City & County of Honolulu	18-07	US Representative	1	R	"TATAII, Steve"	0	0	130	130
+City & County of Honolulu	18-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	18-07	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	18-07	State Representative	18	D	"BERG, Lyla B."	0	0	356	356
+City & County of Honolulu	19-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	430	430
+City & County of Honolulu	19-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	19-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	19-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	19-01	Straight Party			REPUBLICAN PARTY (R)	0	0	301	301
+City & County of Honolulu	19-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	321	321
+City & County of Honolulu	19-01	US Representative	1	R	"TATAII, Steve"	0	0	101	101
+City & County of Honolulu	19-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	19-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	19-01	State Representative	19	D	"ABE, Michael (Mike)"	0	0	248	248
+City & County of Honolulu	19-01	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	282	282
+City & County of Honolulu	19-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	466	466
+City & County of Honolulu	19-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	19-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	19-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	19-02	Straight Party			REPUBLICAN PARTY (R)	0	0	178	178
+City & County of Honolulu	19-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	363	363
+City & County of Honolulu	19-02	US Representative	1	R	"TATAII, Steve"	0	0	63	63
+City & County of Honolulu	19-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	19-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	19-02	State Representative	19	D	"ABE, Michael (Mike)"	0	0	251	251
+City & County of Honolulu	19-02	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	170	170
+City & County of Honolulu	19-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	355	355
+City & County of Honolulu	19-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	19-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	19-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	19-03	Straight Party			REPUBLICAN PARTY (R)	0	0	120	120
+City & County of Honolulu	19-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	268	268
+City & County of Honolulu	19-03	US Representative	1	R	"TATAII, Steve"	0	0	33	33
+City & County of Honolulu	19-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	19-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	19-03	State Representative	19	D	"ABE, Michael (Mike)"	0	0	203	203
+City & County of Honolulu	19-03	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	112	112
+City & County of Honolulu	19-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	603	603
+City & County of Honolulu	19-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	19-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	19-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	19-04	Straight Party			REPUBLICAN PARTY (R)	0	0	218	218
+City & County of Honolulu	19-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	474	474
+City & County of Honolulu	19-04	US Representative	1	R	"TATAII, Steve"	0	0	68	68
+City & County of Honolulu	19-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	19-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	19-04	State Representative	19	D	"ABE, Michael (Mike)"	0	0	332	332
+City & County of Honolulu	19-04	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	209	209
+City & County of Honolulu	19-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	363	363
+City & County of Honolulu	19-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	19-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	19-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	19-05	Straight Party			REPUBLICAN PARTY (R)	0	0	205	205
+City & County of Honolulu	19-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	281	281
+City & County of Honolulu	19-05	US Representative	1	R	"TATAII, Steve"	0	0	56	56
+City & County of Honolulu	19-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	19-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	19-05	State Representative	19	D	"ABE, Michael (Mike)"	0	0	192	192
+City & County of Honolulu	19-05	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	192	192
+City & County of Honolulu	19-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	326	326
+City & County of Honolulu	19-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	19-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	19-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	19-06	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
+City & County of Honolulu	19-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	257	257
+City & County of Honolulu	19-06	US Representative	1	R	"TATAII, Steve"	0	0	28	28
+City & County of Honolulu	19-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	19-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	19-06	State Representative	19	D	"ABE, Michael (Mike)"	0	0	195	195
+City & County of Honolulu	19-06	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	71	71
+City & County of Honolulu	19-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	233	233
+City & County of Honolulu	19-07	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	19-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	19-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	19-07	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
+City & County of Honolulu	19-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	194	194
+City & County of Honolulu	19-07	US Representative	1	R	"TATAII, Steve"	0	0	22	22
+City & County of Honolulu	19-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	19-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	19-07	State Representative	19	D	"ABE, Michael (Mike)"	0	0	141	141
+City & County of Honolulu	19-07	State Representative	19	R	"MARUMOTO, Barbara C."	0	0	59	59
+City & County of Honolulu	20-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	332	332
+City & County of Honolulu	20-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	20-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	20-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	20-01	Straight Party			REPUBLICAN PARTY (R)	0	0	47	47
+City & County of Honolulu	20-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	271	271
+City & County of Honolulu	20-01	US Representative	1	R	"TATAII, Steve"	0	0	26	26
+City & County of Honolulu	20-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	20-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	20-01	State Representative	20	D	"SAY, Calvin K. Y."	0	0	272	272
+City & County of Honolulu	20-01	State Representative	20	R	"ALLEN, Julia E."	0	0	40	40
+City & County of Honolulu	20-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	406	406
+City & County of Honolulu	20-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	20-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	20-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	20-02	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
+City & County of Honolulu	20-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	307	307
+City & County of Honolulu	20-02	US Representative	1	R	"TATAII, Steve"	0	0	51	51
+City & County of Honolulu	20-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	20-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	20-02	State Representative	20	D	"SAY, Calvin K. Y."	0	0	344	344
+City & County of Honolulu	20-02	State Representative	20	R	"ALLEN, Julia E."	0	0	64	64
+City & County of Honolulu	20-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	284	284
+City & County of Honolulu	20-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	20-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	20-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	20-03	Straight Party			REPUBLICAN PARTY (R)	0	0	72	72
+City & County of Honolulu	20-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	212	212
+City & County of Honolulu	20-03	US Representative	1	R	"TATAII, Steve"	0	0	40	40
+City & County of Honolulu	20-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	20-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	20-03	State Representative	20	D	"SAY, Calvin K. Y."	0	0	197	197
+City & County of Honolulu	20-03	State Representative	20	R	"ALLEN, Julia E."	0	0	57	57
+City & County of Honolulu	20-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421
+City & County of Honolulu	20-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	20-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
+City & County of Honolulu	20-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	20-04	Straight Party			REPUBLICAN PARTY (R)	0	0	86	86
+City & County of Honolulu	20-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	346	346
+City & County of Honolulu	20-04	US Representative	1	R	"TATAII, Steve"	0	0	53	53
+City & County of Honolulu	20-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	20-04	US Representative	1	L	"ZHAO, Li"	0	0	6	6
+City & County of Honolulu	20-04	State Representative	20	D	"SAY, Calvin K. Y."	0	0	295	295
+City & County of Honolulu	20-04	State Representative	20	R	"ALLEN, Julia E."	0	0	68	68
+City & County of Honolulu	20-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	646	646
+City & County of Honolulu	20-05	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14
+City & County of Honolulu	20-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+City & County of Honolulu	20-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
+City & County of Honolulu	20-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
+City & County of Honolulu	20-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	483	483
+City & County of Honolulu	20-05	US Representative	1	R	"TATAII, Steve"	0	0	42	42
+City & County of Honolulu	20-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	20-05	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	20-05	State Representative	20	D	"SAY, Calvin K. Y."	0	0	561	561
+City & County of Honolulu	20-05	State Representative	20	R	"ALLEN, Julia E."	0	0	67	67
+City & County of Honolulu	20-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	569	569
+City & County of Honolulu	20-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	20-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	20-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	20-06	Straight Party			REPUBLICAN PARTY (R)	0	0	114	114
+City & County of Honolulu	20-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	426	426
+City & County of Honolulu	20-06	US Representative	1	R	"TATAII, Steve"	0	0	65	65
+City & County of Honolulu	20-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	20-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	20-06	State Representative	20	D	"SAY, Calvin K. Y."	0	0	463	463
+City & County of Honolulu	20-06	State Representative	20	R	"ALLEN, Julia E."	0	0	99	99
+City & County of Honolulu	21-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	353	353
+City & County of Honolulu	21-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	21-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	21-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	21-01	Straight Party			REPUBLICAN PARTY (R)	0	0	44	44
+City & County of Honolulu	21-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	255	255
+City & County of Honolulu	21-01	US Representative	1	R	"TATAII, Steve"	0	0	38	38
+City & County of Honolulu	21-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	21-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	21-01	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	264	264
+City & County of Honolulu	21-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	645	645
+City & County of Honolulu	21-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	21-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	21-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
+City & County of Honolulu	21-02	Straight Party			REPUBLICAN PARTY (R)	0	0	87	87
+City & County of Honolulu	21-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	472	472
+City & County of Honolulu	21-02	US Representative	1	R	"TATAII, Steve"	0	0	78	78
+City & County of Honolulu	21-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	21-02	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	21-02	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	515	515
+City & County of Honolulu	21-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	483	483
+City & County of Honolulu	21-03	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
+City & County of Honolulu	21-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
+City & County of Honolulu	21-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	14	14
+City & County of Honolulu	21-03	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
+City & County of Honolulu	21-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	383	383
+City & County of Honolulu	21-03	US Representative	1	R	"TATAII, Steve"	0	0	98	98
+City & County of Honolulu	21-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	21-03	US Representative	1	L	"ZHAO, Li"	0	0	8	8
+City & County of Honolulu	21-03	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	322	322
+City & County of Honolulu	21-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	265	265
+City & County of Honolulu	21-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	21-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	21-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	21-04	Straight Party			REPUBLICAN PARTY (R)	0	0	98	98
+City & County of Honolulu	21-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	192	192
+City & County of Honolulu	21-04	US Representative	1	R	"TATAII, Steve"	0	0	92	92
+City & County of Honolulu	21-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
+City & County of Honolulu	21-04	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	21-04	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	184	184
+City & County of Honolulu	21-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267
+City & County of Honolulu	21-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	21-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	21-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	21-05	Straight Party			REPUBLICAN PARTY (R)	0	0	99	99
+City & County of Honolulu	21-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	216	216
+City & County of Honolulu	21-05	US Representative	1	R	"TATAII, Steve"	0	0	54	54
+City & County of Honolulu	21-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	21-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	21-05	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	134	134
+City & County of Honolulu	21-05	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	50	50
+City & County of Honolulu	21-05	State Senate	12	R	"TRIMBLE, Gordon"	0	0	92	92
+City & County of Honolulu	21-05	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	171	171
+City & County of Honolulu	21-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	252	252
+City & County of Honolulu	21-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	21-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	21-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	21-06	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
+City & County of Honolulu	21-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	191	191
+City & County of Honolulu	21-06	US Representative	1	R	"TATAII, Steve"	0	0	18	18
+City & County of Honolulu	21-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	21-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	21-06	State Representative	21	D	"NISHIMOTO, Scott Y."	0	0	187	187
+City & County of Honolulu	22-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	120	120
+City & County of Honolulu	22-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	22-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	22-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	22-01	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
+City & County of Honolulu	22-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	91	91
+City & County of Honolulu	22-01	US Representative	1	R	"TATAII, Steve"	0	0	17	17
+City & County of Honolulu	22-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	22-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	22-01	State Representative	22	D	"SAIKI, Scott K."	0	0	81	81
+City & County of Honolulu	22-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236
+City & County of Honolulu	22-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	22-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	22-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	22-02	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
+City & County of Honolulu	22-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	203	203
+City & County of Honolulu	22-02	US Representative	1	R	"TATAII, Steve"	0	0	25	25
+City & County of Honolulu	22-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	22-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	22-02	State Representative	22	D	"SAIKI, Scott K."	0	0	169	169
+City & County of Honolulu	22-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	100	100
+City & County of Honolulu	22-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	22-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	22-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	22-03	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14
+City & County of Honolulu	22-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	81	81
+City & County of Honolulu	22-03	US Representative	1	R	"TATAII, Steve"	0	0	11	11
+City & County of Honolulu	22-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	22-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	22-03	State Representative	22	D	"SAIKI, Scott K."	0	0	58	58
+City & County of Honolulu	22-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293
+City & County of Honolulu	22-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	22-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+City & County of Honolulu	22-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	22-04	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
+City & County of Honolulu	22-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	225	225
+City & County of Honolulu	22-04	US Representative	1	R	"TATAII, Steve"	0	0	42	42
+City & County of Honolulu	22-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
+City & County of Honolulu	22-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	22-04	State Representative	22	D	"SAIKI, Scott K."	0	0	220	220
+City & County of Honolulu	22-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	292	292
+City & County of Honolulu	22-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	22-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
+City & County of Honolulu	22-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	22-05	Straight Party			REPUBLICAN PARTY (R)	0	0	43	43
+City & County of Honolulu	22-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	226	226
+City & County of Honolulu	22-05	US Representative	1	R	"TATAII, Steve"	0	0	40	40
+City & County of Honolulu	22-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5
+City & County of Honolulu	22-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	22-05	State Representative	22	D	"SAIKI, Scott K."	0	0	214	214
+City & County of Honolulu	22-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	374	374
+City & County of Honolulu	22-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	22-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	22-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	22-06	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48
+City & County of Honolulu	22-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	283	283
+City & County of Honolulu	22-06	US Representative	1	R	"TATAII, Steve"	0	0	41	41
+City & County of Honolulu	22-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	22-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	22-06	State Representative	22	D	"SAIKI, Scott K."	0	0	243	243
+City & County of Honolulu	22-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	279	279
+City & County of Honolulu	22-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	22-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	22-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	22-07	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75
+City & County of Honolulu	22-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	222	222
+City & County of Honolulu	22-07	US Representative	1	R	"TATAII, Steve"	0	0	67	67
+City & County of Honolulu	22-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	22-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	22-07	State Representative	22	D	"SAIKI, Scott K."	0	0	175	175
+City & County of Honolulu	23-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
+City & County of Honolulu	23-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	23-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	23-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	23-01	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
+City & County of Honolulu	23-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	150	150
+City & County of Honolulu	23-01	US Representative	1	R	"TATAII, Steve"	0	0	45	45
+City & County of Honolulu	23-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	23-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	23-01	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	96	96
+City & County of Honolulu	23-01	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	35	35
+City & County of Honolulu	23-01	State Senate	12	R	"TRIMBLE, Gordon"	0	0	63	63
+City & County of Honolulu	23-01	State Representative	23	D	"BROWER, Tom"	0	0	115	115
+City & County of Honolulu	23-01	State Representative	23	R	"STEVENS, Anne V."	0	0	61	61
+City & County of Honolulu	23-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200
+City & County of Honolulu	23-02	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	23-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	23-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	23-02	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
+City & County of Honolulu	23-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	152	152
+City & County of Honolulu	23-02	US Representative	1	R	"TATAII, Steve"	0	0	59	59
+City & County of Honolulu	23-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	23-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	23-02	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	109	109
+City & County of Honolulu	23-02	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	40	40
+City & County of Honolulu	23-02	State Senate	12	R	"TRIMBLE, Gordon"	0	0	77	77
+City & County of Honolulu	23-02	State Representative	23	D	"BROWER, Tom"	0	0	133	133
+City & County of Honolulu	23-02	State Representative	23	R	"STEVENS, Anne V."	0	0	77	77
+City & County of Honolulu	23-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	352	352
+City & County of Honolulu	23-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	23-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	23-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	23-03	Straight Party			REPUBLICAN PARTY (R)	0	0	185	185
+City & County of Honolulu	23-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	289	289
+City & County of Honolulu	23-03	US Representative	1	R	"TATAII, Steve"	0	0	99	99
+City & County of Honolulu	23-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	23-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	23-03	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	202	202
+City & County of Honolulu	23-03	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	62	62
+City & County of Honolulu	23-03	State Senate	12	R	"TRIMBLE, Gordon"	0	0	131	131
+City & County of Honolulu	23-03	State Representative	23	D	"BROWER, Tom"	0	0	244	244
+City & County of Honolulu	23-03	State Representative	23	R	"STEVENS, Anne V."	0	0	147	147
+City & County of Honolulu	23-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	314	314
+City & County of Honolulu	23-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	23-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	23-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	23-04	Straight Party			REPUBLICAN PARTY (R)	0	0	146	146
+City & County of Honolulu	23-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	265	265
+City & County of Honolulu	23-04	US Representative	1	R	"TATAII, Steve"	0	0	68	68
+City & County of Honolulu	23-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	23-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	23-04	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	173	173
+City & County of Honolulu	23-04	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	42	42
+City & County of Honolulu	23-04	State Senate	12	R	"TRIMBLE, Gordon"	0	0	105	105
+City & County of Honolulu	23-04	State Representative	23	D	"BROWER, Tom"	0	0	193	193
+City & County of Honolulu	23-04	State Representative	23	R	"STEVENS, Anne V."	0	0	111	111
+City & County of Honolulu	24-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	753	753
+City & County of Honolulu	24-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	24-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	24-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
+City & County of Honolulu	24-01	Straight Party			REPUBLICAN PARTY (R)	0	0	109	109
+City & County of Honolulu	24-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	558	558
+City & County of Honolulu	24-01	US Representative	1	R	"TATAII, Steve"	0	0	42	42
+City & County of Honolulu	24-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	24-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	24-01	State Representative	24	D	"CHOY, Isaac W."	0	0	476	476
+City & County of Honolulu	24-01	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	101	101
+City & County of Honolulu	24-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	414	414
+City & County of Honolulu	24-02	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	24-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	24-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	24-02	Straight Party			REPUBLICAN PARTY (R)	0	0	76	76
+City & County of Honolulu	24-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	309	309
+City & County of Honolulu	24-02	US Representative	1	R	"TATAII, Steve"	0	0	38	38
+City & County of Honolulu	24-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	24-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	24-02	State Representative	24	D	"CHOY, Isaac W."	0	0	247	247
+City & County of Honolulu	24-02	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	70	70
+City & County of Honolulu	24-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	346	346
+City & County of Honolulu	24-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	24-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	24-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	24-03	Straight Party			REPUBLICAN PARTY (R)	0	0	62	62
+City & County of Honolulu	24-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	280	280
+City & County of Honolulu	24-03	US Representative	1	R	"TATAII, Steve"	0	0	34	34
+City & County of Honolulu	24-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	24-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	24-03	State Representative	24	D	"CHOY, Isaac W."	0	0	169	169
+City & County of Honolulu	24-03	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	51	51
+City & County of Honolulu	24-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	414	414
+City & County of Honolulu	24-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	24-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	14	14
+City & County of Honolulu	24-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	24-04	Straight Party			REPUBLICAN PARTY (R)	0	0	91	91
+City & County of Honolulu	24-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	338	338
+City & County of Honolulu	24-04	US Representative	1	R	"TATAII, Steve"	0	0	44	44
+City & County of Honolulu	24-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	5	5
+City & County of Honolulu	24-04	US Representative	1	L	"ZHAO, Li"	0	0	9	9
+City & County of Honolulu	24-04	State Representative	24	D	"CHOY, Isaac W."	0	0	177	177
+City & County of Honolulu	24-04	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	79	79
+City & County of Honolulu	24-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	565	565
+City & County of Honolulu	24-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	24-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
+City & County of Honolulu	24-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	24-05	Straight Party			REPUBLICAN PARTY (R)	0	0	111	111
+City & County of Honolulu	24-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	422	422
+City & County of Honolulu	24-05	US Representative	1	R	"TATAII, Steve"	0	0	57	57
+City & County of Honolulu	24-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	24-05	US Representative	1	L	"ZHAO, Li"	0	0	6	6
+City & County of Honolulu	24-05	State Representative	24	D	"CHOY, Isaac W."	0	0	337	337
+City & County of Honolulu	24-05	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	93	93
+City & County of Honolulu	24-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	671	671
+City & County of Honolulu	24-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	24-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+City & County of Honolulu	24-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	24-06	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115
+City & County of Honolulu	24-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	502	502
+City & County of Honolulu	24-06	US Representative	1	R	"TATAII, Steve"	0	0	54	54
+City & County of Honolulu	24-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	6	6
+City & County of Honolulu	24-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	24-06	State Representative	24	D	"CHOY, Isaac W."	0	0	409	409
+City & County of Honolulu	24-06	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	0	0	103	103
+City & County of Honolulu	25-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	375	375
+City & County of Honolulu	25-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	25-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	25-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	25-01	Straight Party			REPUBLICAN PARTY (R)	0	0	94	94
+City & County of Honolulu	25-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	279	279
+City & County of Honolulu	25-01	US Representative	1	R	"TATAII, Steve"	0	0	86	86
+City & County of Honolulu	25-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	25-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	25-01	State Representative	25	D	"BELATTI, Della A."	0	0	236	236
+City & County of Honolulu	25-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	377	377
+City & County of Honolulu	25-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	25-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+City & County of Honolulu	25-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	25-02	Straight Party			REPUBLICAN PARTY (R)	0	0	74	74
+City & County of Honolulu	25-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	297	297
+City & County of Honolulu	25-02	US Representative	1	R	"TATAII, Steve"	0	0	64	64
+City & County of Honolulu	25-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	25-02	US Representative	1	L	"ZHAO, Li"	0	0	5	5
+City & County of Honolulu	25-02	State Representative	25	D	"BELATTI, Della A."	0	0	250	250
+City & County of Honolulu	25-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	31	31
+City & County of Honolulu	25-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	25-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	25-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	25-03	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
+City & County of Honolulu	25-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	21	21
+City & County of Honolulu	25-03	US Representative	1	R	"TATAII, Steve"	0	0	7	7
+City & County of Honolulu	25-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	25-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	25-03	State Representative	25	D	"BELATTI, Della A."	0	0	19	19
+City & County of Honolulu	25-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	186	186
+City & County of Honolulu	25-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	25-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	25-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	25-04	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31
+City & County of Honolulu	25-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	147	147
+City & County of Honolulu	25-04	US Representative	1	R	"TATAII, Steve"	0	0	29	29
+City & County of Honolulu	25-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	25-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	25-04	State Representative	25	D	"BELATTI, Della A."	0	0	95	95
+City & County of Honolulu	25-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	394	394
+City & County of Honolulu	25-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	25-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	25-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	25-05	Straight Party			REPUBLICAN PARTY (R)	0	0	88	88
+City & County of Honolulu	25-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	318	318
+City & County of Honolulu	25-05	US Representative	1	R	"TATAII, Steve"	0	0	82	82
+City & County of Honolulu	25-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	25-05	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	25-05	State Representative	25	D	"BELATTI, Della A."	0	0	240	240
+City & County of Honolulu	25-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	316	316
+City & County of Honolulu	25-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	25-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	25-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	25-06	Straight Party			REPUBLICAN PARTY (R)	0	0	65	65
+City & County of Honolulu	25-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	256	256
+City & County of Honolulu	25-06	US Representative	1	R	"TATAII, Steve"	0	0	57	57
+City & County of Honolulu	25-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	25-06	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	25-06	State Representative	25	D	"BELATTI, Della A."	0	0	203	203
+City & County of Honolulu	25-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	285	285
+City & County of Honolulu	25-07	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	25-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	25-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	25-07	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
+City & County of Honolulu	25-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	225	225
+City & County of Honolulu	25-07	US Representative	1	R	"TATAII, Steve"	0	0	51	51
+City & County of Honolulu	25-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	25-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	25-07	State Representative	25	D	"BELATTI, Della A."	0	0	172	172
+City & County of Honolulu	26-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	598	598
+City & County of Honolulu	26-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	26-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
+City & County of Honolulu	26-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	26-01	Straight Party			REPUBLICAN PARTY (R)	0	0	66	66
+City & County of Honolulu	26-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	463	463
+City & County of Honolulu	26-01	US Representative	1	R	"TATAII, Steve"	0	0	55	55
+City & County of Honolulu	26-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	26-01	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	26-01	State Representative	26	D	"LUKE, Sylvia"	0	0	480	480
+City & County of Honolulu	26-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	185	185
+City & County of Honolulu	26-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	26-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	26-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	26-02	Straight Party			REPUBLICAN PARTY (R)	0	0	15	15
+City & County of Honolulu	26-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	153	153
+City & County of Honolulu	26-02	US Representative	1	R	"TATAII, Steve"	0	0	14	14
+City & County of Honolulu	26-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	26-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	26-02	State Representative	26	D	"LUKE, Sylvia"	0	0	128	128
+City & County of Honolulu	26-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	300	300
+City & County of Honolulu	26-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	26-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	26-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
+City & County of Honolulu	26-03	Straight Party			REPUBLICAN PARTY (R)	0	0	68	68
+City & County of Honolulu	26-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	248	248
+City & County of Honolulu	26-03	US Representative	1	R	"TATAII, Steve"	0	0	62	62
+City & County of Honolulu	26-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	26-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	26-03	State Representative	26	D	"LUKE, Sylvia"	0	0	199	199
+City & County of Honolulu	26-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	207	207
+City & County of Honolulu	26-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	26-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	26-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	26-04	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
+City & County of Honolulu	26-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	163	163
+City & County of Honolulu	26-04	US Representative	1	R	"TATAII, Steve"	0	0	48	48
+City & County of Honolulu	26-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	26-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	26-04	State Representative	26	D	"LUKE, Sylvia"	0	0	129	129
+City & County of Honolulu	26-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
+City & County of Honolulu	26-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	26-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	6	6
+City & County of Honolulu	26-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	26-05	Straight Party			REPUBLICAN PARTY (R)	1	0	52	53
+City & County of Honolulu	26-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	252	252
+City & County of Honolulu	26-05	US Representative	1	R	"TATAII, Steve"	1	0	47	48
+City & County of Honolulu	26-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	26-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	26-05	State Representative	26	D	"LUKE, Sylvia"	0	0	220	220
+City & County of Honolulu	26-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	575	575
+City & County of Honolulu	26-06	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	26-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	9	9
+City & County of Honolulu	26-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	17	17
+City & County of Honolulu	26-06	Straight Party			REPUBLICAN PARTY (R)	0	0	126	126
+City & County of Honolulu	26-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	454	454
+City & County of Honolulu	26-06	US Representative	1	R	"TATAII, Steve"	0	0	117	117
+City & County of Honolulu	26-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	26-06	US Representative	1	L	"ZHAO, Li"	0	0	7	7
+City & County of Honolulu	26-06	State Representative	26	D	"LUKE, Sylvia"	0	0	418	418
+City & County of Honolulu	26-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	623	623
+City & County of Honolulu	26-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	26-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
+City & County of Honolulu	26-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	26-07	Straight Party			REPUBLICAN PARTY (R)	0	0	139	139
+City & County of Honolulu	26-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	451	451
+City & County of Honolulu	26-07	US Representative	1	R	"TATAII, Steve"	0	0	125	125
+City & County of Honolulu	26-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	26-07	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	26-07	State Representative	26	D	"LUKE, Sylvia"	0	0	485	485
+City & County of Honolulu	27-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	65	65
+City & County of Honolulu	27-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	27-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	27-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	27-01	Straight Party			REPUBLICAN PARTY (R)	0	0	20	20
+City & County of Honolulu	27-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	55	55
+City & County of Honolulu	27-01	US Representative	1	R	"TATAII, Steve"	0	0	6	6
+City & County of Honolulu	27-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	27-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	27-01	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	34	34
+City & County of Honolulu	27-01	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	19	19
+City & County of Honolulu	27-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	292	292
+City & County of Honolulu	27-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	27-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	27-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	27-02	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59
+City & County of Honolulu	27-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	240	240
+City & County of Honolulu	27-02	US Representative	1	R	"TATAII, Steve"	0	0	27	27
+City & County of Honolulu	27-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	27-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	27-02	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	174	174
+City & County of Honolulu	27-02	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	56	56
+City & County of Honolulu	27-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	668	668
+City & County of Honolulu	27-03	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	27-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	27-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	27-03	Straight Party			REPUBLICAN PARTY (R)	0	0	199	199
+City & County of Honolulu	27-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	540	540
+City & County of Honolulu	27-03	US Representative	1	R	"TATAII, Steve"	0	0	54	54
+City & County of Honolulu	27-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	27-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	27-03	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	406	406
+City & County of Honolulu	27-03	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	189	189
+City & County of Honolulu	27-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	122	122
+City & County of Honolulu	27-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	27-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	27-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	27-04	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35
+City & County of Honolulu	27-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	98	98
+City & County of Honolulu	27-04	US Representative	1	R	"TATAII, Steve"	0	0	11	11
+City & County of Honolulu	27-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	27-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	27-04	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	64	64
+City & County of Honolulu	27-04	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	34	34
+City & County of Honolulu	27-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	231	231
+City & County of Honolulu	27-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	27-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	27-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	27-05	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
+City & County of Honolulu	27-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	203	203
+City & County of Honolulu	27-05	US Representative	1	R	"TATAII, Steve"	0	0	15	15
+City & County of Honolulu	27-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
+City & County of Honolulu	27-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	27-05	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	77	77
+City & County of Honolulu	27-05	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	49	49
+City & County of Honolulu	27-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	348	348
+City & County of Honolulu	27-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	27-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	27-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	27-06	Straight Party			REPUBLICAN PARTY (R)	0	0	93	93
+City & County of Honolulu	27-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	298	298
+City & County of Honolulu	27-06	US Representative	1	R	"TATAII, Steve"	0	0	31	31
+City & County of Honolulu	27-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	27-06	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	27-06	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	161	161
+City & County of Honolulu	27-06	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	89	89
+City & County of Honolulu	27-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	112	112
+City & County of Honolulu	27-07	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	27-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	27-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	27-07	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31
+City & County of Honolulu	27-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	93	93
+City & County of Honolulu	27-07	US Representative	1	R	"TATAII, Steve"	0	0	11	11
+City & County of Honolulu	27-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	27-07	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	27-07	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	37	37
+City & County of Honolulu	27-07	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	27	27
+City & County of Honolulu	27-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	266	266
+City & County of Honolulu	27-08	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	27-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	27-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	27-08	Straight Party			REPUBLICAN PARTY (R)	0	0	84	84
+City & County of Honolulu	27-08	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	223	223
+City & County of Honolulu	27-08	US Representative	1	R	"TATAII, Steve"	0	0	31	31
+City & County of Honolulu	27-08	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	27-08	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	27-08	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	0	0	137	137
+City & County of Honolulu	27-08	State Representative	27	R	"CHING, Corinne Wei Lan"	0	0	79	79
+City & County of Honolulu	28-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	200	200
+City & County of Honolulu	28-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	28-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	28-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	28-01	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
+City & County of Honolulu	28-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	155	155
+City & County of Honolulu	28-01	US Representative	1	R	"TATAII, Steve"	0	0	25	25
+City & County of Honolulu	28-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	28-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	28-01	State Representative	28	D	"RHOADS, Karl"	0	0	118	118
+City & County of Honolulu	28-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	235	235
+City & County of Honolulu	28-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	28-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	28-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	28-02	Straight Party			REPUBLICAN PARTY (R)	0	0	53	53
+City & County of Honolulu	28-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	191	191
+City & County of Honolulu	28-02	US Representative	1	R	"TATAII, Steve"	0	0	50	50
+City & County of Honolulu	28-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
+City & County of Honolulu	28-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	28-02	State Representative	28	D	"RHOADS, Karl"	0	0	101	101
+City & County of Honolulu	28-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	135	135
+City & County of Honolulu	28-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	28-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	28-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	28-03	Straight Party			REPUBLICAN PARTY (R)	0	0	52	52
+City & County of Honolulu	28-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	110	110
+City & County of Honolulu	28-03	US Representative	1	R	"TATAII, Steve"	0	0	29	29
+City & County of Honolulu	28-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	28-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	28-03	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	83	83
+City & County of Honolulu	28-03	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	18	18
+City & County of Honolulu	28-03	State Senate	12	R	"TRIMBLE, Gordon"	0	0	47	47
+City & County of Honolulu	28-03	State Representative	28	D	"RHOADS, Karl"	0	0	83	83
+City & County of Honolulu	28-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	176	176
+City & County of Honolulu	28-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	28-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	28-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	28-04	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
+City & County of Honolulu	28-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	145	145
+City & County of Honolulu	28-04	US Representative	1	R	"TATAII, Steve"	0	0	34	34
+City & County of Honolulu	28-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	28-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	28-04	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	110	110
+City & County of Honolulu	28-04	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	29	29
+City & County of Honolulu	28-04	State Senate	12	R	"TRIMBLE, Gordon"	0	0	40	40
+City & County of Honolulu	28-04	State Representative	28	D	"RHOADS, Karl"	0	0	127	127
+City & County of Honolulu	28-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	521	521
+City & County of Honolulu	28-05	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	28-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
+City & County of Honolulu	28-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
+City & County of Honolulu	28-05	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108
+City & County of Honolulu	28-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	386	386
+City & County of Honolulu	28-05	US Representative	1	R	"TATAII, Steve"	0	0	68	68
+City & County of Honolulu	28-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	28-05	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	28-05	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	293	293
+City & County of Honolulu	28-05	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	85	85
+City & County of Honolulu	28-05	State Senate	12	R	"TRIMBLE, Gordon"	0	0	94	94
+City & County of Honolulu	28-05	State Representative	28	D	"RHOADS, Karl"	0	0	327	327
+City & County of Honolulu	28-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	138	138
+City & County of Honolulu	28-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	28-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	28-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	28-06	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22
+City & County of Honolulu	28-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	115	115
+City & County of Honolulu	28-06	US Representative	1	R	"TATAII, Steve"	0	0	16	16
+City & County of Honolulu	28-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	28-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	28-06	State Senate	12	D	"GALUTERIA, Brickwood M."	0	0	67	67
+City & County of Honolulu	28-06	State Senate	12	D	"MIDDLETON, Carlton N."	0	0	23	23
+City & County of Honolulu	28-06	State Senate	12	R	"TRIMBLE, Gordon"	0	0	17	17
+City & County of Honolulu	28-06	State Representative	28	D	"RHOADS, Karl"	0	0	98	98
+City & County of Honolulu	29-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	360	360
+City & County of Honolulu	29-01	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	29-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	29-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	29-01	Straight Party			REPUBLICAN PARTY (R)	0	0	50	50
+City & County of Honolulu	29-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	265	265
+City & County of Honolulu	29-01	US Representative	1	R	"TATAII, Steve"	0	0	31	31
+City & County of Honolulu	29-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	29-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	29-01	State Representative	29	D	"MANAHAN, Joey"	0	0	252	252
+City & County of Honolulu	29-01	State Representative	29	R	"YAW, Shane D. K."	0	0	34	34
+City & County of Honolulu	29-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	389	389
+City & County of Honolulu	29-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	29-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	29-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	29-02	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
+City & County of Honolulu	29-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	320	320
+City & County of Honolulu	29-02	US Representative	1	R	"TATAII, Steve"	0	0	28	28
+City & County of Honolulu	29-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	29-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	29-02	State Representative	29	D	"MANAHAN, Joey"	0	0	290	290
+City & County of Honolulu	29-02	State Representative	29	R	"YAW, Shane D. K."	0	0	33	33
+City & County of Honolulu	29-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	265	265
+City & County of Honolulu	29-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	29-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	29-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	29-03	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
+City & County of Honolulu	29-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	211	211
+City & County of Honolulu	29-03	US Representative	1	R	"TATAII, Steve"	0	0	13	13
+City & County of Honolulu	29-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	29-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	29-03	State Representative	29	D	"MANAHAN, Joey"	0	0	173	173
+City & County of Honolulu	29-03	State Representative	29	R	"YAW, Shane D. K."	0	0	15	15
+City & County of Honolulu	29-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	129	129
+City & County of Honolulu	29-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	29-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	29-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	29-04	Straight Party			REPUBLICAN PARTY (R)	0	0	32	32
+City & County of Honolulu	29-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	109	109
+City & County of Honolulu	29-04	US Representative	1	R	"TATAII, Steve"	0	0	25	25
+City & County of Honolulu	29-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	29-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	29-04	State Representative	29	D	"MANAHAN, Joey"	0	0	64	64
+City & County of Honolulu	29-04	State Representative	29	R	"YAW, Shane D. K."	0	0	20	20
+City & County of Honolulu	29-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	236	236
+City & County of Honolulu	29-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	29-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	29-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	29-05	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
+City & County of Honolulu	29-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	180	180
+City & County of Honolulu	29-05	US Representative	1	R	"TATAII, Steve"	0	0	10	10
+City & County of Honolulu	29-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	29-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	29-05	State Representative	29	D	"MANAHAN, Joey"	0	0	180	180
+City & County of Honolulu	29-05	State Representative	29	R	"YAW, Shane D. K."	0	0	9	9
+City & County of Honolulu	30-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	395	395
+City & County of Honolulu	30-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	30-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	30-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	30-01	Straight Party			REPUBLICAN PARTY (R)	0	0	70	70
+City & County of Honolulu	30-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	313	313
+City & County of Honolulu	30-01	US Representative	1	R	"TATAII, Steve"	0	0	67	67
+City & County of Honolulu	30-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	30-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	30-01	State Representative	30	D	"MIZUNO, John"	0	0	314	314
+City & County of Honolulu	30-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	339	339
+City & County of Honolulu	30-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	30-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	30-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	30-02	Straight Party			REPUBLICAN PARTY (R)	0	0	45	45
+City & County of Honolulu	30-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	264	264
+City & County of Honolulu	30-02	US Representative	1	R	"TATAII, Steve"	0	0	42	42
+City & County of Honolulu	30-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	30-02	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	30-02	State Representative	30	D	"MIZUNO, John"	0	0	242	242
+City & County of Honolulu	30-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	256	256
+City & County of Honolulu	30-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	30-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	30-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	30-03	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
+City & County of Honolulu	30-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	201	201
+City & County of Honolulu	30-03	US Representative	1	R	"TATAII, Steve"	0	0	26	26
+City & County of Honolulu	30-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	30-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	30-03	State Representative	30	D	"MIZUNO, John"	0	0	175	175
+City & County of Honolulu	30-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	175	175
+City & County of Honolulu	30-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	30-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	30-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	30-04	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
+City & County of Honolulu	30-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	127	127
+City & County of Honolulu	30-04	US Representative	1	R	"TATAII, Steve"	0	0	12	12
+City & County of Honolulu	30-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	30-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	30-04	State Representative	30	D	"MIZUNO, John"	0	0	147	147
+City & County of Honolulu	30-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	56	56
+City & County of Honolulu	30-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	30-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	30-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	30-05	Straight Party			REPUBLICAN PARTY (R)	0	0	18	18
+City & County of Honolulu	30-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	41	41
+City & County of Honolulu	30-05	US Representative	1	R	"TATAII, Steve"	0	0	17	17
+City & County of Honolulu	30-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	30-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	30-05	State Representative	30	D	"MIZUNO, John"	0	0	31	31
+City & County of Honolulu	30-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	470	470
+City & County of Honolulu	30-06	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	30-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	30-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	30-06	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59
+City & County of Honolulu	30-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	394	394
+City & County of Honolulu	30-06	US Representative	1	R	"TATAII, Steve"	0	0	57	57
+City & County of Honolulu	30-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	30-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	30-06	State Representative	30	D	"MIZUNO, John"	0	0	345	345
+City & County of Honolulu	31-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	491	491
+City & County of Honolulu	31-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	31-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	31-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	31-01	Straight Party			REPUBLICAN PARTY (R)	0	0	54	54
+City & County of Honolulu	31-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	357	357
+City & County of Honolulu	31-01	US Representative	1	R	"TATAII, Steve"	0	0	46	46
+City & County of Honolulu	31-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	31-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	31-01	State Representative	31	D	"WAKAI, Glenn"	0	0	417	417
+City & County of Honolulu	31-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	515	515
+City & County of Honolulu	31-02	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	31-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	10	10
+City & County of Honolulu	31-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	31-02	Straight Party			REPUBLICAN PARTY (R)	0	0	72	72
+City & County of Honolulu	31-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	412	412
+City & County of Honolulu	31-02	US Representative	1	R	"TATAII, Steve"	0	0	66	66
+City & County of Honolulu	31-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	31-02	US Representative	1	L	"ZHAO, Li"	0	0	10	10
+City & County of Honolulu	31-02	State Representative	31	D	"WAKAI, Glenn"	0	0	413	413
+City & County of Honolulu	31-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	333	333
+City & County of Honolulu	31-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	31-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	31-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
+City & County of Honolulu	31-03	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55
+City & County of Honolulu	31-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	264	264
+City & County of Honolulu	31-03	US Representative	1	R	"TATAII, Steve"	0	0	53	53
+City & County of Honolulu	31-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	31-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	31-03	State Representative	31	D	"WAKAI, Glenn"	0	0	262	262
+City & County of Honolulu	31-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	347	347
+City & County of Honolulu	31-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	31-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	31-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	8	8
+City & County of Honolulu	31-04	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75
+City & County of Honolulu	31-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	261	261
+City & County of Honolulu	31-04	US Representative	1	R	"TATAII, Steve"	0	0	67	67
+City & County of Honolulu	31-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	31-04	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	31-04	State Representative	31	D	"WAKAI, Glenn"	0	0	261	261
+City & County of Honolulu	31-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	634	634
+City & County of Honolulu	31-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	31-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	31-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	31-05	Straight Party			REPUBLICAN PARTY (R)	0	0	81	81
+City & County of Honolulu	31-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	483	483
+City & County of Honolulu	31-05	US Representative	1	R	"TATAII, Steve"	0	0	74	74
+City & County of Honolulu	31-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	31-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	31-05	State Representative	31	D	"WAKAI, Glenn"	0	0	515	515
+City & County of Honolulu	32-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	429	429
+City & County of Honolulu	32-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	32-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	32-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	32-01	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
+City & County of Honolulu	32-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	390	390
+City & County of Honolulu	32-01	US Representative	1	R	"TATAII, Steve"	0	0	42	42
+City & County of Honolulu	32-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	32-01	State Representative	32	R	"FINNEGAN, Lynn"	0	0	95	95
+City & County of Honolulu	32-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	42	42
+City & County of Honolulu	32-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	32-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	32-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	32-02	Straight Party			REPUBLICAN PARTY (R)	0	0	11	11
+City & County of Honolulu	32-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	40	40
+City & County of Honolulu	32-02	US Representative	1	R	"TATAII, Steve"	0	0	3	3
+City & County of Honolulu	32-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	32-02	State Representative	32	R	"FINNEGAN, Lynn"	0	0	9	9
+City & County of Honolulu	32-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	22	22
+City & County of Honolulu	32-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	32-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	32-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	32-03	Straight Party			REPUBLICAN PARTY (R)	0	0	19	19
+City & County of Honolulu	32-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	19	19
+City & County of Honolulu	32-03	US Representative	1	R	"TATAII, Steve"	0	0	13	13
+City & County of Honolulu	32-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	32-03	State Representative	32	R	"FINNEGAN, Lynn"	0	0	13	13
+City & County of Honolulu	32-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	210	210
+City & County of Honolulu	32-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	32-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	32-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	32-04	Straight Party			REPUBLICAN PARTY (R)	0	0	65	65
+City & County of Honolulu	32-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	201	201
+City & County of Honolulu	32-04	US Representative	1	R	"TATAII, Steve"	0	0	23	23
+City & County of Honolulu	32-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	32-04	State Representative	32	R	"FINNEGAN, Lynn"	0	0	61	61
+City & County of Honolulu	32-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	471	471
+City & County of Honolulu	32-05	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
+City & County of Honolulu	32-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	32-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	32-05	Straight Party			REPUBLICAN PARTY (R)	0	0	255	255
+City & County of Honolulu	32-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	429	429
+City & County of Honolulu	32-05	US Representative	1	R	"TATAII, Steve"	0	0	98	98
+City & County of Honolulu	32-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	32-05	State Representative	32	R	"FINNEGAN, Lynn"	0	0	235	235
+City & County of Honolulu	32-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	211	211
+City & County of Honolulu	32-06	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	32-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	32-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	32-06	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
+City & County of Honolulu	32-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	193	193
+City & County of Honolulu	32-06	US Representative	1	R	"TATAII, Steve"	0	0	19	19
+City & County of Honolulu	32-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	32-06	State Representative	32	R	"FINNEGAN, Lynn"	0	0	48	48
+City & County of Honolulu	32-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	145	145
+City & County of Honolulu	32-07	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	32-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	32-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	32-07	Straight Party			REPUBLICAN PARTY (R)	0	0	41	41
+City & County of Honolulu	32-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	138	138
+City & County of Honolulu	32-07	US Representative	1	R	"TATAII, Steve"	0	0	13	13
+City & County of Honolulu	32-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-07	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	32-07	State Representative	32	R	"FINNEGAN, Lynn"	0	0	38	38
+City & County of Honolulu	32-08	Straight Party			DEMOCRATIC PARTY (D)	0	0	266	266
+City & County of Honolulu	32-08	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	32-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	32-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	32-08	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
+City & County of Honolulu	32-08	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	250	250
+City & County of Honolulu	32-08	US Representative	1	R	"TATAII, Steve"	0	0	44	44
+City & County of Honolulu	32-08	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	32-08	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	32-08	State Representative	32	R	"FINNEGAN, Lynn"	0	0	93	93
+City & County of Honolulu	33-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	77	77
+City & County of Honolulu	33-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	33-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	33-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	33-01	Straight Party			REPUBLICAN PARTY (R)	0	0	21	21
+City & County of Honolulu	33-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	58	58
+City & County of Honolulu	33-01	US Representative	1	R	"TATAII, Steve"	0	0	20	20
+City & County of Honolulu	33-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	33-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	33-01	State Representative	33	D	"OSHIRO, Blake K."	0	0	46	46
+City & County of Honolulu	33-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	205	205
+City & County of Honolulu	33-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	33-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	33-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	33-02	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34
+City & County of Honolulu	33-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	169	169
+City & County of Honolulu	33-02	US Representative	1	R	"TATAII, Steve"	0	0	32	32
+City & County of Honolulu	33-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	33-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	33-02	State Representative	33	D	"OSHIRO, Blake K."	0	0	143	143
+City & County of Honolulu	33-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	478	478
+City & County of Honolulu	33-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	33-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	33-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	33-03	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55
+City & County of Honolulu	33-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	381	381
+City & County of Honolulu	33-03	US Representative	1	R	"TATAII, Steve"	0	0	45	45
+City & County of Honolulu	33-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	33-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	33-03	State Representative	33	D	"OSHIRO, Blake K."	0	0	332	332
+City & County of Honolulu	33-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	775	775
+City & County of Honolulu	33-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
+City & County of Honolulu	33-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	8	8
+City & County of Honolulu	33-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
+City & County of Honolulu	33-04	Straight Party			REPUBLICAN PARTY (R)	0	0	149	149
+City & County of Honolulu	33-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	599	599
+City & County of Honolulu	33-04	US Representative	1	R	"TATAII, Steve"	0	0	132	132
+City & County of Honolulu	33-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	3	3
+City & County of Honolulu	33-04	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	33-04	State Senate	16	D	"IGE, David Y."	0	0	436	436
+City & County of Honolulu	33-04	State Representative	33	D	"OSHIRO, Blake K."	0	0	517	517
+City & County of Honolulu	33-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	455	455
+City & County of Honolulu	33-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	33-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	33-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	10	10
+City & County of Honolulu	33-05	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
+City & County of Honolulu	33-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	367	367
+City & County of Honolulu	33-05	US Representative	1	R	"TATAII, Steve"	0	0	100	100
+City & County of Honolulu	33-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	33-05	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	33-05	State Senate	16	D	"IGE, David Y."	0	0	284	284
+City & County of Honolulu	33-05	State Representative	33	D	"OSHIRO, Blake K."	0	0	308	308
+City & County of Honolulu	33-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311
+City & County of Honolulu	33-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	33-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	33-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	33-06	Straight Party			REPUBLICAN PARTY (R)	0	0	55	55
+City & County of Honolulu	33-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	255	255
+City & County of Honolulu	33-06	US Representative	1	R	"TATAII, Steve"	0	0	49	49
+City & County of Honolulu	33-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	33-06	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	33-06	State Senate	16	D	"IGE, David Y."	0	0	176	176
+City & County of Honolulu	33-06	State Representative	33	D	"OSHIRO, Blake K."	0	0	198	198
+City & County of Honolulu	34-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	394	394
+City & County of Honolulu	34-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	34-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	34-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	34-01	Straight Party			REPUBLICAN PARTY (R)	0	0	64	64
+City & County of Honolulu	34-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	299	299
+City & County of Honolulu	34-01	US Representative	1	R	"TATAII, Steve"	0	0	59	59
+City & County of Honolulu	34-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	34-01	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	34-01	State Senate	16	D	"IGE, David Y."	0	0	244	244
+City & County of Honolulu	34-01	State Representative	34	D	"TAKAI, K. Mark"	0	0	282	282
+City & County of Honolulu	34-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	355	355
+City & County of Honolulu	34-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	34-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	34-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	34-02	Straight Party			REPUBLICAN PARTY (R)	0	0	80	80
+City & County of Honolulu	34-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	272	272
+City & County of Honolulu	34-02	US Representative	1	R	"TATAII, Steve"	0	0	78	78
+City & County of Honolulu	34-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	34-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	34-02	State Senate	16	D	"IGE, David Y."	0	0	214	214
+City & County of Honolulu	34-02	State Representative	34	D	"TAKAI, K. Mark"	0	0	261	261
+City & County of Honolulu	34-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	223	223
+City & County of Honolulu	34-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	34-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	34-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	34-03	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
+City & County of Honolulu	34-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	179	179
+City & County of Honolulu	34-03	US Representative	1	R	"TATAII, Steve"	0	0	19	19
+City & County of Honolulu	34-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	34-03	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	34-03	State Senate	16	D	"IGE, David Y."	0	0	151	151
+City & County of Honolulu	34-03	State Representative	34	D	"TAKAI, K. Mark"	0	0	169	169
+City & County of Honolulu	34-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	395	395
+City & County of Honolulu	34-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	34-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	34-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	34-04	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36
+City & County of Honolulu	34-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	305	305
+City & County of Honolulu	34-04	US Representative	1	R	"TATAII, Steve"	0	0	29	29
+City & County of Honolulu	34-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	34-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	34-04	State Senate	16	D	"IGE, David Y."	0	0	244	244
+City & County of Honolulu	34-04	State Representative	34	D	"TAKAI, K. Mark"	0	0	292	292
+City & County of Honolulu	34-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	238	238
+City & County of Honolulu	34-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	34-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	34-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	34-05	Straight Party			REPUBLICAN PARTY (R)	0	0	23	23
+City & County of Honolulu	34-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	187	187
+City & County of Honolulu	34-05	US Representative	1	R	"TATAII, Steve"	0	0	21	21
+City & County of Honolulu	34-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	34-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	34-05	State Senate	16	D	"IGE, David Y."	0	0	142	142
+City & County of Honolulu	34-05	State Representative	34	D	"TAKAI, K. Mark"	0	0	160	160
+City & County of Honolulu	34-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	68	68
+City & County of Honolulu	34-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	34-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	34-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	34-06	Straight Party			REPUBLICAN PARTY (R)	0	0	14	14
+City & County of Honolulu	34-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	61	61
+City & County of Honolulu	34-06	US Representative	1	R	"TATAII, Steve"	0	0	11	11
+City & County of Honolulu	34-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	34-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	34-06	State Senate	18	D	"SONSON, Alex M."	0	0	27	27
+City & County of Honolulu	34-06	State Senate	18	D	"NISHIHARA, Clarence"	0	0	29	29
+City & County of Honolulu	34-06	State Representative	34	D	"TAKAI, K. Mark"	0	0	52	52
+City & County of Honolulu	34-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	1034	1034
+City & County of Honolulu	34-07	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	34-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	9	9
+City & County of Honolulu	34-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	34-07	Straight Party			REPUBLICAN PARTY (R)	0	0	103	103
+City & County of Honolulu	34-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	780	780
+City & County of Honolulu	34-07	US Representative	1	R	"TATAII, Steve"	0	0	95	95
+City & County of Honolulu	34-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	34-07	US Representative	1	L	"ZHAO, Li"	0	0	5	5
+City & County of Honolulu	34-07	State Senate	16	D	"IGE, David Y."	0	0	727	727
+City & County of Honolulu	34-07	State Representative	34	D	"TAKAI, K. Mark"	0	0	809	809
+City & County of Honolulu	35-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	499	499
+City & County of Honolulu	35-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	35-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	35-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	35-01	Straight Party			REPUBLICAN PARTY (R)	0	0	61	61
+City & County of Honolulu	35-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	373	373
+City & County of Honolulu	35-01	US Representative	1	R	"TATAII, Steve"	0	0	41	41
+City & County of Honolulu	35-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	35-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	35-01	State Senate	18	D	"SONSON, Alex M."	0	0	211	211
+City & County of Honolulu	35-01	State Senate	18	D	"NISHIHARA, Clarence"	0	0	262	262
+City & County of Honolulu	35-01	State Representative	35	D	"AQUINO, Henry James C."	0	0	215	215
+City & County of Honolulu	35-01	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	178	178
+City & County of Honolulu	35-01	State Representative	35	D	"VERDADERO, Dante M."	0	0	19	19
+City & County of Honolulu	35-01	State Representative	35	D	"DOMINGO, Constante A."	0	0	21	21
+City & County of Honolulu	35-01	State Representative	35	D	"PARAYNO, Ilalo"	0	0	31	31
+City & County of Honolulu	35-01	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	46	46
+City & County of Honolulu	35-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	745	745
+City & County of Honolulu	35-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	35-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	35-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	35-02	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
+City & County of Honolulu	35-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	572	572
+City & County of Honolulu	35-02	US Representative	1	R	"TATAII, Steve"	0	0	17	17
+City & County of Honolulu	35-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	35-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	35-02	State Senate	18	D	"SONSON, Alex M."	0	0	445	445
+City & County of Honolulu	35-02	State Senate	18	D	"NISHIHARA, Clarence"	0	0	268	268
+City & County of Honolulu	35-02	State Representative	35	D	"AQUINO, Henry James C."	0	0	494	494
+City & County of Honolulu	35-02	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	147	147
+City & County of Honolulu	35-02	State Representative	35	D	"VERDADERO, Dante M."	0	0	36	36
+City & County of Honolulu	35-02	State Representative	35	D	"DOMINGO, Constante A."	0	0	16	16
+City & County of Honolulu	35-02	State Representative	35	D	"PARAYNO, Ilalo"	0	0	25	25
+City & County of Honolulu	35-02	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	32	32
+City & County of Honolulu	35-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	221	221
+City & County of Honolulu	35-03	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	35-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	35-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	35-03	Straight Party			REPUBLICAN PARTY (R)	0	0	17	17
+City & County of Honolulu	35-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	169	169
+City & County of Honolulu	35-03	US Representative	1	R	"TATAII, Steve"	0	0	6	6
+City & County of Honolulu	35-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	35-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	35-03	State Senate	18	D	"SONSON, Alex M."	0	0	113	113
+City & County of Honolulu	35-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	99	99
+City & County of Honolulu	35-03	State Representative	35	D	"AQUINO, Henry James C."	0	0	133	133
+City & County of Honolulu	35-03	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	30	30
+City & County of Honolulu	35-03	State Representative	35	D	"VERDADERO, Dante M."	0	0	17	17
+City & County of Honolulu	35-03	State Representative	35	D	"DOMINGO, Constante A."	0	0	10	10
+City & County of Honolulu	35-03	State Representative	35	D	"PARAYNO, Ilalo"	0	0	12	12
+City & County of Honolulu	35-03	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	14	14
+City & County of Honolulu	35-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	330	330
+City & County of Honolulu	35-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	35-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	35-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	35-04	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22
+City & County of Honolulu	35-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	272	272
+City & County of Honolulu	35-04	US Representative	1	R	"TATAII, Steve"	0	0	15	15
+City & County of Honolulu	35-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	35-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	35-04	State Senate	18	D	"SONSON, Alex M."	0	0	163	163
+City & County of Honolulu	35-04	State Senate	18	D	"NISHIHARA, Clarence"	0	0	157	157
+City & County of Honolulu	35-04	State Representative	35	D	"AQUINO, Henry James C."	0	0	192	192
+City & County of Honolulu	35-04	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	57	57
+City & County of Honolulu	35-04	State Representative	35	D	"VERDADERO, Dante M."	0	0	9	9
+City & County of Honolulu	35-04	State Representative	35	D	"DOMINGO, Constante A."	0	0	12	12
+City & County of Honolulu	35-04	State Representative	35	D	"PARAYNO, Ilalo"	0	0	33	33
+City & County of Honolulu	35-04	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	18	18
+City & County of Honolulu	35-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	279	279
+City & County of Honolulu	35-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	35-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	35-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	35-05	Straight Party			REPUBLICAN PARTY (R)	0	0	13	13
+City & County of Honolulu	35-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	231	231
+City & County of Honolulu	35-05	US Representative	1	R	"TATAII, Steve"	0	0	6	6
+City & County of Honolulu	35-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	35-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	35-05	State Senate	18	D	"SONSON, Alex M."	0	0	173	173
+City & County of Honolulu	35-05	State Senate	18	D	"NISHIHARA, Clarence"	0	0	96	96
+City & County of Honolulu	35-05	State Representative	35	D	"AQUINO, Henry James C."	0	0	176	176
+City & County of Honolulu	35-05	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	36	36
+City & County of Honolulu	35-05	State Representative	35	D	"VERDADERO, Dante M."	0	0	15	15
+City & County of Honolulu	35-05	State Representative	35	D	"DOMINGO, Constante A."	0	0	12	12
+City & County of Honolulu	35-05	State Representative	35	D	"PARAYNO, Ilalo"	0	0	27	27
+City & County of Honolulu	35-05	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	11	11
+City & County of Honolulu	35-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	862	862
+City & County of Honolulu	35-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	35-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	35-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	35-06	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35
+City & County of Honolulu	35-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	705	705
+City & County of Honolulu	35-06	US Representative	1	R	"TATAII, Steve"	0	0	16	16
+City & County of Honolulu	35-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	35-06	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	35-06	State Senate	18	D	"SONSON, Alex M."	0	0	515	515
+City & County of Honolulu	35-06	State Senate	18	D	"NISHIHARA, Clarence"	0	0	321	321
+City & County of Honolulu	35-06	State Representative	35	D	"AQUINO, Henry James C."	0	0	580	580
+City & County of Honolulu	35-06	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	0	0	134	134
+City & County of Honolulu	35-06	State Representative	35	D	"VERDADERO, Dante M."	0	0	24	24
+City & County of Honolulu	35-06	State Representative	35	D	"DOMINGO, Constante A."	0	0	23	23
+City & County of Honolulu	35-06	State Representative	35	D	"PARAYNO, Ilalo"	0	0	74	74
+City & County of Honolulu	35-06	State Representative	35	R	"ANTONIO, Steven Bolosan"	0	0	30	30
+City & County of Honolulu	36-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	531	531
+City & County of Honolulu	36-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	36-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	36-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	36-01	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
+City & County of Honolulu	36-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	429	429
+City & County of Honolulu	36-01	US Representative	1	R	"TATAII, Steve"	0	0	46	46
+City & County of Honolulu	36-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	36-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	36-01	State Senate	16	D	"IGE, David Y."	0	0	338	338
+City & County of Honolulu	36-01	State Representative	36	D	"TAKUMI, Roy M."	0	0	372	372
+City & County of Honolulu	36-01	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	3	3
+City & County of Honolulu	36-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	384	384
+City & County of Honolulu	36-02	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	36-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	36-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	16	16
+City & County of Honolulu	36-02	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
+City & County of Honolulu	36-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	317	317
+City & County of Honolulu	36-02	US Representative	1	R	"TATAII, Steve"	0	0	36	36
+City & County of Honolulu	36-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	36-02	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	36-02	State Senate	16	D	"IGE, David Y."	0	0	239	239
+City & County of Honolulu	36-02	State Representative	36	D	"TAKUMI, Roy M."	0	0	249	249
+City & County of Honolulu	36-02	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	15	15
+City & County of Honolulu	36-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	273	273
+City & County of Honolulu	36-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	36-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	36-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	36-03	Straight Party			REPUBLICAN PARTY (R)	0	0	59	59
+City & County of Honolulu	36-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	226	226
+City & County of Honolulu	36-03	US Representative	1	R	"TATAII, Steve"	0	0	59	59
+City & County of Honolulu	36-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	36-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	36-03	State Senate	18	D	"SONSON, Alex M."	0	0	98	98
+City & County of Honolulu	36-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	135	135
+City & County of Honolulu	36-03	State Representative	36	D	"TAKUMI, Roy M."	0	0	203	203
+City & County of Honolulu	36-03	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0
+City & County of Honolulu	36-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	29	29
+City & County of Honolulu	36-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	36-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	36-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	36-04	Straight Party			REPUBLICAN PARTY (R)	0	0	4	4
+City & County of Honolulu	36-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	26	26
+City & County of Honolulu	36-04	US Representative	1	R	"TATAII, Steve"	0	0	4	4
+City & County of Honolulu	36-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	36-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	36-04	State Senate	18	D	"SONSON, Alex M."	0	0	10	10
+City & County of Honolulu	36-04	State Senate	18	D	"NISHIHARA, Clarence"	0	0	15	15
+City & County of Honolulu	36-04	State Representative	36	D	"TAKUMI, Roy M."	0	0	23	23
+City & County of Honolulu	36-04	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0
+City & County of Honolulu	36-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	765	765
+City & County of Honolulu	36-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	36-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	36-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	36-05	Straight Party			REPUBLICAN PARTY (R)	0	0	69	69
+City & County of Honolulu	36-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	614	614
+City & County of Honolulu	36-05	US Representative	1	R	"TATAII, Steve"	0	0	56	56
+City & County of Honolulu	36-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	36-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	36-05	State Senate	18	D	"SONSON, Alex M."	0	0	212	212
+City & County of Honolulu	36-05	State Senate	18	D	"NISHIHARA, Clarence"	0	0	496	496
+City & County of Honolulu	36-05	State Representative	36	D	"TAKUMI, Roy M."	0	0	599	599
+City & County of Honolulu	36-05	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	4	4
+City & County of Honolulu	36-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	541	541
+City & County of Honolulu	36-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	36-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	36-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
+City & County of Honolulu	36-06	Straight Party			REPUBLICAN PARTY (R)	0	0	97	97
+City & County of Honolulu	36-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	427	427
+City & County of Honolulu	36-06	US Representative	1	R	"TATAII, Steve"	0	0	91	91
+City & County of Honolulu	36-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	36-06	US Representative	1	L	"ZHAO, Li"	0	0	4	4
+City & County of Honolulu	36-06	State Senate	16	D	"IGE, David Y."	0	0	320	320
+City & County of Honolulu	36-06	State Representative	36	D	"TAKUMI, Roy M."	0	0	355	355
+City & County of Honolulu	36-06	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	8	8
+City & County of Honolulu	36-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	396	396
+City & County of Honolulu	36-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	36-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	36-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	9	9
+City & County of Honolulu	36-07	Straight Party			REPUBLICAN PARTY (R)	0	0	67	67
+City & County of Honolulu	36-07	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	310	310
+City & County of Honolulu	36-07	US Representative	1	R	"TATAII, Steve"	0	0	65	65
+City & County of Honolulu	36-07	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	36-07	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	36-07	State Senate	16	D	"IGE, David Y."	0	0	228	228
+City & County of Honolulu	36-07	State Representative	36	D	"TAKUMI, Roy M."	0	0	247	247
+City & County of Honolulu	36-07	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	9	9
+City & County of Honolulu	37-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	940	940
+City & County of Honolulu	37-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	37-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	37-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	37-01	Straight Party			REPUBLICAN PARTY (R)	0	0	119	119
+City & County of Honolulu	37-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	753	753
+City & County of Honolulu	37-01	US Representative	1	R	"TATAII, Steve"	0	0	111	111
+City & County of Honolulu	37-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	37-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	37-01	State Senate	17	D	"KIDANI, Michelle"	0	0	420	420
+City & County of Honolulu	37-01	State Senate	17	D	"MENOR, Ron"	0	0	295	295
+City & County of Honolulu	37-01	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	162	162
+City & County of Honolulu	37-01	State Representative	37	D	"YAMANE, Ryan I."	0	0	773	773
+City & County of Honolulu	37-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	708	708
+City & County of Honolulu	37-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	37-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	37-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	37-02	Straight Party			REPUBLICAN PARTY (R)	0	0	129	129
+City & County of Honolulu	37-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	567	567
+City & County of Honolulu	37-02	US Representative	1	R	"TATAII, Steve"	0	0	117	117
+City & County of Honolulu	37-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	37-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	37-02	State Senate	17	D	"KIDANI, Michelle"	0	0	306	306
+City & County of Honolulu	37-02	State Senate	17	D	"MENOR, Ron"	0	0	276	276
+City & County of Honolulu	37-02	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	90	90
+City & County of Honolulu	37-02	State Representative	37	D	"YAMANE, Ryan I."	0	0	567	567
+City & County of Honolulu	37-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	880	880
+City & County of Honolulu	37-03	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	37-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	37-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	37-03	Straight Party			REPUBLICAN PARTY (R)	0	0	138	138
+City & County of Honolulu	37-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	674	674
+City & County of Honolulu	37-03	US Representative	1	R	"TATAII, Steve"	0	0	133	133
+City & County of Honolulu	37-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	37-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	37-03	State Senate	17	D	"KIDANI, Michelle"	0	0	354	354
+City & County of Honolulu	37-03	State Senate	17	D	"MENOR, Ron"	0	0	384	384
+City & County of Honolulu	37-03	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	100	100
+City & County of Honolulu	37-03	State Representative	37	D	"YAMANE, Ryan I."	0	0	684	684
+City & County of Honolulu	37-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	738	738
+City & County of Honolulu	37-04	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	37-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	37-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	37-04	Straight Party			REPUBLICAN PARTY (R)	0	0	121	121
+City & County of Honolulu	37-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	581	581
+City & County of Honolulu	37-04	US Representative	1	R	"TATAII, Steve"	0	0	111	111
+City & County of Honolulu	37-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	37-04	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	37-04	State Senate	17	D	"KIDANI, Michelle"	0	0	310	310
+City & County of Honolulu	37-04	State Senate	17	D	"MENOR, Ron"	0	0	309	309
+City & County of Honolulu	37-04	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	78	78
+City & County of Honolulu	37-04	State Representative	37	D	"YAMANE, Ryan I."	0	0	598	598
+City & County of Honolulu	38-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	818	818
+City & County of Honolulu	38-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	38-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+City & County of Honolulu	38-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	13	13
+City & County of Honolulu	38-01	Straight Party			REPUBLICAN PARTY (R)	0	0	210	210
+City & County of Honolulu	38-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	665	665
+City & County of Honolulu	38-01	US Representative	1	R	"TATAII, Steve"	0	0	117	117
+City & County of Honolulu	38-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	38-01	US Representative	1	L	"ZHAO, Li"	0	0	3	3
+City & County of Honolulu	38-01	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	503	503
+City & County of Honolulu	38-01	State Representative	38	D	"LEE, Marilyn B."	0	0	539	539
+City & County of Honolulu	38-01	State Representative	38	R	"APANA, Melvin K."	0	0	178	178
+City & County of Honolulu	38-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	972	972
+City & County of Honolulu	38-02	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	38-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	38-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	38-02	Straight Party			REPUBLICAN PARTY (R)	0	0	180	180
+City & County of Honolulu	38-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	770	770
+City & County of Honolulu	38-02	US Representative	1	R	"TATAII, Steve"	0	0	126	126
+City & County of Honolulu	38-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	4	4
+City & County of Honolulu	38-02	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	38-02	State Senate	17	D	"KIDANI, Michelle"	0	0	436	436
+City & County of Honolulu	38-02	State Senate	17	D	"MENOR, Ron"	0	0	388	388
+City & County of Honolulu	38-02	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	102	102
+City & County of Honolulu	38-02	State Representative	38	D	"LEE, Marilyn B."	0	0	776	776
+City & County of Honolulu	38-02	State Representative	38	R	"APANA, Melvin K."	0	0	155	155
+City & County of Honolulu	38-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	676	676
+City & County of Honolulu	38-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	38-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	38-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	38-03	Straight Party			REPUBLICAN PARTY (R)	0	0	114	114
+City & County of Honolulu	38-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	521	521
+City & County of Honolulu	38-03	US Representative	1	R	"TATAII, Steve"	0	0	74	74
+City & County of Honolulu	38-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	38-03	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	38-03	State Senate	17	D	"KIDANI, Michelle"	0	0	258	258
+City & County of Honolulu	38-03	State Senate	17	D	"MENOR, Ron"	0	0	269	269
+City & County of Honolulu	38-03	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	117	117
+City & County of Honolulu	38-03	State Representative	38	D	"LEE, Marilyn B."	0	0	515	515
+City & County of Honolulu	38-03	State Representative	38	R	"APANA, Melvin K."	0	0	90	90
+City & County of Honolulu	38-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	500	500
+City & County of Honolulu	38-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	38-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	38-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	38-04	Straight Party			REPUBLICAN PARTY (R)	0	0	145	145
+City & County of Honolulu	38-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	382	382
+City & County of Honolulu	38-04	US Representative	1	R	"TATAII, Steve"	0	0	94	94
+City & County of Honolulu	38-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	38-04	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	38-04	State Senate	17	D	"KIDANI, Michelle"	0	0	195	195
+City & County of Honolulu	38-04	State Senate	17	D	"MENOR, Ron"	0	0	204	204
+City & County of Honolulu	38-04	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	77	77
+City & County of Honolulu	38-04	State Representative	38	D	"LEE, Marilyn B."	0	0	380	380
+City & County of Honolulu	38-04	State Representative	38	R	"APANA, Melvin K."	0	0	118	118
+City & County of Honolulu	38-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	569	569
+City & County of Honolulu	38-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	38-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	38-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	38-05	Straight Party			REPUBLICAN PARTY (R)	0	0	111	111
+City & County of Honolulu	38-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	478	478
+City & County of Honolulu	38-05	US Representative	1	R	"TATAII, Steve"	0	0	80	80
+City & County of Honolulu	38-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	38-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	38-05	State Senate	17	D	"KIDANI, Michelle"	0	0	181	181
+City & County of Honolulu	38-05	State Senate	17	D	"MENOR, Ron"	0	0	259	259
+City & County of Honolulu	38-05	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	92	92
+City & County of Honolulu	38-05	State Representative	38	D	"LEE, Marilyn B."	0	0	426	426
+City & County of Honolulu	38-05	State Representative	38	R	"APANA, Melvin K."	0	0	88	88
+City & County of Honolulu	39-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	271	271
+City & County of Honolulu	39-01	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	39-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	39-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	39-01	Straight Party			REPUBLICAN PARTY (R)	0	0	51	51
+City & County of Honolulu	39-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	39-01	US Representative	2	D	"HIRONO, Mazie"	0	0	183	183
+City & County of Honolulu	39-01	US Representative	2	R	"EVANS, Roger B."	0	0	48	48
+City & County of Honolulu	39-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	39-01	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	209	209
+City & County of Honolulu	39-01	State Representative	39	D	"OSHIRO, Marcus R."	0	0	171	171
+City & County of Honolulu	39-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	412	412
+City & County of Honolulu	39-02	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	39-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	39-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	39-02	Straight Party			REPUBLICAN PARTY (R)	0	0	49	49
+City & County of Honolulu	39-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+City & County of Honolulu	39-02	US Representative	2	D	"HIRONO, Mazie"	0	0	308	308
+City & County of Honolulu	39-02	US Representative	2	R	"EVANS, Roger B."	0	0	45	45
+City & County of Honolulu	39-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	39-02	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	317	317
+City & County of Honolulu	39-02	State Representative	39	D	"OSHIRO, Marcus R."	0	0	296	296
+City & County of Honolulu	39-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	534	534
+City & County of Honolulu	39-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	39-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	39-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	39-03	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83
+City & County of Honolulu	39-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+City & County of Honolulu	39-03	US Representative	2	D	"HIRONO, Mazie"	0	0	364	364
+City & County of Honolulu	39-03	US Representative	2	R	"EVANS, Roger B."	0	0	76	76
+City & County of Honolulu	39-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	39-03	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	400	400
+City & County of Honolulu	39-03	State Representative	39	D	"OSHIRO, Marcus R."	0	0	373	373
+City & County of Honolulu	39-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392
+City & County of Honolulu	39-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	39-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	39-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	12	12
+City & County of Honolulu	39-04	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83
+City & County of Honolulu	39-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	39-04	US Representative	2	D	"HIRONO, Mazie"	0	0	299	299
+City & County of Honolulu	39-04	US Representative	2	R	"EVANS, Roger B."	0	0	79	79
+City & County of Honolulu	39-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	39-04	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	280	280
+City & County of Honolulu	39-04	State Representative	39	D	"OSHIRO, Marcus R."	0	0	268	268
+City & County of Honolulu	39-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	121	121
+City & County of Honolulu	39-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	39-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	39-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	39-05	Straight Party			REPUBLICAN PARTY (R)	0	0	35	35
+City & County of Honolulu	39-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	99	99
+City & County of Honolulu	39-05	US Representative	1	R	"TATAII, Steve"	0	0	35	35
+City & County of Honolulu	39-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	39-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	39-05	State Senate	17	D	"KIDANI, Michelle"	0	0	49	49
+City & County of Honolulu	39-05	State Senate	17	D	"MENOR, Ron"	0	0	46	46
+City & County of Honolulu	39-05	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	0	0	7	7
+City & County of Honolulu	39-05	State Representative	39	D	"OSHIRO, Marcus R."	0	0	81	81
+City & County of Honolulu	39-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	352	352
+City & County of Honolulu	39-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	39-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	39-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	39-06	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42
+City & County of Honolulu	39-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	39-06	US Representative	2	D	"HIRONO, Mazie"	0	0	270	270
+City & County of Honolulu	39-06	US Representative	2	R	"EVANS, Roger B."	0	0	39	39
+City & County of Honolulu	39-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
+City & County of Honolulu	39-06	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	243	243
+City & County of Honolulu	39-06	State Representative	39	D	"OSHIRO, Marcus R."	0	0	229	229
+City & County of Honolulu	40-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	231	231
+City & County of Honolulu	40-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	40-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	40-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	40-01	Straight Party			REPUBLICAN PARTY (R)	0	0	66	66
+City & County of Honolulu	40-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	40-01	US Representative	2	D	"HIRONO, Mazie"	0	0	181	181
+City & County of Honolulu	40-01	US Representative	2	R	"EVANS, Roger B."	0	0	49	49
+City & County of Honolulu	40-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	40-01	State Representative	40	D	"HAR, Sharon E."	0	0	179	179
+City & County of Honolulu	40-01	State Representative	40	R	"LEGAL,  Jack M."	0	0	47	47
+City & County of Honolulu	40-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	316	316
+City & County of Honolulu	40-02	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	40-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	40-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	40-02	Straight Party			REPUBLICAN PARTY (R)	0	0	118	118
+City & County of Honolulu	40-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+City & County of Honolulu	40-02	US Representative	2	D	"HIRONO, Mazie"	0	0	240	240
+City & County of Honolulu	40-02	US Representative	2	R	"EVANS, Roger B."	0	0	76	76
+City & County of Honolulu	40-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	40-02	State Representative	40	D	"HAR, Sharon E."	0	0	232	232
+City & County of Honolulu	40-02	State Representative	40	R	"LEGAL,  Jack M."	0	0	98	98
+City & County of Honolulu	40-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	463	463
+City & County of Honolulu	40-03	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	40-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	40-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	40-03	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154
+City & County of Honolulu	40-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+City & County of Honolulu	40-03	US Representative	2	D	"HIRONO, Mazie"	0	0	323	323
+City & County of Honolulu	40-03	US Representative	2	R	"EVANS, Roger B."	0	0	94	94
+City & County of Honolulu	40-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	40-03	State Representative	40	D	"HAR, Sharon E."	0	0	342	342
+City & County of Honolulu	40-03	State Representative	40	R	"LEGAL,  Jack M."	0	0	120	120
+City & County of Honolulu	40-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	427	427
+City & County of Honolulu	40-04	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	40-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	40-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	40-04	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154
+City & County of Honolulu	40-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	40-04	US Representative	2	D	"HIRONO, Mazie"	0	0	299	299
+City & County of Honolulu	40-04	US Representative	2	R	"EVANS, Roger B."	0	0	73	73
+City & County of Honolulu	40-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	40-04	State Representative	40	D	"HAR, Sharon E."	0	0	355	355
+City & County of Honolulu	40-04	State Representative	40	R	"LEGAL,  Jack M."	0	0	126	126
+City & County of Honolulu	40-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	393	393
+City & County of Honolulu	40-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	40-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	40-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	40-05	Straight Party			REPUBLICAN PARTY (R)	0	0	166	166
+City & County of Honolulu	40-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	40-05	US Representative	2	D	"HIRONO, Mazie"	0	0	305	305
+City & County of Honolulu	40-05	US Representative	2	R	"EVANS, Roger B."	0	0	98	98
+City & County of Honolulu	40-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	40-05	State Representative	40	D	"HAR, Sharon E."	0	0	300	300
+City & County of Honolulu	40-05	State Representative	40	R	"LEGAL,  Jack M."	0	0	142	142
+City & County of Honolulu	40-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	222	222
+City & County of Honolulu	40-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	40-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	40-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	40-06	Straight Party			REPUBLICAN PARTY (R)	0	0	142	142
+City & County of Honolulu	40-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	40-06	US Representative	2	D	"HIRONO, Mazie"	0	0	174	174
+City & County of Honolulu	40-06	US Representative	2	R	"EVANS, Roger B."	0	0	87	87
+City & County of Honolulu	40-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	40-06	State Representative	40	D	"HAR, Sharon E."	0	0	180	180
+City & County of Honolulu	40-06	State Representative	40	R	"LEGAL,  Jack M."	0	0	114	114
+City & County of Honolulu	41-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	343	343
+City & County of Honolulu	41-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	41-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	41-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	41-01	Straight Party			REPUBLICAN PARTY (R)	0	0	82	82
+City & County of Honolulu	41-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	293	293
+City & County of Honolulu	41-01	US Representative	1	R	"TATAII, Steve"	0	0	54	54
+City & County of Honolulu	41-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	2	2
+City & County of Honolulu	41-01	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	41-01	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	123	123
+City & County of Honolulu	41-01	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	185	185
+City & County of Honolulu	41-01	State Representative	41	R	"SANIATAN, Rito C."	0	0	62	62
+City & County of Honolulu	41-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	347	347
+City & County of Honolulu	41-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	41-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	41-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	41-02	Straight Party			REPUBLICAN PARTY (R)	0	0	78	78
+City & County of Honolulu	41-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	289	289
+City & County of Honolulu	41-02	US Representative	1	R	"TATAII, Steve"	0	0	39	39
+City & County of Honolulu	41-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	41-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	41-02	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	119	119
+City & County of Honolulu	41-02	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	197	197
+City & County of Honolulu	41-02	State Representative	41	R	"SANIATAN, Rito C."	0	0	68	68
+City & County of Honolulu	41-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	538	538
+City & County of Honolulu	41-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	41-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	41-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	41-03	Straight Party			REPUBLICAN PARTY (R)	0	0	40	40
+City & County of Honolulu	41-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	422	422
+City & County of Honolulu	41-03	US Representative	1	R	"TATAII, Steve"	0	0	17	17
+City & County of Honolulu	41-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	41-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	41-03	State Senate	18	D	"SONSON, Alex M."	0	0	237	237
+City & County of Honolulu	41-03	State Senate	18	D	"NISHIHARA, Clarence"	0	0	265	265
+City & County of Honolulu	41-03	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	242	242
+City & County of Honolulu	41-03	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	232	232
+City & County of Honolulu	41-03	State Representative	41	R	"SANIATAN, Rito C."	0	0	33	33
+City & County of Honolulu	41-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	66	66
+City & County of Honolulu	41-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	41-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	41-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	41-04	Straight Party			REPUBLICAN PARTY (R)	0	0	22	22
+City & County of Honolulu	41-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	53	53
+City & County of Honolulu	41-04	US Representative	1	R	"TATAII, Steve"	0	0	11	11
+City & County of Honolulu	41-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	41-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	41-04	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	38	38
+City & County of Honolulu	41-04	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	17	17
+City & County of Honolulu	41-04	State Representative	41	R	"SANIATAN, Rito C."	0	0	20	20
+City & County of Honolulu	41-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	505	505
+City & County of Honolulu	41-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	41-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	41-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	41-05	Straight Party			REPUBLICAN PARTY (R)	0	0	131	131
+City & County of Honolulu	41-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	41-05	US Representative	2	D	"HIRONO, Mazie"	0	0	400	400
+City & County of Honolulu	41-05	US Representative	2	R	"EVANS, Roger B."	0	0	58	58
+City & County of Honolulu	41-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	41-05	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	255	255
+City & County of Honolulu	41-05	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	211	211
+City & County of Honolulu	41-05	State Representative	41	R	"SANIATAN, Rito C."	0	0	110	110
+City & County of Honolulu	41-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313
+City & County of Honolulu	41-06	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	41-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	41-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	41-06	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113
+City & County of Honolulu	41-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	41-06	US Representative	2	D	"HIRONO, Mazie"	0	0	249	249
+City & County of Honolulu	41-06	US Representative	2	R	"EVANS, Roger B."	0	0	52	52
+City & County of Honolulu	41-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	41-06	State Representative	41	D	"CULLEN, Ty Diaz"	0	0	143	143
+City & County of Honolulu	41-06	State Representative	41	D	"KARAMATSU, Jon Riki"	0	0	133	133
+City & County of Honolulu	41-06	State Representative	41	R	"SANIATAN, Rito C."	0	0	90	90
+City & County of Honolulu	42-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	287	287
+City & County of Honolulu	42-01	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	42-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	42-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	42-01	Straight Party			REPUBLICAN PARTY (R)	0	0	26	26
+City & County of Honolulu	42-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	234	234
+City & County of Honolulu	42-01	US Representative	1	R	"TATAII, Steve"	0	0	10	10
+City & County of Honolulu	42-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	42-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	42-01	State Senate	18	D	"SONSON, Alex M."	0	0	148	148
+City & County of Honolulu	42-01	State Senate	18	D	"NISHIHARA, Clarence"	0	0	125	125
+City & County of Honolulu	42-01	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	23	23
+City & County of Honolulu	42-01	State Representative	42	D	"SCHULTZ, Mike P."	0	0	81	81
+City & County of Honolulu	42-01	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	158	158
+City & County of Honolulu	42-01	State Representative	42	R	"BERG, Tom"	0	0	25	25
+City & County of Honolulu	42-01	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
+City & County of Honolulu	42-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	107	107
+City & County of Honolulu	42-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	42-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	42-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	42-02	Straight Party			REPUBLICAN PARTY (R)	0	0	31	31
+City & County of Honolulu	42-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	90	90
+City & County of Honolulu	42-02	US Representative	1	R	"TATAII, Steve"	0	0	20	20
+City & County of Honolulu	42-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	42-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	42-02	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	10	10
+City & County of Honolulu	42-02	State Representative	42	D	"SCHULTZ, Mike P."	0	0	24	24
+City & County of Honolulu	42-02	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	53	53
+City & County of Honolulu	42-02	State Representative	42	R	"BERG, Tom"	0	0	24	24
+City & County of Honolulu	42-02	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
+City & County of Honolulu	42-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	220	220
+City & County of Honolulu	42-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	42-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	42-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	42-03	Straight Party			REPUBLICAN PARTY (R)	0	0	28	28
+City & County of Honolulu	42-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	173	173
+City & County of Honolulu	42-03	US Representative	1	R	"TATAII, Steve"	0	0	18	18
+City & County of Honolulu	42-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	42-03	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	42-03	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	19	19
+City & County of Honolulu	42-03	State Representative	42	D	"SCHULTZ, Mike P."	0	0	97	97
+City & County of Honolulu	42-03	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	93	93
+City & County of Honolulu	42-03	State Representative	42	R	"BERG, Tom"	0	0	24	24
+City & County of Honolulu	42-03	State Representative	42	N	"BIMBO, Genaro Q."	0	0	1	1
+City & County of Honolulu	42-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	520	520
+City & County of Honolulu	42-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	42-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	42-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	42-04	Straight Party			REPUBLICAN PARTY (R)	0	0	58	58
+City & County of Honolulu	42-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	421	421
+City & County of Honolulu	42-04	US Representative	1	R	"TATAII, Steve"	0	0	17	17
+City & County of Honolulu	42-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	42-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	42-04	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	22	22
+City & County of Honolulu	42-04	State Representative	42	D	"SCHULTZ, Mike P."	0	0	177	177
+City & County of Honolulu	42-04	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	293	293
+City & County of Honolulu	42-04	State Representative	42	R	"BERG, Tom"	0	0	55	55
+City & County of Honolulu	42-04	State Representative	42	N	"BIMBO, Genaro Q."	0	0	5	5
+City & County of Honolulu	42-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	403	403
+City & County of Honolulu	42-05	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	42-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	42-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	42-05	Straight Party			REPUBLICAN PARTY (R)	0	0	117	117
+City & County of Honolulu	42-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	342	342
+City & County of Honolulu	42-05	US Representative	1	R	"TATAII, Steve"	0	0	48	48
+City & County of Honolulu	42-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	42-05	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	42-05	State Representative	42	D	"RODRIGUEZ, Rey R."	0	0	18	18
+City & County of Honolulu	42-05	State Representative	42	D	"SCHULTZ, Mike P."	0	0	187	187
+City & County of Honolulu	42-05	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	0	0	155	155
+City & County of Honolulu	42-05	State Representative	42	R	"BERG, Tom"	0	0	108	108
+City & County of Honolulu	42-05	State Representative	42	N	"BIMBO, Genaro Q."	0	0	3	3
+City & County of Honolulu	43-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	219	219
+City & County of Honolulu	43-01	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	43-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	43-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	43-01	Straight Party			REPUBLICAN PARTY (R)	0	0	107	107
+City & County of Honolulu	43-01	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	186	186
+City & County of Honolulu	43-01	US Representative	1	R	"TATAII, Steve"	0	0	30	30
+City & County of Honolulu	43-01	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	43-01	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	43-01	State Representative	43	D	"FEVELLA, Kurt"	0	0	83	83
+City & County of Honolulu	43-01	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	103	103
+City & County of Honolulu	43-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	411	411
+City & County of Honolulu	43-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	43-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	43-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	43-02	Straight Party			REPUBLICAN PARTY (R)	0	0	252	252
+City & County of Honolulu	43-02	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	361	361
+City & County of Honolulu	43-02	US Representative	1	R	"TATAII, Steve"	0	0	105	105
+City & County of Honolulu	43-02	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	43-02	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	43-02	State Representative	43	D	"FEVELLA, Kurt"	0	0	158	158
+City & County of Honolulu	43-02	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	236	236
+City & County of Honolulu	43-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	254	254
+City & County of Honolulu	43-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	43-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	43-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	43-03	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113
+City & County of Honolulu	43-03	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	206	206
+City & County of Honolulu	43-03	US Representative	1	R	"TATAII, Steve"	0	0	42	42
+City & County of Honolulu	43-03	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	43-03	US Representative	1	L	"ZHAO, Li"	0	0	1	1
+City & County of Honolulu	43-03	State Representative	43	D	"FEVELLA, Kurt"	0	0	132	132
+City & County of Honolulu	43-03	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	104	104
+City & County of Honolulu	43-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	272	272
+City & County of Honolulu	43-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	43-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	43-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	43-04	Straight Party			REPUBLICAN PARTY (R)	0	0	160	160
+City & County of Honolulu	43-04	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	230	230
+City & County of Honolulu	43-04	US Representative	1	R	"TATAII, Steve"	0	0	56	56
+City & County of Honolulu	43-04	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+City & County of Honolulu	43-04	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	43-04	State Representative	43	D	"FEVELLA, Kurt"	0	0	146	146
+City & County of Honolulu	43-04	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	156	156
+City & County of Honolulu	43-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	354	354
+City & County of Honolulu	43-05	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	43-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	43-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	43-05	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136
+City & County of Honolulu	43-05	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	297	297
+City & County of Honolulu	43-05	US Representative	1	R	"TATAII, Steve"	0	0	49	49
+City & County of Honolulu	43-05	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	43-05	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+City & County of Honolulu	43-05	State Representative	43	D	"FEVELLA, Kurt"	0	0	150	150
+City & County of Honolulu	43-05	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	128	128
+City & County of Honolulu	43-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
+City & County of Honolulu	43-06	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	43-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	43-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	43-06	Straight Party			REPUBLICAN PARTY (R)	0	0	209	209
+City & County of Honolulu	43-06	US Representative	1	D	"ABERCROMBIE, Neil"	0	0	275	275
+City & County of Honolulu	43-06	US Representative	1	R	"TATAII, Steve"	0	0	59	59
+City & County of Honolulu	43-06	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	1	1
+City & County of Honolulu	43-06	US Representative	1	L	"ZHAO, Li"	0	0	2	2
+City & County of Honolulu	43-06	State Representative	43	D	"FEVELLA, Kurt"	0	0	128	128
+City & County of Honolulu	43-06	State Representative	43	R	"PINE, Kymberly (Marcos)"	0	0	198	198
+City & County of Honolulu	44-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	126	126
+City & County of Honolulu	44-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	44-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	44-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	44-01	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34
+City & County of Honolulu	44-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	44-01	US Representative	2	D	"HIRONO, Mazie"	0	0	108	108
+City & County of Honolulu	44-01	US Representative	2	R	"EVANS, Roger B."	0	0	31	31
+City & County of Honolulu	44-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	44-01	State Representative	44	D	"AWANA, Karen Leinani"	0	0	82	82
+City & County of Honolulu	44-01	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	35	35
+City & County of Honolulu	44-01	State Representative	44	R	"KU, Tercia L."	0	0	23	23
+City & County of Honolulu	44-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	603	603
+City & County of Honolulu	44-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	44-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	44-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	44-02	Straight Party			REPUBLICAN PARTY (R)	0	0	33	33
+City & County of Honolulu	44-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	44-02	US Representative	2	D	"HIRONO, Mazie"	0	0	355	355
+City & County of Honolulu	44-02	US Representative	2	R	"EVANS, Roger B."	0	0	13	13
+City & County of Honolulu	44-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	44-02	State Senate	21	D	"HANABUSA, Colleen"	0	0	430	430
+City & County of Honolulu	44-02	State Senate	21	R	"JOHNSON, Dickyj"	0	0	16	16
+City & County of Honolulu	44-02	State Representative	44	D	"AWANA, Karen Leinani"	0	0	242	242
+City & County of Honolulu	44-02	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	315	315
+City & County of Honolulu	44-02	State Representative	44	R	"KU, Tercia L."	0	0	21	21
+City & County of Honolulu	44-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	421	421
+City & County of Honolulu	44-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	44-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	44-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	44-03	Straight Party			REPUBLICAN PARTY (R)	0	0	57	57
+City & County of Honolulu	44-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	44-03	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300
+City & County of Honolulu	44-03	US Representative	2	R	"EVANS, Roger B."	0	0	35	35
+City & County of Honolulu	44-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	44-03	State Senate	21	D	"HANABUSA, Colleen"	0	0	295	295
+City & County of Honolulu	44-03	State Senate	21	R	"JOHNSON, Dickyj"	0	0	42	42
+City & County of Honolulu	44-03	State Representative	44	D	"AWANA, Karen Leinani"	0	0	172	172
+City & County of Honolulu	44-03	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	200	200
+City & County of Honolulu	44-03	State Representative	44	R	"KU, Tercia L."	0	0	38	38
+City & County of Honolulu	44-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	477	477
+City & County of Honolulu	44-04	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	44-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	44-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	44-04	Straight Party			REPUBLICAN PARTY (R)	0	0	90	90
+City & County of Honolulu	44-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	44-04	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300
+City & County of Honolulu	44-04	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
+City & County of Honolulu	44-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	44-04	State Senate	21	D	"HANABUSA, Colleen"	0	0	341	341
+City & County of Honolulu	44-04	State Senate	21	R	"JOHNSON, Dickyj"	0	0	58	58
+City & County of Honolulu	44-04	State Representative	44	D	"AWANA, Karen Leinani"	0	0	232	232
+City & County of Honolulu	44-04	State Representative	44	D	"AIPOALANI, Hanalei Y."	0	0	175	175
+City & County of Honolulu	44-04	State Representative	44	R	"KU, Tercia L."	0	0	64	64
+City & County of Honolulu	45-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	637	637
+City & County of Honolulu	45-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	45-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	45-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	45-01	Straight Party			REPUBLICAN PARTY (R)	0	0	101	101
+City & County of Honolulu	45-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	45-01	US Representative	2	D	"HIRONO, Mazie"	0	0	433	433
+City & County of Honolulu	45-01	US Representative	2	R	"EVANS, Roger B."	0	0	53	53
+City & County of Honolulu	45-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	45-01	State Senate	21	D	"HANABUSA, Colleen"	0	0	497	497
+City & County of Honolulu	45-01	State Senate	21	R	"JOHNSON, Dickyj"	0	0	58	58
+City & County of Honolulu	45-01	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	471	471
+City & County of Honolulu	45-01	State Representative	45	D	"SAYLORS, Denise"	0	0	85	85
+City & County of Honolulu	45-01	State Representative	45	R	"GAPOL, Derek A."	0	0	72	72
+City & County of Honolulu	45-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	312	312
+City & County of Honolulu	45-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	45-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	45-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	45-02	Straight Party			REPUBLICAN PARTY (R)	0	0	42	42
+City & County of Honolulu	45-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	45-02	US Representative	2	D	"HIRONO, Mazie"	0	0	221	221
+City & County of Honolulu	45-02	US Representative	2	R	"EVANS, Roger B."	0	0	21	21
+City & County of Honolulu	45-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	45-02	State Senate	21	D	"HANABUSA, Colleen"	0	0	237	237
+City & County of Honolulu	45-02	State Senate	21	R	"JOHNSON, Dickyj"	0	0	20	20
+City & County of Honolulu	45-02	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	213	213
+City & County of Honolulu	45-02	State Representative	45	D	"SAYLORS, Denise"	0	0	53	53
+City & County of Honolulu	45-02	State Representative	45	R	"GAPOL, Derek A."	0	0	28	28
+City & County of Honolulu	45-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	136	136
+City & County of Honolulu	45-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	45-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	45-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	45-03	Straight Party			REPUBLICAN PARTY (R)	0	0	24	24
+City & County of Honolulu	45-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	45-03	US Representative	2	D	"HIRONO, Mazie"	0	0	88	88
+City & County of Honolulu	45-03	US Representative	2	R	"EVANS, Roger B."	0	0	11	11
+City & County of Honolulu	45-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	45-03	State Senate	21	D	"HANABUSA, Colleen"	0	0	98	98
+City & County of Honolulu	45-03	State Senate	21	R	"JOHNSON, Dickyj"	0	0	13	13
+City & County of Honolulu	45-03	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	96	96
+City & County of Honolulu	45-03	State Representative	45	D	"SAYLORS, Denise"	0	0	24	24
+City & County of Honolulu	45-03	State Representative	45	R	"GAPOL, Derek A."	0	0	13	13
+City & County of Honolulu	45-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	424	424
+City & County of Honolulu	45-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	45-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	45-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	45-04	Straight Party			REPUBLICAN PARTY (R)	0	0	91	91
+City & County of Honolulu	45-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	45-04	US Representative	2	D	"HIRONO, Mazie"	0	0	266	266
+City & County of Honolulu	45-04	US Representative	2	R	"EVANS, Roger B."	0	0	44	44
+City & County of Honolulu	45-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	45-04	State Senate	21	D	"HANABUSA, Colleen"	0	0	291	291
+City & County of Honolulu	45-04	State Senate	21	R	"JOHNSON, Dickyj"	0	0	56	56
+City & County of Honolulu	45-04	State Representative	45	D	"SHIMABUKURO, Maile S. L."	0	0	265	265
+City & County of Honolulu	45-04	State Representative	45	D	"SAYLORS, Denise"	0	0	110	110
+City & County of Honolulu	45-04	State Representative	45	R	"GAPOL, Derek A."	0	0	63	63
+City & County of Honolulu	46-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	225	225
+City & County of Honolulu	46-01	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	46-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	46-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	46-01	Straight Party			REPUBLICAN PARTY (R)	0	0	164	164
+City & County of Honolulu	46-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	46-01	US Representative	2	D	"HIRONO, Mazie"	0	0	152	152
+City & County of Honolulu	46-01	US Representative	2	R	"EVANS, Roger B."	0	0	106	106
+City & County of Honolulu	46-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	46-01	State Senate	23	D	"HEE, Clayton"	0	0	162	162
+City & County of Honolulu	46-01	State Senate	23	D	"MURAKI, Noel S."	0	0	35	35
+City & County of Honolulu	46-01	State Senate	23	R	"FALE, Richard"	0	0	117	117
+City & County of Honolulu	46-01	State Representative	46	D	"LUNASCO, Ollie"	0	0	6	6
+City & County of Honolulu	46-01	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	155	155
+City & County of Honolulu	46-01	State Representative	46	D	"WASSON, Dawn K."	0	0	50	50
+City & County of Honolulu	46-01	State Representative	46	R	"PHILIPS, Carol"	0	0	102	102
+City & County of Honolulu	46-01	State Representative	46	R	"RIVIERE, Gil"	0	0	49	49
+City & County of Honolulu	46-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	42	42
+City & County of Honolulu	46-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	46-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	46-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	46-02	Straight Party			REPUBLICAN PARTY (R)	0	0	8	8
+City & County of Honolulu	46-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	46-02	US Representative	2	D	"HIRONO, Mazie"	0	0	33	33
+City & County of Honolulu	46-02	US Representative	2	R	"EVANS, Roger B."	0	0	5	5
+City & County of Honolulu	46-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	46-02	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	30	30
+City & County of Honolulu	46-02	State Representative	46	D	"LUNASCO, Ollie"	0	0	8	8
+City & County of Honolulu	46-02	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	28	28
+City & County of Honolulu	46-02	State Representative	46	D	"WASSON, Dawn K."	0	0	3	3
+City & County of Honolulu	46-02	State Representative	46	R	"PHILIPS, Carol"	0	0	6	6
+City & County of Honolulu	46-02	State Representative	46	R	"RIVIERE, Gil"	0	0	1	1
+City & County of Honolulu	46-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	481	481
+City & County of Honolulu	46-03	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	46-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	46-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	46-03	Straight Party			REPUBLICAN PARTY (R)	0	0	222	222
+City & County of Honolulu	46-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	46-03	US Representative	2	D	"HIRONO, Mazie"	0	0	346	346
+City & County of Honolulu	46-03	US Representative	2	R	"EVANS, Roger B."	0	0	79	79
+City & County of Honolulu	46-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	46-03	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	352	352
+City & County of Honolulu	46-03	State Representative	46	D	"LUNASCO, Ollie"	0	0	91	91
+City & County of Honolulu	46-03	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	328	328
+City & County of Honolulu	46-03	State Representative	46	D	"WASSON, Dawn K."	0	0	39	39
+City & County of Honolulu	46-03	State Representative	46	R	"PHILIPS, Carol"	0	0	100	100
+City & County of Honolulu	46-03	State Representative	46	R	"RIVIERE, Gil"	0	0	119	119
+City & County of Honolulu	46-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	392	392
+City & County of Honolulu	46-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	46-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	46-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	46-04	Straight Party			REPUBLICAN PARTY (R)	0	0	208	208
+City & County of Honolulu	46-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	46-04	US Representative	2	D	"HIRONO, Mazie"	0	0	307	307
+City & County of Honolulu	46-04	US Representative	2	R	"EVANS, Roger B."	0	0	70	70
+City & County of Honolulu	46-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	46-04	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	289	289
+City & County of Honolulu	46-04	State Representative	46	D	"LUNASCO, Ollie"	0	0	57	57
+City & County of Honolulu	46-04	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	289	289
+City & County of Honolulu	46-04	State Representative	46	D	"WASSON, Dawn K."	0	0	25	25
+City & County of Honolulu	46-04	State Representative	46	R	"PHILIPS, Carol"	0	0	88	88
+City & County of Honolulu	46-04	State Representative	46	R	"RIVIERE, Gil"	0	0	117	117
+City & County of Honolulu	46-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	254	254
+City & County of Honolulu	46-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	46-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	46-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	46-05	Straight Party			REPUBLICAN PARTY (R)	0	0	295	295
+City & County of Honolulu	46-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	46-05	US Representative	2	D	"HIRONO, Mazie"	0	0	174	174
+City & County of Honolulu	46-05	US Representative	2	R	"EVANS, Roger B."	0	0	106	106
+City & County of Honolulu	46-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	46-05	State Senate	22	D	"BUNDA, Robert (Bobby)"	0	0	154	154
+City & County of Honolulu	46-05	State Representative	46	D	"LUNASCO, Ollie"	0	0	31	31
+City & County of Honolulu	46-05	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	160	160
+City & County of Honolulu	46-05	State Representative	46	D	"WASSON, Dawn K."	0	0	35	35
+City & County of Honolulu	46-05	State Representative	46	R	"PHILIPS, Carol"	0	0	108	108
+City & County of Honolulu	46-05	State Representative	46	R	"RIVIERE, Gil"	0	0	186	186
+City & County of Honolulu	46-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	220	220
+City & County of Honolulu	46-06	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	46-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	46-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	46-06	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115
+City & County of Honolulu	46-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	46-06	US Representative	2	D	"HIRONO, Mazie"	0	0	177	177
+City & County of Honolulu	46-06	US Representative	2	R	"EVANS, Roger B."	0	0	51	51
+City & County of Honolulu	46-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	46-06	State Senate	23	D	"HEE, Clayton"	0	0	153	153
+City & County of Honolulu	46-06	State Senate	23	D	"MURAKI, Noel S."	0	0	29	29
+City & County of Honolulu	46-06	State Senate	23	R	"FALE, Richard"	0	0	66	66
+City & County of Honolulu	46-06	State Representative	46	D	"LUNASCO, Ollie"	0	0	26	26
+City & County of Honolulu	46-06	State Representative	46	D	"MAGAOAY, Michael Y."	0	0	130	130
+City & County of Honolulu	46-06	State Representative	46	D	"WASSON, Dawn K."	0	0	51	51
+City & County of Honolulu	46-06	State Representative	46	R	"PHILIPS, Carol"	0	0	55	55
+City & County of Honolulu	46-06	State Representative	46	R	"RIVIERE, Gil"	0	0	50	50
+City & County of Honolulu	47-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	496	496
+City & County of Honolulu	47-01	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	47-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	47-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	47-01	Straight Party			REPUBLICAN PARTY (R)	0	0	258	258
+City & County of Honolulu	47-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	47-01	US Representative	2	D	"HIRONO, Mazie"	0	0	348	348
+City & County of Honolulu	47-01	US Representative	2	R	"EVANS, Roger B."	0	0	107	107
+City & County of Honolulu	47-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	47-01	State Senate	23	D	"HEE, Clayton"	0	0	309	309
+City & County of Honolulu	47-01	State Senate	23	D	"MURAKI, Noel S."	0	0	112	112
+City & County of Honolulu	47-01	State Senate	23	R	"FALE, Richard"	0	0	129	129
+City & County of Honolulu	47-01	State Representative	47	D	"PACHECO, Maria"	0	0	131	131
+City & County of Honolulu	47-01	State Representative	47	D	"WOOLEY, Jessica"	0	0	299	299
+City & County of Honolulu	47-01	State Representative	47	R	"MEYER, Colleen"	0	0	223	223
+City & County of Honolulu	47-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	383	383
+City & County of Honolulu	47-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	47-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	47-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	47-02	Straight Party			REPUBLICAN PARTY (R)	0	0	113	113
+City & County of Honolulu	47-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	47-02	US Representative	2	D	"HIRONO, Mazie"	0	0	288	288
+City & County of Honolulu	47-02	US Representative	2	R	"EVANS, Roger B."	0	0	33	33
+City & County of Honolulu	47-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	47-02	State Senate	23	D	"HEE, Clayton"	0	0	253	253
+City & County of Honolulu	47-02	State Senate	23	D	"MURAKI, Noel S."	0	0	81	81
+City & County of Honolulu	47-02	State Senate	23	R	"FALE, Richard"	0	0	34	34
+City & County of Honolulu	47-02	State Representative	47	D	"PACHECO, Maria"	0	0	74	74
+City & County of Honolulu	47-02	State Representative	47	D	"WOOLEY, Jessica"	0	0	265	265
+City & County of Honolulu	47-02	State Representative	47	R	"MEYER, Colleen"	0	0	109	109
+City & County of Honolulu	47-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	387	387
+City & County of Honolulu	47-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	47-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	47-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	47-03	Straight Party			REPUBLICAN PARTY (R)	0	0	136	136
+City & County of Honolulu	47-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	47-03	US Representative	2	D	"HIRONO, Mazie"	0	0	310	310
+City & County of Honolulu	47-03	US Representative	2	R	"EVANS, Roger B."	0	0	63	63
+City & County of Honolulu	47-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	47-03	State Senate	23	D	"HEE, Clayton"	0	0	255	255
+City & County of Honolulu	47-03	State Senate	23	D	"MURAKI, Noel S."	0	0	93	93
+City & County of Honolulu	47-03	State Senate	23	R	"FALE, Richard"	0	0	60	60
+City & County of Honolulu	47-03	State Representative	47	D	"PACHECO, Maria"	0	0	82	82
+City & County of Honolulu	47-03	State Representative	47	D	"WOOLEY, Jessica"	0	0	270	270
+City & County of Honolulu	47-03	State Representative	47	R	"MEYER, Colleen"	0	0	129	129
+City & County of Honolulu	47-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	147	147
+City & County of Honolulu	47-04	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	47-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	47-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	47-04	Straight Party			REPUBLICAN PARTY (R)	0	0	36	36
+City & County of Honolulu	47-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+City & County of Honolulu	47-04	US Representative	2	D	"HIRONO, Mazie"	0	0	117	117
+City & County of Honolulu	47-04	US Representative	2	R	"EVANS, Roger B."	0	0	17	17
+City & County of Honolulu	47-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	47-04	State Senate	23	D	"HEE, Clayton"	0	0	93	93
+City & County of Honolulu	47-04	State Senate	23	D	"MURAKI, Noel S."	0	0	33	33
+City & County of Honolulu	47-04	State Senate	23	R	"FALE, Richard"	0	0	13	13
+City & County of Honolulu	47-04	State Representative	47	D	"PACHECO, Maria"	0	0	22	22
+City & County of Honolulu	47-04	State Representative	47	D	"WOOLEY, Jessica"	0	0	98	98
+City & County of Honolulu	47-04	State Representative	47	R	"MEYER, Colleen"	0	0	34	34
+City & County of Honolulu	47-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	87	87
+City & County of Honolulu	47-05	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	47-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	47-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	47-05	Straight Party			REPUBLICAN PARTY (R)	0	0	37	37
+City & County of Honolulu	47-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	47-05	US Representative	2	D	"HIRONO, Mazie"	0	0	73	73
+City & County of Honolulu	47-05	US Representative	2	R	"EVANS, Roger B."	0	0	19	19
+City & County of Honolulu	47-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	47-05	State Senate	23	D	"HEE, Clayton"	0	0	44	44
+City & County of Honolulu	47-05	State Senate	23	D	"MURAKI, Noel S."	0	0	35	35
+City & County of Honolulu	47-05	State Senate	23	R	"FALE, Richard"	0	0	20	20
+City & County of Honolulu	47-05	State Representative	47	D	"PACHECO, Maria"	0	0	20	20
+City & County of Honolulu	47-05	State Representative	47	D	"WOOLEY, Jessica"	0	0	55	55
+City & County of Honolulu	47-05	State Representative	47	R	"MEYER, Colleen"	0	0	35	35
+City & County of Honolulu	47-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	984	984
+City & County of Honolulu	47-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	47-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	7	7
+City & County of Honolulu	47-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	47-06	Straight Party			REPUBLICAN PARTY (R)	0	0	240	240
+City & County of Honolulu	47-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+City & County of Honolulu	47-06	US Representative	2	D	"HIRONO, Mazie"	0	0	730	730
+City & County of Honolulu	47-06	US Representative	2	R	"EVANS, Roger B."	0	0	90	90
+City & County of Honolulu	47-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	7	7
+City & County of Honolulu	47-06	State Senate	23	D	"HEE, Clayton"	0	0	645	645
+City & County of Honolulu	47-06	State Senate	23	D	"MURAKI, Noel S."	0	0	220	220
+City & County of Honolulu	47-06	State Senate	23	R	"FALE, Richard"	0	0	85	85
+City & County of Honolulu	47-06	State Representative	47	D	"PACHECO, Maria"	0	0	160	160
+City & County of Honolulu	47-06	State Representative	47	D	"WOOLEY, Jessica"	0	0	683	683
+City & County of Honolulu	47-06	State Representative	47	R	"MEYER, Colleen"	0	0	231	231
+City & County of Honolulu	48-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	600	600
+City & County of Honolulu	48-01	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	48-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	48-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	48-01	Straight Party			REPUBLICAN PARTY (R)	0	0	112	112
+City & County of Honolulu	48-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	48-01	US Representative	2	D	"HIRONO, Mazie"	0	0	481	481
+City & County of Honolulu	48-01	US Representative	2	R	"EVANS, Roger B."	0	0	85	85
+City & County of Honolulu	48-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	48-01	State Senate	23	D	"HEE, Clayton"	0	0	356	356
+City & County of Honolulu	48-01	State Senate	23	D	"MURAKI, Noel S."	0	0	150	150
+City & County of Honolulu	48-01	State Senate	23	R	"FALE, Richard"	0	0	75	75
+City & County of Honolulu	48-01	State Representative	48	D	"ITO, Ken"	0	0	452	452
+City & County of Honolulu	48-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	486	486
+City & County of Honolulu	48-02	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	48-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	48-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	48-02	Straight Party			REPUBLICAN PARTY (R)	0	0	108	108
+City & County of Honolulu	48-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+City & County of Honolulu	48-02	US Representative	2	D	"HIRONO, Mazie"	0	0	380	380
+City & County of Honolulu	48-02	US Representative	2	R	"EVANS, Roger B."	0	0	104	104
+City & County of Honolulu	48-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	48-02	State Representative	48	D	"ITO, Ken"	0	0	355	355
+City & County of Honolulu	48-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	642	642
+City & County of Honolulu	48-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	48-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	48-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
+City & County of Honolulu	48-03	Straight Party			REPUBLICAN PARTY (R)	0	0	115	115
+City & County of Honolulu	48-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+City & County of Honolulu	48-03	US Representative	2	D	"HIRONO, Mazie"	0	0	487	487
+City & County of Honolulu	48-03	US Representative	2	R	"EVANS, Roger B."	0	0	107	107
+City & County of Honolulu	48-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	48-03	State Representative	48	D	"ITO, Ken"	0	0	493	493
+City & County of Honolulu	48-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	833	833
+City & County of Honolulu	48-04	Straight Party			INDEPENDENT PARTY (I)	0	0	9	9
+City & County of Honolulu	48-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	48-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	48-04	Straight Party			REPUBLICAN PARTY (R)	0	0	128	128
+City & County of Honolulu	48-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	9	9
+City & County of Honolulu	48-04	US Representative	2	D	"HIRONO, Mazie"	0	0	667	667
+City & County of Honolulu	48-04	US Representative	2	R	"EVANS, Roger B."	0	0	121	121
+City & County of Honolulu	48-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
+City & County of Honolulu	48-04	State Representative	48	D	"ITO, Ken"	0	0	659	659
+City & County of Honolulu	48-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	267	267
+City & County of Honolulu	48-05	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	48-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	48-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+City & County of Honolulu	48-05	Straight Party			REPUBLICAN PARTY (R)	0	0	48	48
+City & County of Honolulu	48-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+City & County of Honolulu	48-05	US Representative	2	D	"HIRONO, Mazie"	0	0	205	205
+City & County of Honolulu	48-05	US Representative	2	R	"EVANS, Roger B."	0	0	41	41
+City & County of Honolulu	48-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	48-05	State Senate	23	D	"HEE, Clayton"	0	0	150	150
+City & County of Honolulu	48-05	State Senate	23	D	"MURAKI, Noel S."	0	0	82	82
+City & County of Honolulu	48-05	State Senate	23	R	"FALE, Richard"	0	0	35	35
+City & County of Honolulu	48-05	State Representative	48	D	"ITO, Ken"	0	0	204	204
+City & County of Honolulu	49-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	513	513
+City & County of Honolulu	49-01	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15
+City & County of Honolulu	49-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	49-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	49-01	Straight Party			REPUBLICAN PARTY (R)	0	0	192	192
+City & County of Honolulu	49-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
+City & County of Honolulu	49-01	US Representative	2	D	"HIRONO, Mazie"	0	0	361	361
+City & County of Honolulu	49-01	US Representative	2	R	"EVANS, Roger B."	0	0	182	182
+City & County of Honolulu	49-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+City & County of Honolulu	49-01	State Representative	49	D	"CHONG, Pono"	0	0	343	343
+City & County of Honolulu	49-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	283	283
+City & County of Honolulu	49-02	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	49-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	49-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	49-02	Straight Party			REPUBLICAN PARTY (R)	0	0	63	63
+City & County of Honolulu	49-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	49-02	US Representative	2	D	"HIRONO, Mazie"	0	0	226	226
+City & County of Honolulu	49-02	US Representative	2	R	"EVANS, Roger B."	0	0	57	57
+City & County of Honolulu	49-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	49-02	State Representative	49	D	"CHONG, Pono"	0	0	192	192
+City & County of Honolulu	49-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	578	578
+City & County of Honolulu	49-03	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	49-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	49-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	49-03	Straight Party			REPUBLICAN PARTY (R)	0	0	154	154
+City & County of Honolulu	49-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+City & County of Honolulu	49-03	US Representative	2	D	"HIRONO, Mazie"	0	0	422	422
+City & County of Honolulu	49-03	US Representative	2	R	"EVANS, Roger B."	0	0	143	143
+City & County of Honolulu	49-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
+City & County of Honolulu	49-03	State Representative	49	D	"CHONG, Pono"	0	0	410	410
+City & County of Honolulu	49-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	232	232
+City & County of Honolulu	49-04	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	49-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	49-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	49-04	Straight Party			REPUBLICAN PARTY (R)	0	0	75	75
+City & County of Honolulu	49-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	49-04	US Representative	2	D	"HIRONO, Mazie"	0	0	175	175
+City & County of Honolulu	49-04	US Representative	2	R	"EVANS, Roger B."	0	0	74	74
+City & County of Honolulu	49-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	49-04	State Representative	49	D	"CHONG, Pono"	0	0	149	149
+City & County of Honolulu	49-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	317	317
+City & County of Honolulu	49-05	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	49-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	49-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	49-05	Straight Party			REPUBLICAN PARTY (R)	0	0	105	105
+City & County of Honolulu	49-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	49-05	US Representative	2	D	"HIRONO, Mazie"	0	0	235	235
+City & County of Honolulu	49-05	US Representative	2	R	"EVANS, Roger B."	0	0	103	103
+City & County of Honolulu	49-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+City & County of Honolulu	49-05	State Representative	49	D	"CHONG, Pono"	0	0	212	212
+City & County of Honolulu	49-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	417	417
+City & County of Honolulu	49-06	Straight Party			INDEPENDENT PARTY (I)	0	0	11	11
+City & County of Honolulu	49-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	49-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	49-06	Straight Party			REPUBLICAN PARTY (R)	0	0	69	69
+City & County of Honolulu	49-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
+City & County of Honolulu	49-06	US Representative	2	D	"HIRONO, Mazie"	0	0	338	338
+City & County of Honolulu	49-06	US Representative	2	R	"EVANS, Roger B."	0	0	69	69
+City & County of Honolulu	49-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	49-06	State Representative	49	D	"CHONG, Pono"	0	0	251	251
+City & County of Honolulu	49-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	575	575
+City & County of Honolulu	49-07	Straight Party			INDEPENDENT PARTY (I)	0	0	8	8
+City & County of Honolulu	49-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	49-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	4	4
+City & County of Honolulu	49-07	Straight Party			REPUBLICAN PARTY (R)	0	0	143	143
+City & County of Honolulu	49-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+City & County of Honolulu	49-07	US Representative	2	D	"HIRONO, Mazie"	0	0	463	463
+City & County of Honolulu	49-07	US Representative	2	R	"EVANS, Roger B."	0	0	117	117
+City & County of Honolulu	49-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+City & County of Honolulu	49-07	State Senate	23	D	"HEE, Clayton"	0	0	319	319
+City & County of Honolulu	49-07	State Senate	23	D	"MURAKI, Noel S."	0	0	154	154
+City & County of Honolulu	49-07	State Senate	23	R	"FALE, Richard"	0	0	87	87
+City & County of Honolulu	49-07	State Representative	49	D	"CHONG, Pono"	0	0	430	430
+City & County of Honolulu	50-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	275	275
+City & County of Honolulu	50-01	Straight Party			INDEPENDENT PARTY (I)	0	0	14	14
+City & County of Honolulu	50-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	50-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	6	6
+City & County of Honolulu	50-01	Straight Party			REPUBLICAN PARTY (R)	0	0	202	202
+City & County of Honolulu	50-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	11	11
+City & County of Honolulu	50-01	US Representative	2	D	"HIRONO, Mazie"	0	0	253	253
+City & County of Honolulu	50-01	US Representative	2	R	"EVANS, Roger B."	0	0	58	58
+City & County of Honolulu	50-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	50-01	State Representative	50	R	"THIELEN, Cynthia"	0	0	184	184
+City & County of Honolulu	50-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	311	311
+City & County of Honolulu	50-02	Straight Party			INDEPENDENT PARTY (I)	0	0	15	15
+City & County of Honolulu	50-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	50-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	50-02	Straight Party			REPUBLICAN PARTY (R)	0	0	174	174
+City & County of Honolulu	50-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	15	15
+City & County of Honolulu	50-02	US Representative	2	D	"HIRONO, Mazie"	0	0	286	286
+City & County of Honolulu	50-02	US Representative	2	R	"EVANS, Roger B."	0	0	54	54
+City & County of Honolulu	50-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	4	4
+City & County of Honolulu	50-02	State Representative	50	R	"THIELEN, Cynthia"	0	0	155	155
+City & County of Honolulu	50-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	214	214
+City & County of Honolulu	50-03	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	50-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	50-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	50-03	Straight Party			REPUBLICAN PARTY (R)	0	0	140	140
+City & County of Honolulu	50-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	50-03	US Representative	2	D	"HIRONO, Mazie"	0	0	201	201
+City & County of Honolulu	50-03	US Representative	2	R	"EVANS, Roger B."	0	0	39	39
+City & County of Honolulu	50-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	50-03	State Representative	50	R	"THIELEN, Cynthia"	0	0	121	121
+City & County of Honolulu	50-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	319	319
+City & County of Honolulu	50-04	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
+City & County of Honolulu	50-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	50-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	7	7
+City & County of Honolulu	50-04	Straight Party			REPUBLICAN PARTY (R)	0	0	151	151
+City & County of Honolulu	50-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	10	10
+City & County of Honolulu	50-04	US Representative	2	D	"HIRONO, Mazie"	0	0	300	300
+City & County of Honolulu	50-04	US Representative	2	R	"EVANS, Roger B."	0	0	47	47
+City & County of Honolulu	50-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	50-04	State Representative	50	R	"THIELEN, Cynthia"	0	0	133	133
+City & County of Honolulu	50-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	313	313
+City & County of Honolulu	50-05	Straight Party			INDEPENDENT PARTY (I)	0	0	10	10
+City & County of Honolulu	50-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	50-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	5	5
+City & County of Honolulu	50-05	Straight Party			REPUBLICAN PARTY (R)	0	0	270	270
+City & County of Honolulu	50-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	8	8
+City & County of Honolulu	50-05	US Representative	2	D	"HIRONO, Mazie"	0	0	296	296
+City & County of Honolulu	50-05	US Representative	2	R	"EVANS, Roger B."	0	0	83	83
+City & County of Honolulu	50-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	50-05	State Representative	50	R	"THIELEN, Cynthia"	0	0	244	244
+City & County of Honolulu	50-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	293	293
+City & County of Honolulu	50-06	Straight Party			INDEPENDENT PARTY (I)	0	0	7	7
+City & County of Honolulu	50-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	50-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	11	11
+City & County of Honolulu	50-06	Straight Party			REPUBLICAN PARTY (R)	0	0	282	282
+City & County of Honolulu	50-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	7	7
+City & County of Honolulu	50-06	US Representative	2	D	"HIRONO, Mazie"	0	0	265	265
+City & County of Honolulu	50-06	US Representative	2	R	"EVANS, Roger B."	0	0	76	76
+City & County of Honolulu	50-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	50-06	State Representative	50	R	"THIELEN, Cynthia"	0	0	248	248
+City & County of Honolulu	50-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	117	117
+City & County of Honolulu	50-07	Straight Party			INDEPENDENT PARTY (I)	0	0	5	5
+City & County of Honolulu	50-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	2	2
+City & County of Honolulu	50-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	50-07	Straight Party			REPUBLICAN PARTY (R)	0	0	137	137
+City & County of Honolulu	50-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	5	5
+City & County of Honolulu	50-07	US Representative	2	D	"HIRONO, Mazie"	0	0	106	106
+City & County of Honolulu	50-07	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
+City & County of Honolulu	50-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	2	2
+City & County of Honolulu	50-07	State Representative	50	R	"THIELEN, Cynthia"	0	0	129	129
+City & County of Honolulu	51-01	Straight Party			DEMOCRATIC PARTY (D)	0	0	327	327
+City & County of Honolulu	51-01	Straight Party			INDEPENDENT PARTY (I)	0	0	6	6
+City & County of Honolulu	51-01	Straight Party			LIBERTARIAN PARTY (L)	0	0	4	4
+City & County of Honolulu	51-01	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	51-01	Straight Party			REPUBLICAN PARTY (R)	0	0	161	161
+City & County of Honolulu	51-01	US Representative	2	I	"STENSHOL, Shaun"	0	0	6	6
+City & County of Honolulu	51-01	US Representative	2	D	"HIRONO, Mazie"	0	0	195	195
+City & County of Honolulu	51-01	US Representative	2	R	"EVANS, Roger B."	0	0	65	65
+City & County of Honolulu	51-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	51-01	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	82	82
+City & County of Honolulu	51-01	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	12	12
+City & County of Honolulu	51-01	State Representative	51	D	"LEE, Chris Kalani"	0	0	210	210
+City & County of Honolulu	51-01	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	149	149
+City & County of Honolulu	51-02	Straight Party			DEMOCRATIC PARTY (D)	0	0	567	567
+City & County of Honolulu	51-02	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	51-02	Straight Party			LIBERTARIAN PARTY (L)	0	0	5	5
+City & County of Honolulu	51-02	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	51-02	Straight Party			REPUBLICAN PARTY (R)	0	0	92	92
+City & County of Honolulu	51-02	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	51-02	US Representative	2	D	"HIRONO, Mazie"	0	0	381	381
+City & County of Honolulu	51-02	US Representative	2	R	"EVANS, Roger B."	0	0	42	42
+City & County of Honolulu	51-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	5	5
+City & County of Honolulu	51-02	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	304	304
+City & County of Honolulu	51-02	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	12	12
+City & County of Honolulu	51-02	State Representative	51	D	"LEE, Chris Kalani"	0	0	225	225
+City & County of Honolulu	51-02	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	85	85
+City & County of Honolulu	51-03	Straight Party			DEMOCRATIC PARTY (D)	0	0	663	663
+City & County of Honolulu	51-03	Straight Party			INDEPENDENT PARTY (I)	0	0	1	1
+City & County of Honolulu	51-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	51-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	1	1
+City & County of Honolulu	51-03	Straight Party			REPUBLICAN PARTY (R)	0	0	82	82
+City & County of Honolulu	51-03	US Representative	2	I	"STENSHOL, Shaun"	0	0	1	1
+City & County of Honolulu	51-03	US Representative	2	D	"HIRONO, Mazie"	0	0	423	423
+City & County of Honolulu	51-03	US Representative	2	R	"EVANS, Roger B."	0	0	27	27
+City & County of Honolulu	51-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	51-03	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	340	340
+City & County of Honolulu	51-03	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	21	21
+City & County of Honolulu	51-03	State Representative	51	D	"LEE, Chris Kalani"	0	0	285	285
+City & County of Honolulu	51-03	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	78	78
+City & County of Honolulu	51-04	Straight Party			DEMOCRATIC PARTY (D)	0	0	132	132
+City & County of Honolulu	51-04	Straight Party			INDEPENDENT PARTY (I)	0	0	2	2
+City & County of Honolulu	51-04	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+City & County of Honolulu	51-04	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	51-04	Straight Party			REPUBLICAN PARTY (R)	0	0	34	34
+City & County of Honolulu	51-04	US Representative	2	I	"STENSHOL, Shaun"	0	0	2	2
+City & County of Honolulu	51-04	US Representative	2	D	"HIRONO, Mazie"	0	0	102	102
+City & County of Honolulu	51-04	US Representative	2	R	"EVANS, Roger B."	0	0	13	13
+City & County of Honolulu	51-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+City & County of Honolulu	51-04	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	35	35
+City & County of Honolulu	51-04	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	7	7
+City & County of Honolulu	51-04	State Representative	51	D	"LEE, Chris Kalani"	0	0	87	87
+City & County of Honolulu	51-04	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	32	32
+City & County of Honolulu	51-05	Straight Party			DEMOCRATIC PARTY (D)	0	0	706	706
+City & County of Honolulu	51-05	Straight Party			INDEPENDENT PARTY (I)	0	0	4	4
+City & County of Honolulu	51-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	51-05	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	51-05	Straight Party			REPUBLICAN PARTY (R)	0	0	176	176
+City & County of Honolulu	51-05	US Representative	2	I	"STENSHOL, Shaun"	0	0	4	4
+City & County of Honolulu	51-05	US Representative	2	D	"HIRONO, Mazie"	0	0	467	467
+City & County of Honolulu	51-05	US Representative	2	R	"EVANS, Roger B."	0	0	62	62
+City & County of Honolulu	51-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	51-05	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	241	241
+City & County of Honolulu	51-05	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	21	21
+City & County of Honolulu	51-05	State Representative	51	D	"LEE, Chris Kalani"	0	0	414	414
+City & County of Honolulu	51-05	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	170	170
+City & County of Honolulu	51-06	Straight Party			DEMOCRATIC PARTY (D)	0	0	360	360
+City & County of Honolulu	51-06	Straight Party			INDEPENDENT PARTY (I)	0	0	3	3
+City & County of Honolulu	51-06	Straight Party			LIBERTARIAN PARTY (L)	0	0	3	3
+City & County of Honolulu	51-06	Straight Party			NONPARTISAN BALLOT (N)	0	0	2	2
+City & County of Honolulu	51-06	Straight Party			REPUBLICAN PARTY (R)	0	0	137	137
+City & County of Honolulu	51-06	US Representative	2	I	"STENSHOL, Shaun"	0	0	3	3
+City & County of Honolulu	51-06	US Representative	2	D	"HIRONO, Mazie"	0	0	224	224
+City & County of Honolulu	51-06	US Representative	2	R	"EVANS, Roger B."	0	0	60	60
+City & County of Honolulu	51-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	3	3
+City & County of Honolulu	51-06	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	85	85
+City & County of Honolulu	51-06	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	26	26
+City & County of Honolulu	51-06	State Representative	51	D	"LEE, Chris Kalani"	0	0	229	229
+City & County of Honolulu	51-06	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	129	129
+City & County of Honolulu	51-07	Straight Party			DEMOCRATIC PARTY (D)	0	0	162	162
+City & County of Honolulu	51-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+City & County of Honolulu	51-07	Straight Party			LIBERTARIAN PARTY (L)	0	0	1	1
+City & County of Honolulu	51-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	3	3
+City & County of Honolulu	51-07	Straight Party			REPUBLICAN PARTY (R)	0	0	83	83
+City & County of Honolulu	51-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+City & County of Honolulu	51-07	US Representative	2	D	"HIRONO, Mazie"	0	0	106	106
+City & County of Honolulu	51-07	US Representative	2	R	"EVANS, Roger B."	0	0	34	34
+City & County of Honolulu	51-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	1	1
+City & County of Honolulu	51-07	State Representative	51	D	"ANDERSON, J. Ikaika"	0	0	29	29
+City & County of Honolulu	51-07	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	0	0	6	6
+City & County of Honolulu	51-07	State Representative	51	D	"LEE, Chris Kalani"	0	0	109	109
+City & County of Honolulu	51-07	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	0	0	69	69
+	AB-01	Straight Party			DEMOCRATIC PARTY (D)	174	312	0	486
+	AB-01	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
+	AB-01	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
+	AB-01	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7
+	AB-01	Straight Party			REPUBLICAN PARTY (R)	27	27	0	54
+	AB-01	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1
+	AB-01	US Representative	2	D	"HIRONO, Mazie"	146	242	0	388
+	AB-01	US Representative	2	R	"EVANS, Roger B."	22	17	0	39
+	AB-01	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
+	AB-01	State Senate	3	D	"ISBELL, Virginia"	30	31	0	61
+	AB-01	State Senate	3	D	"GREEN, Josh"	137	264	0	401
+	AB-01	State Representative	1	D	"FUJIYAMA, Ken"	12	49	0	61
+	AB-01	State Representative	1	D	"KIM, Jo"	44	70	0	114
+	AB-01	State Representative	1	D	"NAKASHIMA, Mark M."	84	146	0	230
+	AB-01	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	16	11	0	27
+	AB-01	State Representative	1	R	"OFFENBAKER, Steven A."	14	11	0	25
+	AB-01	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	8	8	0	16
+	AB-02	Straight Party			DEMOCRATIC PARTY (D)	721	460	0	1181
+	AB-02	Straight Party			INDEPENDENT PARTY (I)	2	2	0	4
+	AB-02	Straight Party			LIBERTARIAN PARTY (L)	2	1	0	3
+	AB-02	Straight Party			NONPARTISAN BALLOT (N)	1	5	0	6
+	AB-02	Straight Party			REPUBLICAN PARTY (R)	75	67	0	142
+	AB-02	US Representative	2	I	"STENSHOL, Shaun"	2	2	0	4
+	AB-02	US Representative	2	D	"HIRONO, Mazie"	574	360	0	934
+	AB-02	US Representative	2	R	"EVANS, Roger B."	45	44	0	89
+	AB-02	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2
+	AB-02	State Senate	1	D	"TAKAMINE, Dwight Y."	627	380	0	1007
+	AB-02	State Senate	1	R	"HONG, Ted H.S."	58	62	0	120
+	AB-02	State Representative	1	D	"FUJIYAMA, Ken"	75	59	0	134
+	AB-02	State Representative	1	D	"KIM, Jo"	144	115	0	259
+	AB-02	State Representative	1	D	"NAKASHIMA, Mark M."	437	230	0	667
+	AB-02	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	16	17	0	33
+	AB-02	State Representative	1	R	"OFFENBAKER, Steven A."	37	41	0	78
+	AB-02	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	15	10	0	25
+	AB-03	Straight Party			DEMOCRATIC PARTY (D)	23	34	0	57
+	AB-03	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
+	AB-03	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-03	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-03	Straight Party			REPUBLICAN PARTY (R)	12	10	0	22
+	AB-03	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1
+	AB-03	US Representative	2	D	"HIRONO, Mazie"	20	25	0	45
+	AB-03	US Representative	2	R	"EVANS, Roger B."	8	9	0	17
+	AB-03	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-03	State Senate	1	D	"TAKAMINE, Dwight Y."	17	23	0	40
+	AB-03	State Senate	1	R	"HONG, Ted H.S."	10	9	0	19
+	AB-03	State Representative	1	D	"FUJIYAMA, Ken"	3	7	0	10
+	AB-03	State Representative	1	D	"KIM, Jo"	3	12	0	15
+	AB-03	State Representative	1	D	"NAKASHIMA, Mark M."	10	8	0	18
+	AB-03	State Representative	1	D	"NAKKIM, Lynn (Kalama)"	1	0	0	1
+	AB-03	State Representative	1	R	"OFFENBAKER, Steven A."	6	6	0	12
+	AB-03	State Representative	1	R	"WEINERT, Eric, Jr. (Drake)"	5	1	0	6
+	AB-04	Straight Party			DEMOCRATIC PARTY (D)	726	830	0	1556
+	AB-04	Straight Party			INDEPENDENT PARTY (I)	5	7	0	12
+	AB-04	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
+	AB-04	Straight Party			NONPARTISAN BALLOT (N)	7	9	0	16
+	AB-04	Straight Party			REPUBLICAN PARTY (R)	145	126	0	271
+	AB-04	US Representative	2	I	"STENSHOL, Shaun"	3	6	0	9
+	AB-04	US Representative	2	D	"HIRONO, Mazie"	575	593	0	1168
+	AB-04	US Representative	2	R	"EVANS, Roger B."	86	57	0	143
+	AB-04	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2
+	AB-04	State Senate	1	D	"TAKAMINE, Dwight Y."	568	596	0	1164
+	AB-04	State Senate	1	R	"HONG, Ted H.S."	132	118	0	250
+	AB-04	State Representative	2	D	"CHANG, Jerry Leslie"	554	603	0	1157
+	AB-05	Straight Party			DEMOCRATIC PARTY (D)	283	349	0	632
+	AB-05	Straight Party			INDEPENDENT PARTY (I)	1	6	0	7
+	AB-05	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-05	Straight Party			NONPARTISAN BALLOT (N)	3	3	0	6
+	AB-05	Straight Party			REPUBLICAN PARTY (R)	39	52	0	91
+	AB-05	US Representative	2	I	"STENSHOL, Shaun"	1	4	0	5
+	AB-05	US Representative	2	D	"HIRONO, Mazie"	243	252	0	495
+	AB-05	US Representative	2	R	"EVANS, Roger B."	17	32	0	49
+	AB-05	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-05	State Senate	1	D	"TAKAMINE, Dwight Y."	215	248	0	463
+	AB-05	State Senate	1	R	"HONG, Ted H.S."	36	48	0	84
+	AB-05	State Representative	2	D	"CHANG, Jerry Leslie"	215	248	0	463
+	AB-06	Straight Party			DEMOCRATIC PARTY (D)	854	874	0	1728
+	AB-06	Straight Party			INDEPENDENT PARTY (I)	5	3	0	8
+	AB-06	Straight Party			LIBERTARIAN PARTY (L)	3	2	0	5
+	AB-06	Straight Party			NONPARTISAN BALLOT (N)	5	8	0	13
+	AB-06	Straight Party			REPUBLICAN PARTY (R)	74	67	0	141
+	AB-06	US Representative	2	I	"STENSHOL, Shaun"	5	2	0	7
+	AB-06	US Representative	2	D	"HIRONO, Mazie"	725	710	0	1435
+	AB-06	US Representative	2	R	"EVANS, Roger B."	53	48	0	101
+	AB-06	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	2	0	5
+	AB-06	State Representative	3	D	"TSUJI, Clifton (Clift)"	713	737	0	1450
+	AB-06	State Representative	3	R	"TAVARES, Deirdre (Moana)"	54	45	0	99
+	AB-07	Straight Party			DEMOCRATIC PARTY (D)	67	68	0	135
+	AB-07	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-07	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-07	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-07	Straight Party			REPUBLICAN PARTY (R)	6	3	0	9
+	AB-07	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+	AB-07	US Representative	2	D	"HIRONO, Mazie"	59	57	0	116
+	AB-07	US Representative	2	R	"EVANS, Roger B."	4	2	0	6
+	AB-07	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
+	AB-07	State Representative	3	D	"TSUJI, Clifton (Clift)"	55	61	0	116
+	AB-07	State Representative	3	R	"TAVARES, Deirdre (Moana)"	5	3	0	8
+	AB-08	Straight Party			DEMOCRATIC PARTY (D)	61	69	0	130
+	AB-08	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-08	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-08	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-08	Straight Party			REPUBLICAN PARTY (R)	2	12	0	14
+	AB-08	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+	AB-08	US Representative	2	D	"HIRONO, Mazie"	52	56	0	108
+	AB-08	US Representative	2	R	"EVANS, Roger B."	1	7	0	8
+	AB-08	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-08	State Senate	1	D	"TAKAMINE, Dwight Y."	51	47	0	98
+	AB-08	State Senate	1	R	"HONG, Ted H.S."	2	7	0	9
+	AB-08	State Representative	3	D	"TSUJI, Clifton (Clift)"	51	57	0	108
+	AB-08	State Representative	3	R	"TAVARES, Deirdre (Moana)"	1	5	0	6
+	AB-09	Straight Party			DEMOCRATIC PARTY (D)	273	361	0	634
+	AB-09	Straight Party			INDEPENDENT PARTY (I)	1	3	0	4
+	AB-09	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-09	Straight Party			NONPARTISAN BALLOT (N)	1	6	0	7
+	AB-09	Straight Party			REPUBLICAN PARTY (R)	38	32	0	70
+	AB-09	US Representative	2	I	"STENSHOL, Shaun"	1	3	0	4
+	AB-09	US Representative	2	D	"HIRONO, Mazie"	226	282	0	508
+	AB-09	US Representative	2	R	"EVANS, Roger B."	21	16	0	37
+	AB-09	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-09	State Senate	1	D	"TAKAMINE, Dwight Y."	219	276	0	495
+	AB-09	State Senate	1	R	"HONG, Ted H.S."	33	26	0	59
+	AB-09	State Representative	3	D	"TSUJI, Clifton (Clift)"	214	283	0	497
+	AB-09	State Representative	3	R	"TAVARES, Deirdre (Moana)"	15	14	0	29
+	AB-10	Straight Party			DEMOCRATIC PARTY (D)	180	225	0	405
+	AB-10	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
+	AB-10	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-10	Straight Party			NONPARTISAN BALLOT (N)	0	4	0	4
+	AB-10	Straight Party			REPUBLICAN PARTY (R)	15	12	0	27
+	AB-10	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+	AB-10	US Representative	2	D	"HIRONO, Mazie"	152	180	0	332
+	AB-10	US Representative	2	R	"EVANS, Roger B."	11	7	0	18
+	AB-10	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
+	AB-10	State Representative	3	D	"TSUJI, Clifton (Clift)"	156	170	0	326
+	AB-10	State Representative	3	R	"TAVARES, Deirdre (Moana)"	7	6	0	13
+	AB-11	Straight Party			DEMOCRATIC PARTY (D)	59	89	0	148
+	AB-11	Straight Party			INDEPENDENT PARTY (I)	1	3	0	4
+	AB-11	Straight Party			LIBERTARIAN PARTY (L)	0	1	0	1
+	AB-11	Straight Party			NONPARTISAN BALLOT (N)	6	4	0	10
+	AB-11	Straight Party			REPUBLICAN PARTY (R)	10	17	0	27
+	AB-11	US Representative	2	I	"STENSHOL, Shaun"	1	3	0	4
+	AB-11	US Representative	2	D	"HIRONO, Mazie"	47	78	0	125
+	AB-11	US Representative	2	R	"EVANS, Roger B."	8	10	0	18
+	AB-11	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1
+	AB-11	State Representative	4	D	"HANOHANO, Faye P."	28	37	0	65
+	AB-11	State Representative	4	D	"MARZI, Anthony (Tony)"	10	17	0	27
+	AB-11	State Representative	4	D	"SPARKS, Steven B."	7	27	0	34
+	AB-11	State Representative	4	R	"BLAS, Fred"	9	12	0	21
+	AB-12	Straight Party			DEMOCRATIC PARTY (D)	73	73	0	146
+	AB-12	Straight Party			INDEPENDENT PARTY (I)	1	2	0	3
+	AB-12	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-12	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-12	Straight Party			REPUBLICAN PARTY (R)	15	13	0	28
+	AB-12	US Representative	2	I	"STENSHOL, Shaun"	1	2	0	3
+	AB-12	US Representative	2	D	"HIRONO, Mazie"	60	59	0	119
+	AB-12	US Representative	2	R	"EVANS, Roger B."	13	9	0	22
+	AB-12	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
+	AB-12	State Representative	4	D	"HANOHANO, Faye P."	30	41	0	71
+	AB-12	State Representative	4	D	"MARZI, Anthony (Tony)"	13	14	0	27
+	AB-12	State Representative	4	D	"SPARKS, Steven B."	19	5	0	24
+	AB-12	State Representative	4	R	"BLAS, Fred"	14	11	0	25
+	AB-13	Straight Party			DEMOCRATIC PARTY (D)	472	637	0	1109
+	AB-13	Straight Party			INDEPENDENT PARTY (I)	8	11	0	19
+	AB-13	Straight Party			LIBERTARIAN PARTY (L)	1	2	0	3
+	AB-13	Straight Party			NONPARTISAN BALLOT (N)	6	12	0	18
+	AB-13	Straight Party			REPUBLICAN PARTY (R)	125	145	0	270
+	AB-13	US Representative	2	I	"STENSHOL, Shaun"	8	9	0	17
+	AB-13	US Representative	2	D	"HIRONO, Mazie"	356	460	0	816
+	AB-13	US Representative	2	R	"EVANS, Roger B."	84	78	0	162
+	AB-13	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	2	0	3
+	AB-13	State Representative	4	D	"HANOHANO, Faye P."	226	278	0	504
+	AB-13	State Representative	4	D	"MARZI, Anthony (Tony)"	140	211	0	351
+	AB-13	State Representative	4	D	"SPARKS, Steven B."	60	100	0	160
+	AB-13	State Representative	4	R	"BLAS, Fred"	93	114	0	207
+	AB-14	Straight Party			DEMOCRATIC PARTY (D)	31	27	0	58
+	AB-14	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-14	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-14	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-14	Straight Party			REPUBLICAN PARTY (R)	7	8	0	15
+	AB-14	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+	AB-14	US Representative	2	D	"HIRONO, Mazie"	26	23	0	49
+	AB-14	US Representative	2	R	"EVANS, Roger B."	7	7	0	14
+	AB-14	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-14	State Representative	5	D	"HERKES, Robert (Bob)"	24	19	0	43
+	AB-15	Straight Party			DEMOCRATIC PARTY (D)	337	439	0	776
+	AB-15	Straight Party			INDEPENDENT PARTY (I)	13	11	0	24
+	AB-15	Straight Party			LIBERTARIAN PARTY (L)	6	3	0	9
+	AB-15	Straight Party			NONPARTISAN BALLOT (N)	7	12	0	19
+	AB-15	Straight Party			REPUBLICAN PARTY (R)	37	71	0	108
+	AB-15	US Representative	2	I	"STENSHOL, Shaun"	11	9	0	20
+	AB-15	US Representative	2	D	"HIRONO, Mazie"	280	356	0	636
+	AB-15	US Representative	2	R	"EVANS, Roger B."	34	65	0	99
+	AB-15	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	6	3	0	9
+	AB-15	State Representative	5	D	"HERKES, Robert (Bob)"	233	287	0	520
+	AB-16	Straight Party			DEMOCRATIC PARTY (D)	110	64	0	174
+	AB-16	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-16	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-16	Straight Party			NONPARTISAN BALLOT (N)	7	0	0	7
+	AB-16	Straight Party			REPUBLICAN PARTY (R)	12	1	0	13
+	AB-16	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+	AB-16	US Representative	2	D	"HIRONO, Mazie"	82	49	0	131
+	AB-16	US Representative	2	R	"EVANS, Roger B."	11	1	0	12
+	AB-16	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-16	State Senate	3	D	"ISBELL, Virginia"	29	19	0	48
+	AB-16	State Senate	3	D	"GREEN, Josh"	78	43	0	121
+	AB-16	State Representative	5	D	"HERKES, Robert (Bob)"	73	41	0	114
+	AB-17	Straight Party			DEMOCRATIC PARTY (D)	256	203	0	459
+	AB-17	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
+	AB-17	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-17	Straight Party			NONPARTISAN BALLOT (N)	2	2	0	4
+	AB-17	Straight Party			REPUBLICAN PARTY (R)	23	27	0	50
+	AB-17	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5
+	AB-17	US Representative	2	D	"HIRONO, Mazie"	201	156	0	357
+	AB-17	US Representative	2	R	"EVANS, Roger B."	21	23	0	44
+	AB-17	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-17	State Senate	3	D	"ISBELL, Virginia"	89	63	0	152
+	AB-17	State Senate	3	D	"GREEN, Josh"	153	129	0	282
+	AB-17	State Representative	5	D	"HERKES, Robert (Bob)"	174	134	0	308
+	AB-18	Straight Party			DEMOCRATIC PARTY (D)	274	471	0	745
+	AB-18	Straight Party			INDEPENDENT PARTY (I)	3	4	0	7
+	AB-18	Straight Party			LIBERTARIAN PARTY (L)	0	2	0	2
+	AB-18	Straight Party			NONPARTISAN BALLOT (N)	4	10	0	14
+	AB-18	Straight Party			REPUBLICAN PARTY (R)	107	122	0	229
+	AB-18	US Representative	2	I	"STENSHOL, Shaun"	2	3	0	5
+	AB-18	US Representative	2	D	"HIRONO, Mazie"	189	345	0	534
+	AB-18	US Representative	2	R	"EVANS, Roger B."	74	70	0	144
+	AB-18	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	2	0	2
+	AB-18	State Senate	3	D	"ISBELL, Virginia"	46	49	0	95
+	AB-18	State Senate	3	D	"GREEN, Josh"	220	408	0	628
+	AB-18	State Representative	6	D	"COFFMAN, Denny"	102	232	0	334
+	AB-18	State Representative	6	D	"LESLIE, Gene (Bucky)"	80	108	0	188
+	AB-18	State Representative	6	D	"MACGREGOR, Maegan"	37	63	0	100
+	AB-18	State Representative	6	R	"SMITH, Andy"	100	108	0	208
+	AB-19	Straight Party			DEMOCRATIC PARTY (D)	215	351	0	566
+	AB-19	Straight Party			INDEPENDENT PARTY (I)	0	2	0	2
+	AB-19	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
+	AB-19	Straight Party			NONPARTISAN BALLOT (N)	0	9	0	9
+	AB-19	Straight Party			REPUBLICAN PARTY (R)	81	91	0	172
+	AB-19	US Representative	2	I	"STENSHOL, Shaun"	0	2	0	2
+	AB-19	US Representative	2	D	"HIRONO, Mazie"	150	267	0	417
+	AB-19	US Representative	2	R	"EVANS, Roger B."	54	61	0	115
+	AB-19	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
+	AB-19	State Senate	3	D	"ISBELL, Virginia"	48	63	0	111
+	AB-19	State Senate	3	D	"GREEN, Josh"	161	276	0	437
+	AB-19	State Representative	6	D	"COFFMAN, Denny"	69	153	0	222
+	AB-19	State Representative	6	D	"LESLIE, Gene (Bucky)"	40	95	0	135
+	AB-19	State Representative	6	D	"MACGREGOR, Maegan"	45	52	0	97
+	AB-19	State Representative	6	R	"SMITH, Andy"	74	81	0	155
+	AB-20	Straight Party			DEMOCRATIC PARTY (D)	183	307	0	490
+	AB-20	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
+	AB-20	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
+	AB-20	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7
+	AB-20	Straight Party			REPUBLICAN PARTY (R)	50	56	0	106
+	AB-20	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
+	AB-20	US Representative	2	D	"HIRONO, Mazie"	121	222	0	343
+	AB-20	US Representative	2	R	"EVANS, Roger B."	48	43	0	91
+	AB-20	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
+	AB-20	State Senate	3	D	"ISBELL, Virginia"	34	62	0	96
+	AB-20	State Senate	3	D	"GREEN, Josh"	136	234	0	370
+	AB-20	State Representative	7	D	"EVANS, Cindy"	117	238	0	355
+	AB-20	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	27	24	0	51
+	AB-20	State Representative	7	R	"KAILIMAI, B.J."	10	21	0	31
+	AB-21	Straight Party			DEMOCRATIC PARTY (D)	107	90	0	197
+	AB-21	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
+	AB-21	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
+	AB-21	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
+	AB-21	Straight Party			REPUBLICAN PARTY (R)	35	24	0	59
+	AB-21	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
+	AB-21	US Representative	2	D	"HIRONO, Mazie"	75	73	0	148
+	AB-21	US Representative	2	R	"EVANS, Roger B."	32	19	0	51
+	AB-21	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	1	0	4
+	AB-21	State Senate	3	D	"ISBELL, Virginia"	22	27	0	49
+	AB-21	State Senate	3	D	"GREEN, Josh"	74	60	0	134
+	AB-21	State Representative	7	D	"EVANS, Cindy"	89	78	0	167
+	AB-21	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	22	13	0	35
+	AB-21	State Representative	7	R	"KAILIMAI, B.J."	5	9	0	14
+	AB-22	Straight Party			DEMOCRATIC PARTY (D)	125	452	0	577
+	AB-22	Straight Party			INDEPENDENT PARTY (I)	4	1	0	5
+	AB-22	Straight Party			LIBERTARIAN PARTY (L)	0	2	0	2
+	AB-22	Straight Party			NONPARTISAN BALLOT (N)	1	2	0	3
+	AB-22	Straight Party			REPUBLICAN PARTY (R)	37	131	0	168
+	AB-22	US Representative	2	I	"STENSHOL, Shaun"	4	0	0	4
+	AB-22	US Representative	2	D	"HIRONO, Mazie"	98	331	0	429
+	AB-22	US Representative	2	R	"EVANS, Roger B."	23	86	0	109
+	AB-22	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	2	0	2
+	AB-22	State Senate	1	D	"TAKAMINE, Dwight Y."	103	345	0	448
+	AB-22	State Senate	1	R	"HONG, Ted H.S."	33	104	0	137
+	AB-22	State Representative	7	D	"EVANS, Cindy"	95	322	0	417
+	AB-22	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	17	63	0	80
+	AB-22	State Representative	7	R	"KAILIMAI, B.J."	11	51	0	62
+	AB-23	Straight Party			DEMOCRATIC PARTY (D)	33	85	0	118
+	AB-23	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-23	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-23	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-23	Straight Party			REPUBLICAN PARTY (R)	18	19	0	37
+	AB-23	US Representative	2	I	"STENSHOL, Shaun"	0	0	0	0
+	AB-23	US Representative	2	D	"HIRONO, Mazie"	24	61	0	85
+	AB-23	US Representative	2	R	"EVANS, Roger B."	10	12	0	22
+	AB-23	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-23	State Senate	1	D	"TAKAMINE, Dwight Y."	28	64	0	92
+	AB-23	State Senate	1	R	"HONG, Ted H.S."	13	11	0	24
+	AB-23	State Representative	7	D	"EVANS, Cindy"	22	61	0	83
+	AB-23	State Representative	7	R	"DELA CRUZ, Ronald (Makaula)"	5	12	0	17
+	AB-23	State Representative	7	R	"KAILIMAI, B.J."	7	3	0	10
+	AB-24	Straight Party			DEMOCRATIC PARTY (D)	1077	560	0	1637
+	AB-24	Straight Party			INDEPENDENT PARTY (I)	7	9	0	16
+	AB-24	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
+	AB-24	Straight Party			NONPARTISAN BALLOT (N)	6	3	0	9
+	AB-24	Straight Party			REPUBLICAN PARTY (R)	82	62	0	144
+	AB-24	US Representative	2	I	"STENSHOL, Shaun"	7	8	0	15
+	AB-24	US Representative	2	D	"HIRONO, Mazie"	888	470	0	1358
+	AB-24	US Representative	2	R	"EVANS, Roger B."	75	56	0	131
+	AB-24	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	1	0	4
+	AB-24	State Representative	8	D	"KAMA, Tasha"	360	200	0	560
+	AB-24	State Representative	8	D	"SOUKI, Joe"	648	331	0	979
+	AB-25	Straight Party			DEMOCRATIC PARTY (D)	1034	367	0	1401
+	AB-25	Straight Party			INDEPENDENT PARTY (I)	6	2	0	8
+	AB-25	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
+	AB-25	Straight Party			NONPARTISAN BALLOT (N)	4	1	0	5
+	AB-25	Straight Party			REPUBLICAN PARTY (R)	84	47	0	131
+	AB-25	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5
+	AB-25	US Representative	2	D	"HIRONO, Mazie"	925	318	0	1243
+	AB-25	US Representative	2	R	"EVANS, Roger B."	57	31	0	88
+	AB-25	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
+	AB-25	State Representative	9	D	"NAKASONE, Bob"	799	288	0	1087
+	AB-25	State Representative	9	R	"KAHULA, Henry P., Jr."	55	36	0	91
+	AB-26	Straight Party			DEMOCRATIC PARTY (D)	332	234	0	566
+	AB-26	Straight Party			INDEPENDENT PARTY (I)	9	4	0	13
+	AB-26	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
+	AB-26	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6
+	AB-26	Straight Party			REPUBLICAN PARTY (R)	104	63	0	167
+	AB-26	US Representative	2	I	"STENSHOL, Shaun"	7	3	0	10
+	AB-26	US Representative	2	D	"HIRONO, Mazie"	272	167	0	439
+	AB-26	US Representative	2	R	"EVANS, Roger B."	50	42	0	92
+	AB-26	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
+	AB-26	State Senate	5	D	"BAKER, Roz"	253	157	0	410
+	AB-26	State Senate	5	D	"MULVIHILL, Bart"	63	63	0	126
+	AB-26	State Senate	5	R	"SHIELDS, Jan"	93	56	0	149
+	AB-26	State Representative	10	D	"MCKELVEY, Angus"	260	194	0	454
+	AB-26	State Representative	10	R	"MADDEN, Ramon K."	51	45	0	96
+	AB-27	Straight Party			DEMOCRATIC PARTY (D)	366	159	0	525
+	AB-27	Straight Party			INDEPENDENT PARTY (I)	11	2	0	13
+	AB-27	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-27	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-27	Straight Party			REPUBLICAN PARTY (R)	214	56	0	270
+	AB-27	US Representative	2	I	"STENSHOL, Shaun"	8	1	0	9
+	AB-27	US Representative	2	D	"HIRONO, Mazie"	287	113	0	400
+	AB-27	US Representative	2	R	"EVANS, Roger B."	134	24	0	158
+	AB-27	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
+	AB-27	State Senate	5	D	"BAKER, Roz"	218	93	0	311
+	AB-27	State Senate	5	D	"MULVIHILL, Bart"	110	53	0	163
+	AB-27	State Senate	5	R	"SHIELDS, Jan"	183	44	0	227
+	AB-27	State Representative	11	D	"GINGERICH, Michael"	97	46	0	143
+	AB-27	State Representative	11	D	"BERTRAM, Joe, III"	234	100	0	334
+	AB-27	State Representative	11	R	"FONTAINE, George R."	164	33	0	197
+	AB-28	Straight Party			DEMOCRATIC PARTY (D)	1051	381	0	1432
+	AB-28	Straight Party			INDEPENDENT PARTY (I)	9	5	0	14
+	AB-28	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-28	Straight Party			NONPARTISAN BALLOT (N)	7	1	0	8
+	AB-28	Straight Party			REPUBLICAN PARTY (R)	150	37	0	187
+	AB-28	US Representative	2	I	"STENSHOL, Shaun"	3	3	0	6
+	AB-28	US Representative	2	D	"HIRONO, Mazie"	820	292	0	1112
+	AB-28	US Representative	2	R	"EVANS, Roger B."	79	15	0	94
+	AB-28	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-28	State Senate	6	I	"BLUMER-BUELL, John"	6	2	0	8
+	AB-28	State Senate	6	D	"ENGLISH, J. Kalani"	755	272	0	1027
+	AB-28	State Representative	12	D	"YAMASHITA, Kyle"	770	250	0	1020
+	AB-28	State Representative	12	D	"STARR, Summer"	235	118	0	353
+	AB-28	State Representative	12	R	"VIERRA, Mickey"	127	25	0	152
+	AB-29	Straight Party			DEMOCRATIC PARTY (D)	488	438	0	926
+	AB-29	Straight Party			INDEPENDENT PARTY (I)	23	10	0	33
+	AB-29	Straight Party			LIBERTARIAN PARTY (L)	0	1	0	1
+	AB-29	Straight Party			NONPARTISAN BALLOT (N)	9	4	0	13
+	AB-29	Straight Party			REPUBLICAN PARTY (R)	65	60	0	125
+	AB-29	US Representative	2	I	"STENSHOL, Shaun"	9	5	0	14
+	AB-29	US Representative	2	D	"HIRONO, Mazie"	379	340	0	719
+	AB-29	US Representative	2	R	"EVANS, Roger B."	57	57	0	114
+	AB-29	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1
+	AB-29	State Senate	6	I	"BLUMER-BUELL, John"	20	9	0	29
+	AB-29	State Senate	6	D	"ENGLISH, J. Kalani"	340	333	0	673
+	AB-29	State Representative	13	D	"CARROLL, Mele"	352	334	0	686
+	AB-30	Straight Party			DEMOCRATIC PARTY (D)	13	0	0	13
+	AB-30	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
+	AB-30	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-30	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-30	Straight Party			REPUBLICAN PARTY (R)	3	0	0	3
+	AB-30	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
+	AB-30	US Representative	2	D	"HIRONO, Mazie"	11	0	0	11
+	AB-30	US Representative	2	R	"EVANS, Roger B."	3	0	0	3
+	AB-30	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-30	State Senate	6	I	"BLUMER-BUELL, John"	2	0	0	2
+	AB-30	State Senate	6	D	"ENGLISH, J. Kalani"	9	0	0	9
+	AB-30	State Representative	13	D	"CARROLL, Mele"	8	0	0	8
+	AB-31	Straight Party			DEMOCRATIC PARTY (D)	1291	610	0	1901
+	AB-31	Straight Party			INDEPENDENT PARTY (I)	15	4	0	19
+	AB-31	Straight Party			LIBERTARIAN PARTY (L)	8	1	0	9
+	AB-31	Straight Party			NONPARTISAN BALLOT (N)	20	6	0	26
+	AB-31	Straight Party			REPUBLICAN PARTY (R)	212	86	0	298
+	AB-31	US Representative	2	I	"STENSHOL, Shaun"	11	2	0	13
+	AB-31	US Representative	2	D	"HIRONO, Mazie"	942	408	0	1350
+	AB-31	US Representative	2	R	"EVANS, Roger B."	146	51	0	197
+	AB-31	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	8	1	0	9
+	AB-31	State Senate	7	D	"HOOSER, Gary L."	901	424	0	1325
+	AB-31	State Senate	7	R	"GEORGI, JoAnne S."	171	63	0	234
+	AB-31	State Representative	14	D	"MORITA, Hermina (Mina)"	838	368	0	1206
+	AB-32	Straight Party			DEMOCRATIC PARTY (D)	1692	1167	0	2859
+	AB-32	Straight Party			INDEPENDENT PARTY (I)	13	12	0	25
+	AB-32	Straight Party			LIBERTARIAN PARTY (L)	7	6	0	13
+	AB-32	Straight Party			NONPARTISAN BALLOT (N)	25	13	0	38
+	AB-32	Straight Party			REPUBLICAN PARTY (R)	260	133	0	393
+	AB-32	US Representative	2	I	"STENSHOL, Shaun"	10	4	0	14
+	AB-32	US Representative	2	D	"HIRONO, Mazie"	1260	826	0	2086
+	AB-32	US Representative	2	R	"EVANS, Roger B."	178	64	0	242
+	AB-32	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	7	6	0	13
+	AB-32	State Senate	7	D	"HOOSER, Gary L."	1146	784	0	1930
+	AB-32	State Senate	7	R	"GEORGI, JoAnne S."	210	85	0	295
+	AB-32	State Representative	15	D	"TOKIOKA, James Kunane"	1083	737	0	1820
+	AB-33	Straight Party			DEMOCRATIC PARTY (D)	1327	583	0	1910
+	AB-33	Straight Party			INDEPENDENT PARTY (I)	14	8	0	22
+	AB-33	Straight Party			LIBERTARIAN PARTY (L)	2	3	0	5
+	AB-33	Straight Party			NONPARTISAN BALLOT (N)	16	5	0	21
+	AB-33	Straight Party			REPUBLICAN PARTY (R)	178	84	0	262
+	AB-33	US Representative	2	I	"STENSHOL, Shaun"	9	5	0	14
+	AB-33	US Representative	2	D	"HIRONO, Mazie"	954	400	0	1354
+	AB-33	US Representative	2	R	"EVANS, Roger B."	124	35	0	159
+	AB-33	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	3	0	5
+	AB-33	State Senate	7	D	"HOOSER, Gary L."	826	362	0	1188
+	AB-33	State Senate	7	R	"GEORGI, JoAnne S."	138	59	0	197
+	AB-33	State Representative	16	D	"SAGUM, Roland D., III"	778	351	0	1129
+	AB-34	Straight Party			DEMOCRATIC PARTY (D)	1624	305	0	1929
+	AB-34	Straight Party			INDEPENDENT PARTY (I)	20	4	0	24
+	AB-34	Straight Party			LIBERTARIAN PARTY (L)	9	1	0	10
+	AB-34	Straight Party			NONPARTISAN BALLOT (N)	21	4	0	25
+	AB-34	Straight Party			REPUBLICAN PARTY (R)	787	99	0	886
+	AB-34	US Representative	1	D	"ABERCROMBIE, Neil"	1304	246	0	1550
+	AB-34	US Representative	1	R	"TATAII, Steve"	318	49	0	367
+	AB-34	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	1	0	4
+	AB-34	US Representative	1	L	"ZHAO, Li"	6	0	0	6
+	AB-34	State Representative	17	D	"MONK, Amy Yukiko"	1030	223	0	1253
+	AB-34	State Representative	17	R	"WARD, Gene"	754	97	0	851
+	AB-35	Straight Party			DEMOCRATIC PARTY (D)	1606	289	0	1895
+	AB-35	Straight Party			INDEPENDENT PARTY (I)	21	5	0	26
+	AB-35	Straight Party			LIBERTARIAN PARTY (L)	13	1	0	14
+	AB-35	Straight Party			NONPARTISAN BALLOT (N)	30	3	0	33
+	AB-35	Straight Party			REPUBLICAN PARTY (R)	422	61	0	483
+	AB-35	US Representative	1	D	"ABERCROMBIE, Neil"	1239	227	0	1466
+	AB-35	US Representative	1	R	"TATAII, Steve"	370	55	0	425
+	AB-35	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4
+	AB-35	US Representative	1	L	"ZHAO, Li"	9	1	0	10
+	AB-35	State Representative	18	D	"BERG, Lyla B."	1137	212	0	1349
+	AB-36	Straight Party			DEMOCRATIC PARTY (D)	1357	257	0	1614
+	AB-36	Straight Party			INDEPENDENT PARTY (I)	7	0	0	7
+	AB-36	Straight Party			LIBERTARIAN PARTY (L)	8	3	0	11
+	AB-36	Straight Party			NONPARTISAN BALLOT (N)	18	2	0	20
+	AB-36	Straight Party			REPUBLICAN PARTY (R)	664	76	0	740
+	AB-36	US Representative	1	D	"ABERCROMBIE, Neil"	1095	212	0	1307
+	AB-36	US Representative	1	R	"TATAII, Steve"	226	24	0	250
+	AB-36	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	2	0	4
+	AB-36	US Representative	1	L	"ZHAO, Li"	5	1	0	6
+	AB-36	State Representative	19	D	"ABE, Michael (Mike)"	836	155	0	991
+	AB-36	State Representative	19	R	"MARUMOTO, Barbara C."	638	68	0	706
+	AB-37	Straight Party			DEMOCRATIC PARTY (D)	163	19	0	182
+	AB-37	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-37	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-37	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-37	Straight Party			REPUBLICAN PARTY (R)	51	10	0	61
+	AB-37	US Representative	1	D	"ABERCROMBIE, Neil"	128	16	0	144
+	AB-37	US Representative	1	R	"TATAII, Steve"	15	4	0	19
+	AB-37	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-37	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-37	State Representative	19	D	"ABE, Michael (Mike)"	105	11	0	116
+	AB-37	State Representative	19	R	"MARUMOTO, Barbara C."	49	8	0	57
+	AB-38	Straight Party			DEMOCRATIC PARTY (D)	1112	218	0	1330
+	AB-38	Straight Party			INDEPENDENT PARTY (I)	4	0	0	4
+	AB-38	Straight Party			LIBERTARIAN PARTY (L)	6	1	0	7
+	AB-38	Straight Party			NONPARTISAN BALLOT (N)	12	2	0	14
+	AB-38	Straight Party			REPUBLICAN PARTY (R)	148	30	0	178
+	AB-38	US Representative	1	D	"ABERCROMBIE, Neil"	901	169	0	1070
+	AB-38	US Representative	1	R	"TATAII, Steve"	103	25	0	128
+	AB-38	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	1	0	3
+	AB-38	US Representative	1	L	"ZHAO, Li"	4	0	0	4
+	AB-38	State Representative	20	D	"SAY, Calvin K. Y."	976	189	0	1165
+	AB-38	State Representative	20	R	"ALLEN, Julia E."	131	26	0	157
+	AB-39	Straight Party			DEMOCRATIC PARTY (D)	420	79	0	499
+	AB-39	Straight Party			INDEPENDENT PARTY (I)	2	2	0	4
+	AB-39	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5
+	AB-39	Straight Party			NONPARTISAN BALLOT (N)	3	3	0	6
+	AB-39	Straight Party			REPUBLICAN PARTY (R)	89	20	0	109
+	AB-39	US Representative	1	D	"ABERCROMBIE, Neil"	345	65	0	410
+	AB-39	US Representative	1	R	"TATAII, Steve"	53	14	0	67
+	AB-39	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
+	AB-39	US Representative	1	L	"ZHAO, Li"	0	1	0	1
+	AB-39	State Representative	20	D	"SAY, Calvin K. Y."	315	64	0	379
+	AB-39	State Representative	20	R	"ALLEN, Julia E."	76	17	0	93
+	AB-40	Straight Party			DEMOCRATIC PARTY (D)	936	202	0	1138
+	AB-40	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
+	AB-40	Straight Party			LIBERTARIAN PARTY (L)	8	1	0	9
+	AB-40	Straight Party			NONPARTISAN BALLOT (N)	8	1	0	9
+	AB-40	Straight Party			REPUBLICAN PARTY (R)	125	30	0	155
+	AB-40	US Representative	1	D	"ABERCROMBIE, Neil"	735	160	0	895
+	AB-40	US Representative	1	R	"TATAII, Steve"	113	28	0	141
+	AB-40	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
+	AB-40	US Representative	1	L	"ZHAO, Li"	5	1	0	6
+	AB-40	State Representative	21	D	"NISHIMOTO, Scott Y."	773	168	0	941
+	AB-41	Straight Party			DEMOCRATIC PARTY (D)	98	17	0	115
+	AB-41	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2
+	AB-41	Straight Party			LIBERTARIAN PARTY (L)	6	1	0	7
+	AB-41	Straight Party			NONPARTISAN BALLOT (N)	2	1	0	3
+	AB-41	Straight Party			REPUBLICAN PARTY (R)	60	5	0	65
+	AB-41	US Representative	1	D	"ABERCROMBIE, Neil"	69	14	0	83
+	AB-41	US Representative	1	R	"TATAII, Steve"	55	5	0	60
+	AB-41	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	0	0	6
+	AB-41	US Representative	1	L	"ZHAO, Li"	0	1	0	1
+	AB-41	State Representative	21	D	"NISHIMOTO, Scott Y."	64	13	0	77
+	AB-42	Straight Party			DEMOCRATIC PARTY (D)	128	36	0	164
+	AB-42	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
+	AB-42	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
+	AB-42	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
+	AB-42	Straight Party			REPUBLICAN PARTY (R)	62	15	0	77
+	AB-42	US Representative	1	D	"ABERCROMBIE, Neil"	113	32	0	145
+	AB-42	US Representative	1	R	"TATAII, Steve"	43	13	0	56
+	AB-42	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-42	US Representative	1	L	"ZHAO, Li"	3	0	0	3
+	AB-42	State Senate	12	D	"GALUTERIA, Brickwood M."	76	16	0	92
+	AB-42	State Senate	12	D	"MIDDLETON, Carlton N."	30	14	0	44
+	AB-42	State Senate	12	R	"TRIMBLE, Gordon"	58	13	0	71
+	AB-42	State Representative	21	D	"NISHIMOTO, Scott Y."	103	32	0	135
+	AB-43	Straight Party			DEMOCRATIC PARTY (D)	1042	239	0	1281
+	AB-43	Straight Party			INDEPENDENT PARTY (I)	11	4	0	15
+	AB-43	Straight Party			LIBERTARIAN PARTY (L)	11	0	0	11
+	AB-43	Straight Party			NONPARTISAN BALLOT (N)	12	2	0	14
+	AB-43	Straight Party			REPUBLICAN PARTY (R)	189	30	0	219
+	AB-43	US Representative	1	D	"ABERCROMBIE, Neil"	861	185	0	1046
+	AB-43	US Representative	1	R	"TATAII, Steve"	171	24	0	195
+	AB-43	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4
+	AB-43	US Representative	1	L	"ZHAO, Li"	6	0	0	6
+	AB-43	State Representative	22	D	"SAIKI, Scott K."	787	173	0	960
+	AB-44	Straight Party			DEMOCRATIC PARTY (D)	909	300	0	1209
+	AB-44	Straight Party			INDEPENDENT PARTY (I)	29	1	0	30
+	AB-44	Straight Party			LIBERTARIAN PARTY (L)	17	1	0	18
+	AB-44	Straight Party			NONPARTISAN BALLOT (N)	22	3	0	25
+	AB-44	Straight Party			REPUBLICAN PARTY (R)	467	107	0	574
+	AB-44	US Representative	1	D	"ABERCROMBIE, Neil"	792	245	0	1037
+	AB-44	US Representative	1	R	"TATAII, Steve"	299	57	0	356
+	AB-44	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	1	0	7
+	AB-44	US Representative	1	L	"ZHAO, Li"	9	0	0	9
+	AB-44	State Senate	12	D	"GALUTERIA, Brickwood M."	490	184	0	674
+	AB-44	State Senate	12	D	"MIDDLETON, Carlton N."	194	51	0	245
+	AB-44	State Senate	12	R	"TRIMBLE, Gordon"	373	86	0	459
+	AB-44	State Representative	23	D	"BROWER, Tom"	635	198	0	833
+	AB-44	State Representative	23	R	"STEVENS, Anne V."	389	81	0	470
+	AB-45	Straight Party			DEMOCRATIC PARTY (D)	1705	375	0	2080
+	AB-45	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13
+	AB-45	Straight Party			LIBERTARIAN PARTY (L)	16	2	0	18
+	AB-45	Straight Party			NONPARTISAN BALLOT (N)	23	5	0	28
+	AB-45	Straight Party			REPUBLICAN PARTY (R)	333	65	0	398
+	AB-45	US Representative	1	D	"ABERCROMBIE, Neil"	1430	312	0	1742
+	AB-45	US Representative	1	R	"TATAII, Steve"	202	30	0	232
+	AB-45	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	0	0	6
+	AB-45	US Representative	1	L	"ZHAO, Li"	10	2	0	12
+	AB-45	State Representative	24	D	"CHOY, Isaac W."	950	256	0	1206
+	AB-45	State Representative	24	R	"JEFFRYES, Jerilyn (Jeri)"	270	52	0	322
+	AB-46	Straight Party			DEMOCRATIC PARTY (D)	808	230	0	1038
+	AB-46	Straight Party			INDEPENDENT PARTY (I)	11	3	0	14
+	AB-46	Straight Party			LIBERTARIAN PARTY (L)	16	5	0	21
+	AB-46	Straight Party			NONPARTISAN BALLOT (N)	9	3	0	12
+	AB-46	Straight Party			REPUBLICAN PARTY (R)	163	52	0	215
+	AB-46	US Representative	1	D	"ABERCROMBIE, Neil"	648	181	0	829
+	AB-46	US Representative	1	R	"TATAII, Steve"	151	43	0	194
+	AB-46	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	9	4	0	13
+	AB-46	US Representative	1	L	"ZHAO, Li"	7	1	0	8
+	AB-46	State Representative	25	D	"BELATTI, Della A."	553	152	0	705
+	AB-47	Straight Party			DEMOCRATIC PARTY (D)	593	120	0	713
+	AB-47	Straight Party			INDEPENDENT PARTY (I)	8	2	0	10
+	AB-47	Straight Party			LIBERTARIAN PARTY (L)	6	4	0	10
+	AB-47	Straight Party			NONPARTISAN BALLOT (N)	9	0	0	9
+	AB-47	Straight Party			REPUBLICAN PARTY (R)	105	21	0	126
+	AB-47	US Representative	1	D	"ABERCROMBIE, Neil"	485	98	0	583
+	AB-47	US Representative	1	R	"TATAII, Steve"	95	18	0	113
+	AB-47	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	3	0	5
+	AB-47	US Representative	1	L	"ZHAO, Li"	4	1	0	5
+	AB-47	State Representative	25	D	"BELATTI, Della A."	346	77	0	423
+	AB-48	Straight Party			DEMOCRATIC PARTY (D)	1546	434	0	1980
+	AB-48	Straight Party			INDEPENDENT PARTY (I)	21	8	0	29
+	AB-48	Straight Party			LIBERTARIAN PARTY (L)	17	6	0	23
+	AB-48	Straight Party			NONPARTISAN BALLOT (N)	19	7	0	26
+	AB-48	Straight Party			REPUBLICAN PARTY (R)	275	67	0	342
+	AB-48	US Representative	1	D	"ABERCROMBIE, Neil"	1259	355	0	1614
+	AB-48	US Representative	1	R	"TATAII, Steve"	248	55	0	303
+	AB-48	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	10	1	0	11
+	AB-48	US Representative	1	L	"ZHAO, Li"	7	4	0	11
+	AB-48	State Representative	26	D	"LUKE, Sylvia"	1140	341	0	1481
+	AB-49	Straight Party			DEMOCRATIC PARTY (D)	1059	238	0	1297
+	AB-49	Straight Party			INDEPENDENT PARTY (I)	2	1	0	3
+	AB-49	Straight Party			LIBERTARIAN PARTY (L)	5	0	0	5
+	AB-49	Straight Party			NONPARTISAN BALLOT (N)	13	4	0	17
+	AB-49	Straight Party			REPUBLICAN PARTY (R)	313	65	0	378
+	AB-49	US Representative	1	D	"ABERCROMBIE, Neil"	904	195	0	1099
+	AB-49	US Representative	1	R	"TATAII, Steve"	128	33	0	161
+	AB-49	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
+	AB-49	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-49	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	577	140	0	717
+	AB-49	State Representative	27	R	"CHING, Corinne Wei Lan"	296	58	0	354
+	AB-50	Straight Party			DEMOCRATIC PARTY (D)	68	15	0	83
+	AB-50	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
+	AB-50	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-50	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-50	Straight Party			REPUBLICAN PARTY (R)	31	4	0	35
+	AB-50	US Representative	1	D	"ABERCROMBIE, Neil"	57	12	0	69
+	AB-50	US Representative	1	R	"TATAII, Steve"	18	1	0	19
+	AB-50	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-50	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-50	State Representative	27	D	"MOEPONO, Sesnita Der-Ling"	35	8	0	43
+	AB-50	State Representative	27	R	"CHING, Corinne Wei Lan"	29	4	0	33
+	AB-51	Straight Party			DEMOCRATIC PARTY (D)	133	41	0	174
+	AB-51	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-51	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-51	Straight Party			NONPARTISAN BALLOT (N)	0	1	0	1
+	AB-51	Straight Party			REPUBLICAN PARTY (R)	18	6	0	24
+	AB-51	US Representative	1	D	"ABERCROMBIE, Neil"	101	38	0	139
+	AB-51	US Representative	1	R	"TATAII, Steve"	9	5	0	14
+	AB-51	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-51	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-51	State Representative	28	D	"RHOADS, Karl"	89	20	0	109
+	AB-52	Straight Party			DEMOCRATIC PARTY (D)	158	33	0	191
+	AB-52	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
+	AB-52	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-52	Straight Party			NONPARTISAN BALLOT (N)	3	5	0	8
+	AB-52	Straight Party			REPUBLICAN PARTY (R)	18	5	0	23
+	AB-52	US Representative	1	D	"ABERCROMBIE, Neil"	134	27	0	161
+	AB-52	US Representative	1	R	"TATAII, Steve"	15	5	0	20
+	AB-52	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-52	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-52	State Representative	28	D	"RHOADS, Karl"	90	20	0	110
+	AB-53	Straight Party			DEMOCRATIC PARTY (D)	545	207	0	752
+	AB-53	Straight Party			INDEPENDENT PARTY (I)	8	1	0	9
+	AB-53	Straight Party			LIBERTARIAN PARTY (L)	10	0	0	10
+	AB-53	Straight Party			NONPARTISAN BALLOT (N)	11	4	0	15
+	AB-53	Straight Party			REPUBLICAN PARTY (R)	163	59	0	222
+	AB-53	US Representative	1	D	"ABERCROMBIE, Neil"	446	166	0	612
+	AB-53	US Representative	1	R	"TATAII, Steve"	112	36	0	148
+	AB-53	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	3	0	0	3
+	AB-53	US Representative	1	L	"ZHAO, Li"	7	0	0	7
+	AB-53	State Senate	12	D	"GALUTERIA, Brickwood M."	302	133	0	435
+	AB-53	State Senate	12	D	"MIDDLETON, Carlton N."	116	32	0	148
+	AB-53	State Senate	12	R	"TRIMBLE, Gordon"	150	55	0	205
+	AB-53	State Representative	28	D	"RHOADS, Karl"	403	160	0	563
+	AB-54	Straight Party			DEMOCRATIC PARTY (D)	177	40	0	217
+	AB-54	Straight Party			INDEPENDENT PARTY (I)	0	2	0	2
+	AB-54	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-54	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-54	Straight Party			REPUBLICAN PARTY (R)	38	11	0	49
+	AB-54	US Representative	1	D	"ABERCROMBIE, Neil"	152	34	0	186
+	AB-54	US Representative	1	R	"TATAII, Steve"	28	4	0	32
+	AB-54	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-54	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-54	State Senate	12	D	"GALUTERIA, Brickwood M."	121	22	0	143
+	AB-54	State Senate	12	D	"MIDDLETON, Carlton N."	34	9	0	43
+	AB-54	State Senate	12	R	"TRIMBLE, Gordon"	33	10	0	43
+	AB-54	State Representative	28	D	"RHOADS, Karl"	143	33	0	176
+	AB-55	Straight Party			DEMOCRATIC PARTY (D)	714	126	0	840
+	AB-55	Straight Party			INDEPENDENT PARTY (I)	2	3	0	5
+	AB-55	Straight Party			LIBERTARIAN PARTY (L)	6	0	0	6
+	AB-55	Straight Party			NONPARTISAN BALLOT (N)	6	0	0	6
+	AB-55	Straight Party			REPUBLICAN PARTY (R)	100	23	0	123
+	AB-55	US Representative	1	D	"ABERCROMBIE, Neil"	603	106	0	709
+	AB-55	US Representative	1	R	"TATAII, Steve"	71	17	0	88
+	AB-55	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-55	US Representative	1	L	"ZHAO, Li"	5	0	0	5
+	AB-55	State Representative	29	D	"MANAHAN, Joey"	558	84	0	642
+	AB-55	State Representative	29	R	"YAW, Shane D. K."	81	16	0	97
+	AB-56	Straight Party			DEMOCRATIC PARTY (D)	567	122	0	689
+	AB-56	Straight Party			INDEPENDENT PARTY (I)	7	1	0	8
+	AB-56	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5
+	AB-56	Straight Party			NONPARTISAN BALLOT (N)	6	1	0	7
+	AB-56	Straight Party			REPUBLICAN PARTY (R)	74	18	0	92
+	AB-56	US Representative	1	D	"ABERCROMBIE, Neil"	476	102	0	578
+	AB-56	US Representative	1	R	"TATAII, Steve"	61	17	0	78
+	AB-56	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-56	US Representative	1	L	"ZHAO, Li"	4	1	0	5
+	AB-56	State Representative	30	D	"MIZUNO, John"	460	87	0	547
+	AB-57	Straight Party			DEMOCRATIC PARTY (D)	257	47	0	304
+	AB-57	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
+	AB-57	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-57	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2
+	AB-57	Straight Party			REPUBLICAN PARTY (R)	17	8	0	25
+	AB-57	US Representative	1	D	"ABERCROMBIE, Neil"	235	35	0	270
+	AB-57	US Representative	1	R	"TATAII, Steve"	12	5	0	17
+	AB-57	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-57	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-57	State Representative	30	D	"MIZUNO, John"	203	39	0	242
+	AB-58	Straight Party			DEMOCRATIC PARTY (D)	295	71	0	366
+	AB-58	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-58	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-58	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2
+	AB-58	Straight Party			REPUBLICAN PARTY (R)	22	10	0	32
+	AB-58	US Representative	1	D	"ABERCROMBIE, Neil"	241	59	0	300
+	AB-58	US Representative	1	R	"TATAII, Steve"	18	6	0	24
+	AB-58	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-58	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-58	State Representative	31	D	"WAKAI, Glenn"	260	59	0	319
+	AB-59	Straight Party			DEMOCRATIC PARTY (D)	982	213	0	1195
+	AB-59	Straight Party			INDEPENDENT PARTY (I)	9	2	0	11
+	AB-59	Straight Party			LIBERTARIAN PARTY (L)	14	1	0	15
+	AB-59	Straight Party			NONPARTISAN BALLOT (N)	13	2	0	15
+	AB-59	Straight Party			REPUBLICAN PARTY (R)	186	31	0	217
+	AB-59	US Representative	1	D	"ABERCROMBIE, Neil"	807	168	0	975
+	AB-59	US Representative	1	R	"TATAII, Steve"	176	23	0	199
+	AB-59	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	6	1	0	7
+	AB-59	US Representative	1	L	"ZHAO, Li"	8	0	0	8
+	AB-59	State Representative	31	D	"WAKAI, Glenn"	792	159	0	951
+	AB-60	Straight Party			DEMOCRATIC PARTY (D)	418	114	0	532
+	AB-60	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
+	AB-60	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
+	AB-60	Straight Party			NONPARTISAN BALLOT (N)	6	0	0	6
+	AB-60	Straight Party			REPUBLICAN PARTY (R)	124	28	0	152
+	AB-60	US Representative	1	D	"ABERCROMBIE, Neil"	387	102	0	489
+	AB-60	US Representative	1	R	"TATAII, Steve"	55	12	0	67
+	AB-60	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	1	0	2
+	AB-60	US Representative	1	L	"ZHAO, Li"	2	0	0	2
+	AB-60	State Representative	32	R	"FINNEGAN, Lynn"	115	24	0	139
+	AB-61	Straight Party			DEMOCRATIC PARTY (D)	327	93	0	420
+	AB-61	Straight Party			INDEPENDENT PARTY (I)	6	2	0	8
+	AB-61	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
+	AB-61	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
+	AB-61	Straight Party			REPUBLICAN PARTY (R)	204	20	0	224
+	AB-61	US Representative	1	D	"ABERCROMBIE, Neil"	302	86	0	388
+	AB-61	US Representative	1	R	"TATAII, Steve"	101	4	0	105
+	AB-61	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-61	US Representative	1	L	"ZHAO, Li"	2	0	0	2
+	AB-61	State Representative	32	R	"FINNEGAN, Lynn"	197	19	0	216
+	AB-62	Straight Party			DEMOCRATIC PARTY (D)	437	161	0	598
+	AB-62	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
+	AB-62	Straight Party			LIBERTARIAN PARTY (L)	5	2	0	7
+	AB-62	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6
+	AB-62	Straight Party			REPUBLICAN PARTY (R)	62	19	0	81
+	AB-62	US Representative	1	D	"ABERCROMBIE, Neil"	364	130	0	494
+	AB-62	US Representative	1	R	"TATAII, Steve"	51	13	0	64
+	AB-62	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	0	0	2
+	AB-62	US Representative	1	L	"ZHAO, Li"	3	1	0	4
+	AB-62	State Representative	33	D	"OSHIRO, Blake K."	333	119	0	452
+	AB-63	Straight Party			DEMOCRATIC PARTY (D)	927	385	0	1312
+	AB-63	Straight Party			INDEPENDENT PARTY (I)	7	4	0	11
+	AB-63	Straight Party			LIBERTARIAN PARTY (L)	10	1	0	11
+	AB-63	Straight Party			NONPARTISAN BALLOT (N)	10	2	0	12
+	AB-63	Straight Party			REPUBLICAN PARTY (R)	162	53	0	215
+	AB-63	US Representative	1	D	"ABERCROMBIE, Neil"	750	309	0	1059
+	AB-63	US Representative	1	R	"TATAII, Steve"	155	36	0	191
+	AB-63	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	2	0	0	2
+	AB-63	US Representative	1	L	"ZHAO, Li"	8	0	0	8
+	AB-63	State Senate	16	D	"IGE, David Y."	593	265	0	858
+	AB-63	State Representative	33	D	"OSHIRO, Blake K."	655	297	0	952
+	AB-64	Straight Party			DEMOCRATIC PARTY (D)	1681	458	0	2139
+	AB-64	Straight Party			INDEPENDENT PARTY (I)	8	2	0	10
+	AB-64	Straight Party			LIBERTARIAN PARTY (L)	10	1	0	11
+	AB-64	Straight Party			NONPARTISAN BALLOT (N)	15	1	0	16
+	AB-64	Straight Party			REPUBLICAN PARTY (R)	205	44	0	249
+	AB-64	US Representative	1	D	"ABERCROMBIE, Neil"	1354	372	0	1726
+	AB-64	US Representative	1	R	"TATAII, Steve"	182	37	0	219
+	AB-64	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	7	0	0	7
+	AB-64	US Representative	1	L	"ZHAO, Li"	3	1	0	4
+	AB-64	State Senate	16	D	"IGE, David Y."	1236	349	0	1585
+	AB-64	State Representative	34	D	"TAKAI, K. Mark"	1376	374	0	1750
+	AB-65	Straight Party			DEMOCRATIC PARTY (D)	78	10	0	88
+	AB-65	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
+	AB-65	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-65	Straight Party			NONPARTISAN BALLOT (N)	1	1	0	2
+	AB-65	Straight Party			REPUBLICAN PARTY (R)	13	1	0	14
+	AB-65	US Representative	1	D	"ABERCROMBIE, Neil"	63	9	0	72
+	AB-65	US Representative	1	R	"TATAII, Steve"	13	0	0	13
+	AB-65	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-65	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-65	State Senate	18	D	"SONSON, Alex M."	37	5	0	42
+	AB-65	State Senate	18	D	"NISHIHARA, Clarence"	34	4	0	38
+	AB-65	State Representative	34	D	"TAKAI, K. Mark"	63	7	0	70
+	AB-66	Straight Party			DEMOCRATIC PARTY (D)	230	43	0	273
+	AB-66	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2
+	AB-66	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-66	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-66	Straight Party			REPUBLICAN PARTY (R)	16	11	0	27
+	AB-66	US Representative	1	D	"ABERCROMBIE, Neil"	186	37	0	223
+	AB-66	US Representative	1	R	"TATAII, Steve"	9	7	0	16
+	AB-66	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-66	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-66	State Senate	18	D	"SONSON, Alex M."	74	19	0	93
+	AB-66	State Senate	18	D	"NISHIHARA, Clarence"	147	23	0	170
+	AB-66	State Representative	35	D	"AQUINO, Henry James C."	98	21	0	119
+	AB-66	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	77	13	0	90
+	AB-66	State Representative	35	D	"VERDADERO, Dante M."	3	1	0	4
+	AB-66	State Representative	35	D	"DOMINGO, Constante A."	9	2	0	11
+	AB-66	State Representative	35	D	"PARAYNO, Ilalo"	18	1	0	19
+	AB-66	State Representative	35	R	"ANTONIO, Steven Bolosan"	15	7	0	22
+	AB-67	Straight Party			DEMOCRATIC PARTY (D)	1020	141	0	1161
+	AB-67	Straight Party			INDEPENDENT PARTY (I)	3	0	0	3
+	AB-67	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
+	AB-67	Straight Party			NONPARTISAN BALLOT (N)	2	0	0	2
+	AB-67	Straight Party			REPUBLICAN PARTY (R)	56	11	0	67
+	AB-67	US Representative	1	D	"ABERCROMBIE, Neil"	865	123	0	988
+	AB-67	US Representative	1	R	"TATAII, Steve"	37	7	0	44
+	AB-67	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-67	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-67	State Senate	18	D	"SONSON, Alex M."	593	61	0	654
+	AB-67	State Senate	18	D	"NISHIHARA, Clarence"	397	73	0	470
+	AB-67	State Representative	35	D	"AQUINO, Henry James C."	571	79	0	650
+	AB-67	State Representative	35	D	"RAHMAN, I. Perreira Padilla"	233	21	0	254
+	AB-67	State Representative	35	D	"VERDADERO, Dante M."	54	10	0	64
+	AB-67	State Representative	35	D	"DOMINGO, Constante A."	66	8	0	74
+	AB-67	State Representative	35	D	"PARAYNO, Ilalo"	46	12	0	58
+	AB-67	State Representative	35	R	"ANTONIO, Steven Bolosan"	48	10	0	58
+	AB-68	Straight Party			DEMOCRATIC PARTY (D)	952	220	0	1172
+	AB-68	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
+	AB-68	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
+	AB-68	Straight Party			NONPARTISAN BALLOT (N)	18	2	0	20
+	AB-68	Straight Party			REPUBLICAN PARTY (R)	89	17	0	106
+	AB-68	US Representative	1	D	"ABERCROMBIE, Neil"	764	182	0	946
+	AB-68	US Representative	1	R	"TATAII, Steve"	75	14	0	89
+	AB-68	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-68	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-68	State Senate	16	D	"IGE, David Y."	681	164	0	845
+	AB-68	State Representative	36	D	"TAKUMI, Roy M."	702	171	0	873
+	AB-68	State Representative	36	N	"LUM LEE, Christopher-Travis"	15	1	0	16
+	AB-69	Straight Party			DEMOCRATIC PARTY (D)	563	107	0	670
+	AB-69	Straight Party			INDEPENDENT PARTY (I)	4	3	0	7
+	AB-69	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-69	Straight Party			NONPARTISAN BALLOT (N)	4	2	0	6
+	AB-69	Straight Party			REPUBLICAN PARTY (R)	42	10	0	52
+	AB-69	US Representative	1	D	"ABERCROMBIE, Neil"	464	80	0	544
+	AB-69	US Representative	1	R	"TATAII, Steve"	38	6	0	44
+	AB-69	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-69	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-69	State Senate	18	D	"SONSON, Alex M."	146	26	0	172
+	AB-69	State Senate	18	D	"NISHIHARA, Clarence"	371	72	0	443
+	AB-69	State Representative	36	D	"TAKUMI, Roy M."	456	88	0	544
+	AB-69	State Representative	36	N	"LUM LEE, Christopher-Travis"	2	2	0	4
+	AB-70	Straight Party			DEMOCRATIC PARTY (D)	12	5	0	17
+	AB-70	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-70	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-70	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-70	Straight Party			REPUBLICAN PARTY (R)	2	0	0	2
+	AB-70	US Representative	1	D	"ABERCROMBIE, Neil"	11	5	0	16
+	AB-70	US Representative	1	R	"TATAII, Steve"	2	0	0	2
+	AB-70	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-70	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-70	State Senate	18	D	"SONSON, Alex M."	1	1	0	2
+	AB-70	State Senate	18	D	"NISHIHARA, Clarence"	11	3	0	14
+	AB-70	State Representative	36	D	"TAKUMI, Roy M."	12	4	0	16
+	AB-70	State Representative	36	N	"LUM LEE, Christopher-Travis"	0	0	0	0
+	AB-71	Straight Party			DEMOCRATIC PARTY (D)	400	84	0	484
+	AB-71	Straight Party			INDEPENDENT PARTY (I)	3	2	0	5
+	AB-71	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
+	AB-71	Straight Party			NONPARTISAN BALLOT (N)	0	1	0	1
+	AB-71	Straight Party			REPUBLICAN PARTY (R)	56	9	0	65
+	AB-71	US Representative	1	D	"ABERCROMBIE, Neil"	341	77	0	418
+	AB-71	US Representative	1	R	"TATAII, Steve"	50	7	0	57
+	AB-71	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-71	US Representative	1	L	"ZHAO, Li"	2	0	0	2
+	AB-71	State Senate	17	D	"KIDANI, Michelle"	162	42	0	204
+	AB-71	State Senate	17	D	"MENOR, Ron"	151	30	0	181
+	AB-71	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	52	8	0	60
+	AB-71	State Representative	37	D	"YAMANE, Ryan I."	339	75	0	414
+	AB-72	Straight Party			DEMOCRATIC PARTY (D)	1004	201	0	1205
+	AB-72	Straight Party			INDEPENDENT PARTY (I)	1	1	0	2
+	AB-72	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
+	AB-72	Straight Party			NONPARTISAN BALLOT (N)	1	2	0	3
+	AB-72	Straight Party			REPUBLICAN PARTY (R)	116	18	0	134
+	AB-72	US Representative	1	D	"ABERCROMBIE, Neil"	784	165	0	949
+	AB-72	US Representative	1	R	"TATAII, Steve"	107	14	0	121
+	AB-72	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	4	0	0	4
+	AB-72	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-72	State Senate	17	D	"KIDANI, Michelle"	427	82	0	509
+	AB-72	State Senate	17	D	"MENOR, Ron"	431	83	0	514
+	AB-72	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	105	28	0	133
+	AB-72	State Representative	37	D	"YAMANE, Ryan I."	825	171	0	996
+	AB-73	Straight Party			DEMOCRATIC PARTY (D)	447	90	0	537
+	AB-73	Straight Party			INDEPENDENT PARTY (I)	3	1	0	4
+	AB-73	Straight Party			LIBERTARIAN PARTY (L)	6	0	0	6
+	AB-73	Straight Party			NONPARTISAN BALLOT (N)	9	1	0	10
+	AB-73	Straight Party			REPUBLICAN PARTY (R)	74	14	0	88
+	AB-73	US Representative	1	D	"ABERCROMBIE, Neil"	372	70	0	442
+	AB-73	US Representative	1	R	"TATAII, Steve"	51	9	0	60
+	AB-73	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-73	US Representative	1	L	"ZHAO, Li"	5	0	0	5
+	AB-73	State Senate	22	D	"BUNDA, Robert (Bobby)"	283	64	0	347
+	AB-73	State Representative	38	D	"LEE, Marilyn B."	315	70	0	385
+	AB-73	State Representative	38	R	"APANA, Melvin K."	65	13	0	78
+	AB-74	Straight Party			DEMOCRATIC PARTY (D)	513	85	0	598
+	AB-74	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
+	AB-74	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
+	AB-74	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
+	AB-74	Straight Party			REPUBLICAN PARTY (R)	57	11	0	68
+	AB-74	US Representative	1	D	"ABERCROMBIE, Neil"	413	76	0	489
+	AB-74	US Representative	1	R	"TATAII, Steve"	42	7	0	49
+	AB-74	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-74	US Representative	1	L	"ZHAO, Li"	1	1	0	2
+	AB-74	State Senate	17	D	"KIDANI, Michelle"	227	33	0	260
+	AB-74	State Senate	17	D	"MENOR, Ron"	193	36	0	229
+	AB-74	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	58	9	0	67
+	AB-74	State Representative	38	D	"LEE, Marilyn B."	412	67	0	479
+	AB-74	State Representative	38	R	"APANA, Melvin K."	48	8	0	56
+	AB-75	Straight Party			DEMOCRATIC PARTY (D)	829	170	0	999
+	AB-75	Straight Party			INDEPENDENT PARTY (I)	5	1	0	6
+	AB-75	Straight Party			LIBERTARIAN PARTY (L)	4	1	0	5
+	AB-75	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-75	Straight Party			REPUBLICAN PARTY (R)	113	20	0	133
+	AB-75	US Representative	1	D	"ABERCROMBIE, Neil"	666	134	0	800
+	AB-75	US Representative	1	R	"TATAII, Steve"	87	17	0	104
+	AB-75	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	1	0	2
+	AB-75	US Representative	1	L	"ZHAO, Li"	3	0	0	3
+	AB-75	State Senate	17	D	"KIDANI, Michelle"	320	61	0	381
+	AB-75	State Senate	17	D	"MENOR, Ron"	337	68	0	405
+	AB-75	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	131	30	0	161
+	AB-75	State Representative	38	D	"LEE, Marilyn B."	657	140	0	797
+	AB-75	State Representative	38	R	"APANA, Melvin K."	101	16	0	117
+	AB-76	Straight Party			DEMOCRATIC PARTY (D)	859	89	0	948
+	AB-76	Straight Party			INDEPENDENT PARTY (I)	9	0	0	9
+	AB-76	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
+	AB-76	Straight Party			NONPARTISAN BALLOT (N)	15	1	0	16
+	AB-76	Straight Party			REPUBLICAN PARTY (R)	132	14	0	146
+	AB-76	US Representative	2	I	"STENSHOL, Shaun"	7	0	0	7
+	AB-76	US Representative	2	D	"HIRONO, Mazie"	706	71	0	777
+	AB-76	US Representative	2	R	"EVANS, Roger B."	122	12	0	134
+	AB-76	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	1	0	1
+	AB-76	State Senate	22	D	"BUNDA, Robert (Bobby)"	634	71	0	705
+	AB-76	State Representative	39	D	"OSHIRO, Marcus R."	641	74	0	715
+	AB-77	Straight Party			DEMOCRATIC PARTY (D)	48	8	0	56
+	AB-77	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-77	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-77	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-77	Straight Party			REPUBLICAN PARTY (R)	16	2	0	18
+	AB-77	US Representative	1	D	"ABERCROMBIE, Neil"	33	7	0	40
+	AB-77	US Representative	1	R	"TATAII, Steve"	16	1	0	17
+	AB-77	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-77	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-77	State Senate	17	D	"KIDANI, Michelle"	19	6	0	25
+	AB-77	State Senate	17	D	"MENOR, Ron"	22	0	0	22
+	AB-77	State Senate	17	D	"TSUNEYOSHI, Resa R. K."	4	1	0	5
+	AB-77	State Representative	39	D	"OSHIRO, Marcus R."	29	6	0	35
+	AB-78	Straight Party			DEMOCRATIC PARTY (D)	512	243	0	755
+	AB-78	Straight Party			INDEPENDENT PARTY (I)	8	3	0	11
+	AB-78	Straight Party			LIBERTARIAN PARTY (L)	3	1	0	4
+	AB-78	Straight Party			NONPARTISAN BALLOT (N)	10	3	0	13
+	AB-78	Straight Party			REPUBLICAN PARTY (R)	184	57	0	241
+	AB-78	US Representative	2	I	"STENSHOL, Shaun"	6	1	0	7
+	AB-78	US Representative	2	D	"HIRONO, Mazie"	379	200	0	579
+	AB-78	US Representative	2	R	"EVANS, Roger B."	136	44	0	180
+	AB-78	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
+	AB-78	State Representative	40	D	"HAR, Sharon E."	435	212	0	647
+	AB-78	State Representative	40	R	"LEGAL,  Jack M."	166	52	0	218
+	AB-79	Straight Party			DEMOCRATIC PARTY (D)	301	128	0	429
+	AB-79	Straight Party			INDEPENDENT PARTY (I)	4	0	0	4
+	AB-79	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
+	AB-79	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
+	AB-79	Straight Party			REPUBLICAN PARTY (R)	97	40	0	137
+	AB-79	US Representative	2	I	"STENSHOL, Shaun"	3	0	0	3
+	AB-79	US Representative	2	D	"HIRONO, Mazie"	242	99	0	341
+	AB-79	US Representative	2	R	"EVANS, Roger B."	75	28	0	103
+	AB-79	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
+	AB-79	State Representative	40	D	"HAR, Sharon E."	232	109	0	341
+	AB-79	State Representative	40	R	"LEGAL,  Jack M."	84	32	0	116
+	AB-80	Straight Party			DEMOCRATIC PARTY (D)	351	89	0	440
+	AB-80	Straight Party			INDEPENDENT PARTY (I)	4	2	0	6
+	AB-80	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-80	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-80	Straight Party			REPUBLICAN PARTY (R)	75	7	0	82
+	AB-80	US Representative	1	D	"ABERCROMBIE, Neil"	287	80	0	367
+	AB-80	US Representative	1	R	"TATAII, Steve"	48	5	0	53
+	AB-80	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-80	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-80	State Representative	41	D	"CULLEN, Ty Diaz"	83	26	0	109
+	AB-80	State Representative	41	D	"KARAMATSU, Jon Riki"	225	58	0	283
+	AB-80	State Representative	41	R	"SANIATAN, Rito C."	63	6	0	69
+	AB-81	Straight Party			DEMOCRATIC PARTY (D)	174	27	0	201
+	AB-81	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-81	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-81	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-81	Straight Party			REPUBLICAN PARTY (R)	17	0	0	17
+	AB-81	US Representative	1	D	"ABERCROMBIE, Neil"	158	21	0	179
+	AB-81	US Representative	1	R	"TATAII, Steve"	8	0	0	8
+	AB-81	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-81	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-81	State Senate	18	D	"SONSON, Alex M."	57	7	0	64
+	AB-81	State Senate	18	D	"NISHIHARA, Clarence"	113	19	0	132
+	AB-81	State Representative	41	D	"CULLEN, Ty Diaz"	58	10	0	68
+	AB-81	State Representative	41	D	"KARAMATSU, Jon Riki"	113	15	0	128
+	AB-81	State Representative	41	R	"SANIATAN, Rito C."	13	0	0	13
+	AB-82	Straight Party			DEMOCRATIC PARTY (D)	311	79	0	390
+	AB-82	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
+	AB-82	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-82	Straight Party			NONPARTISAN BALLOT (N)	3	0	0	3
+	AB-82	Straight Party			REPUBLICAN PARTY (R)	91	12	0	103
+	AB-82	US Representative	2	I	"STENSHOL, Shaun"	1	0	0	1
+	AB-82	US Representative	2	D	"HIRONO, Mazie"	270	66	0	336
+	AB-82	US Representative	2	R	"EVANS, Roger B."	60	5	0	65
+	AB-82	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-82	State Representative	41	D	"CULLEN, Ty Diaz"	114	27	0	141
+	AB-82	State Representative	41	D	"KARAMATSU, Jon Riki"	167	48	0	215
+	AB-82	State Representative	41	R	"SANIATAN, Rito C."	79	7	0	86
+	AB-83	Straight Party			DEMOCRATIC PARTY (D)	148	13	0	161
+	AB-83	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-83	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-83	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-83	Straight Party			REPUBLICAN PARTY (R)	5	0	0	5
+	AB-83	US Representative	1	D	"ABERCROMBIE, Neil"	120	7	0	127
+	AB-83	US Representative	1	R	"TATAII, Steve"	2	0	0	2
+	AB-83	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-83	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-83	State Senate	18	D	"SONSON, Alex M."	55	4	0	59
+	AB-83	State Senate	18	D	"NISHIHARA, Clarence"	88	8	0	96
+	AB-83	State Representative	42	D	"RODRIGUEZ, Rey R."	11	1	0	12
+	AB-83	State Representative	42	D	"SCHULTZ, Mike P."	52	7	0	59
+	AB-83	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	73	4	0	77
+	AB-83	State Representative	42	R	"BERG, Tom"	4	0	0	4
+	AB-83	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
+	AB-84	Straight Party			DEMOCRATIC PARTY (D)	31	8	0	39
+	AB-84	Straight Party			INDEPENDENT PARTY (I)	0	0	0	0
+	AB-84	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-84	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-84	Straight Party			REPUBLICAN PARTY (R)	1	1	0	2
+	AB-84	US Representative	1	D	"ABERCROMBIE, Neil"	28	6	0	34
+	AB-84	US Representative	1	R	"TATAII, Steve"	1	0	0	1
+	AB-84	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	0	0	0	0
+	AB-84	US Representative	1	L	"ZHAO, Li"	0	0	0	0
+	AB-84	State Representative	42	D	"RODRIGUEZ, Rey R."	4	1	0	5
+	AB-84	State Representative	42	D	"SCHULTZ, Mike P."	12	2	0	14
+	AB-84	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	11	4	0	15
+	AB-84	State Representative	42	R	"BERG, Tom"	1	1	0	2
+	AB-84	State Representative	42	N	"BIMBO, Genaro Q."	0	0	0	0
+	AB-85	Straight Party			DEMOCRATIC PARTY (D)	499	115	0	614
+	AB-85	Straight Party			INDEPENDENT PARTY (I)	2	1	0	3
+	AB-85	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
+	AB-85	Straight Party			NONPARTISAN BALLOT (N)	4	0	0	4
+	AB-85	Straight Party			REPUBLICAN PARTY (R)	86	21	0	107
+	AB-85	US Representative	1	D	"ABERCROMBIE, Neil"	433	98	0	531
+	AB-85	US Representative	1	R	"TATAII, Steve"	47	16	0	63
+	AB-85	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-85	US Representative	1	L	"ZHAO, Li"	1	0	0	1
+	AB-85	State Representative	42	D	"RODRIGUEZ, Rey R."	34	14	0	48
+	AB-85	State Representative	42	D	"SCHULTZ, Mike P."	216	48	0	264
+	AB-85	State Representative	42	D	"CABANILLA ARAKAWA, Rida T. R."	217	48	0	265
+	AB-85	State Representative	42	R	"BERG, Tom"	76	21	0	97
+	AB-85	State Representative	42	N	"BIMBO, Genaro Q."	3	0	0	3
+	AB-86	Straight Party			DEMOCRATIC PARTY (D)	660	165	0	825
+	AB-86	Straight Party			INDEPENDENT PARTY (I)	12	5	0	17
+	AB-86	Straight Party			LIBERTARIAN PARTY (L)	2	1	0	3
+	AB-86	Straight Party			NONPARTISAN BALLOT (N)	8	2	0	10
+	AB-86	Straight Party			REPUBLICAN PARTY (R)	385	84	0	469
+	AB-86	US Representative	1	D	"ABERCROMBIE, Neil"	606	145	0	751
+	AB-86	US Representative	1	R	"TATAII, Steve"	154	47	0	201
+	AB-86	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	AB-86	US Representative	1	L	"ZHAO, Li"	1	1	0	2
+	AB-86	State Representative	43	D	"FEVELLA, Kurt"	317	108	0	425
+	AB-86	State Representative	43	R	"PINE, Kymberly (Marcos)"	368	79	0	447
+	AB-87	Straight Party			DEMOCRATIC PARTY (D)	36	11	0	47
+	AB-87	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
+	AB-87	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-87	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	AB-87	Straight Party			REPUBLICAN PARTY (R)	13	4	0	17
+	AB-87	US Representative	2	I	"STENSHOL, Shaun"	1	0	0	1
+	AB-87	US Representative	2	D	"HIRONO, Mazie"	35	9	0	44
+	AB-87	US Representative	2	R	"EVANS, Roger B."	11	4	0	15
+	AB-87	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-87	State Representative	44	D	"AWANA, Karen Leinani"	18	8	0	26
+	AB-87	State Representative	44	D	"AIPOALANI, Hanalei Y."	9	2	0	11
+	AB-87	State Representative	44	R	"KU, Tercia L."	9	3	0	12
+	AB-88	Straight Party			DEMOCRATIC PARTY (D)	480	164	0	644
+	AB-88	Straight Party			INDEPENDENT PARTY (I)	5	2	0	7
+	AB-88	Straight Party			LIBERTARIAN PARTY (L)	3	0	0	3
+	AB-88	Straight Party			NONPARTISAN BALLOT (N)	3	1	0	4
+	AB-88	Straight Party			REPUBLICAN PARTY (R)	92	28	0	120
+	AB-88	US Representative	2	I	"STENSHOL, Shaun"	5	2	0	7
+	AB-88	US Representative	2	D	"HIRONO, Mazie"	373	131	0	504
+	AB-88	US Representative	2	R	"EVANS, Roger B."	65	24	0	89
+	AB-88	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
+	AB-88	State Senate	21	D	"HANABUSA, Colleen"	379	131	0	510
+	AB-88	State Senate	21	R	"JOHNSON, Dickyj"	65	19	0	84
+	AB-88	State Representative	44	D	"AWANA, Karen Leinani"	243	75	0	318
+	AB-88	State Representative	44	D	"AIPOALANI, Hanalei Y."	198	78	0	276
+	AB-88	State Representative	44	R	"KU, Tercia L."	71	20	0	91
+	AB-89	Straight Party			DEMOCRATIC PARTY (D)	562	135	0	697
+	AB-89	Straight Party			INDEPENDENT PARTY (I)	9	1	0	10
+	AB-89	Straight Party			LIBERTARIAN PARTY (L)	1	2	0	3
+	AB-89	Straight Party			NONPARTISAN BALLOT (N)	2	1	0	3
+	AB-89	Straight Party			REPUBLICAN PARTY (R)	95	21	0	116
+	AB-89	US Representative	2	I	"STENSHOL, Shaun"	5	1	0	6
+	AB-89	US Representative	2	D	"HIRONO, Mazie"	441	109	0	550
+	AB-89	US Representative	2	R	"EVANS, Roger B."	65	14	0	79
+	AB-89	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	2	0	3
+	AB-89	State Senate	21	D	"HANABUSA, Colleen"	451	113	0	564
+	AB-89	State Senate	21	R	"JOHNSON, Dickyj"	66	14	0	80
+	AB-89	State Representative	45	D	"SHIMABUKURO, Maile S. L."	432	99	0	531
+	AB-89	State Representative	45	D	"SAYLORS, Denise"	94	30	0	124
+	AB-89	State Representative	45	R	"GAPOL, Derek A."	73	13	0	86
+	AB-90	Straight Party			DEMOCRATIC PARTY (D)	58	21	0	79
+	AB-90	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
+	AB-90	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-90	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-90	Straight Party			REPUBLICAN PARTY (R)	36	15	0	51
+	AB-90	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
+	AB-90	US Representative	2	D	"HIRONO, Mazie"	51	12	0	63
+	AB-90	US Representative	2	R	"EVANS, Roger B."	25	11	0	36
+	AB-90	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-90	State Senate	23	D	"HEE, Clayton"	39	14	0	53
+	AB-90	State Senate	23	D	"MURAKI, Noel S."	16	5	0	21
+	AB-90	State Senate	23	R	"FALE, Richard"	26	13	0	39
+	AB-90	State Representative	46	D	"LUNASCO, Ollie"	5	6	0	11
+	AB-90	State Representative	46	D	"MAGAOAY, Michael Y."	35	11	0	46
+	AB-90	State Representative	46	D	"WASSON, Dawn K."	12	4	0	16
+	AB-90	State Representative	46	R	"PHILIPS, Carol"	20	9	0	29
+	AB-90	State Representative	46	R	"RIVIERE, Gil"	16	4	0	20
+	AB-91	Straight Party			DEMOCRATIC PARTY (D)	479	51	0	530
+	AB-91	Straight Party			INDEPENDENT PARTY (I)	5	1	0	6
+	AB-91	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
+	AB-91	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-91	Straight Party			REPUBLICAN PARTY (R)	193	16	0	209
+	AB-91	US Representative	2	I	"STENSHOL, Shaun"	5	1	0	6
+	AB-91	US Representative	2	D	"HIRONO, Mazie"	383	40	0	423
+	AB-91	US Representative	2	R	"EVANS, Roger B."	93	9	0	102
+	AB-91	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4
+	AB-91	State Senate	22	D	"BUNDA, Robert (Bobby)"	380	36	0	416
+	AB-91	State Representative	46	D	"LUNASCO, Ollie"	90	11	0	101
+	AB-91	State Representative	46	D	"MAGAOAY, Michael Y."	309	33	0	342
+	AB-91	State Representative	46	D	"WASSON, Dawn K."	55	4	0	59
+	AB-91	State Representative	46	R	"PHILIPS, Carol"	95	3	0	98
+	AB-91	State Representative	46	R	"RIVIERE, Gil"	92	13	0	105
+	AB-92	Straight Party			DEMOCRATIC PARTY (D)	891	497	0	1388
+	AB-92	Straight Party			INDEPENDENT PARTY (I)	12	2	0	14
+	AB-92	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
+	AB-92	Straight Party			NONPARTISAN BALLOT (N)	3	2	0	5
+	AB-92	Straight Party			REPUBLICAN PARTY (R)	260	140	0	400
+	AB-92	US Representative	2	I	"STENSHOL, Shaun"	10	2	0	12
+	AB-92	US Representative	2	D	"HIRONO, Mazie"	714	404	0	1118
+	AB-92	US Representative	2	R	"EVANS, Roger B."	128	64	0	192
+	AB-92	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	3	0	0	3
+	AB-92	State Senate	23	D	"HEE, Clayton"	562	314	0	876
+	AB-92	State Senate	23	D	"MURAKI, Noel S."	256	148	0	404
+	AB-92	State Senate	23	R	"FALE, Richard"	126	62	0	188
+	AB-92	State Representative	47	D	"PACHECO, Maria"	162	97	0	259
+	AB-92	State Representative	47	D	"WOOLEY, Jessica"	601	352	0	953
+	AB-92	State Representative	47	R	"MEYER, Colleen"	236	132	0	368
+	AB-93	Straight Party			DEMOCRATIC PARTY (D)	51	55	0	106
+	AB-93	Straight Party			INDEPENDENT PARTY (I)	0	1	0	1
+	AB-93	Straight Party			LIBERTARIAN PARTY (L)	0	0	0	0
+	AB-93	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	AB-93	Straight Party			REPUBLICAN PARTY (R)	21	10	0	31
+	AB-93	US Representative	2	I	"STENSHOL, Shaun"	0	1	0	1
+	AB-93	US Representative	2	D	"HIRONO, Mazie"	45	49	0	94
+	AB-93	US Representative	2	R	"EVANS, Roger B."	15	2	0	17
+	AB-93	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	0	0	0	0
+	AB-93	State Senate	23	D	"HEE, Clayton"	36	24	0	60
+	AB-93	State Senate	23	D	"MURAKI, Noel S."	10	23	0	33
+	AB-93	State Senate	23	R	"FALE, Richard"	16	2	0	18
+	AB-93	State Representative	47	D	"PACHECO, Maria"	4	11	0	15
+	AB-93	State Representative	47	D	"WOOLEY, Jessica"	37	35	0	72
+	AB-93	State Representative	47	R	"MEYER, Colleen"	21	8	0	29
+	AB-94	Straight Party			DEMOCRATIC PARTY (D)	345	218	0	563
+	AB-94	Straight Party			INDEPENDENT PARTY (I)	4	1	0	5
+	AB-94	Straight Party			LIBERTARIAN PARTY (L)	1	0	0	1
+	AB-94	Straight Party			NONPARTISAN BALLOT (N)	4	3	0	7
+	AB-94	Straight Party			REPUBLICAN PARTY (R)	50	35	0	85
+	AB-94	US Representative	2	I	"STENSHOL, Shaun"	4	1	0	5
+	AB-94	US Representative	2	D	"HIRONO, Mazie"	292	185	0	477
+	AB-94	US Representative	2	R	"EVANS, Roger B."	44	30	0	74
+	AB-94	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	0	0	1
+	AB-94	State Senate	23	D	"HEE, Clayton"	200	125	0	325
+	AB-94	State Senate	23	D	"MURAKI, Noel S."	107	59	0	166
+	AB-94	State Senate	23	R	"FALE, Richard"	41	23	0	64
+	AB-94	State Representative	48	D	"ITO, Ken"	296	190	0	486
+	AB-95	Straight Party			DEMOCRATIC PARTY (D)	1164	573	0	1737
+	AB-95	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13
+	AB-95	Straight Party			LIBERTARIAN PARTY (L)	5	2	0	7
+	AB-95	Straight Party			NONPARTISAN BALLOT (N)	12	3	0	15
+	AB-95	Straight Party			REPUBLICAN PARTY (R)	170	65	0	235
+	AB-95	US Representative	2	I	"STENSHOL, Shaun"	8	1	0	9
+	AB-95	US Representative	2	D	"HIRONO, Mazie"	990	486	0	1476
+	AB-95	US Representative	2	R	"EVANS, Roger B."	160	60	0	220
+	AB-95	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	5	2	0	7
+	AB-95	State Representative	48	D	"ITO, Ken"	928	451	0	1379
+	AB-96	Straight Party			DEMOCRATIC PARTY (D)	909	318	0	1227
+	AB-96	Straight Party			INDEPENDENT PARTY (I)	11	5	0	16
+	AB-96	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
+	AB-96	Straight Party			NONPARTISAN BALLOT (N)	14	6	0	20
+	AB-96	Straight Party			REPUBLICAN PARTY (R)	226	65	0	291
+	AB-96	US Representative	2	I	"STENSHOL, Shaun"	11	4	0	15
+	AB-96	US Representative	2	D	"HIRONO, Mazie"	758	258	0	1016
+	AB-96	US Representative	2	R	"EVANS, Roger B."	214	60	0	274
+	AB-96	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4
+	AB-96	State Representative	49	D	"CHONG, Pono"	653	226	0	879
+	AB-97	Straight Party			DEMOCRATIC PARTY (D)	286	180	0	466
+	AB-97	Straight Party			INDEPENDENT PARTY (I)	3	2	0	5
+	AB-97	Straight Party			LIBERTARIAN PARTY (L)	1	1	0	2
+	AB-97	Straight Party			NONPARTISAN BALLOT (N)	5	4	0	9
+	AB-97	Straight Party			REPUBLICAN PARTY (R)	73	56	0	129
+	AB-97	US Representative	2	I	"STENSHOL, Shaun"	3	2	0	5
+	AB-97	US Representative	2	D	"HIRONO, Mazie"	237	144	0	381
+	AB-97	US Representative	2	R	"EVANS, Roger B."	63	45	0	108
+	AB-97	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	1	1	0	2
+	AB-97	State Senate	23	D	"HEE, Clayton"	160	96	0	256
+	AB-97	State Senate	23	D	"MURAKI, Noel S."	81	62	0	143
+	AB-97	State Senate	23	R	"FALE, Richard"	61	42	0	103
+	AB-97	State Representative	49	D	"CHONG, Pono"	233	140	0	373
+	AB-98	Straight Party			DEMOCRATIC PARTY (D)	628	292	0	920
+	AB-98	Straight Party			INDEPENDENT PARTY (I)	17	5	0	22
+	AB-98	Straight Party			LIBERTARIAN PARTY (L)	8	2	0	10
+	AB-98	Straight Party			NONPARTISAN BALLOT (N)	11	1	0	12
+	AB-98	Straight Party			REPUBLICAN PARTY (R)	554	138	0	692
+	AB-98	US Representative	2	I	"STENSHOL, Shaun"	13	2	0	15
+	AB-98	US Representative	2	D	"HIRONO, Mazie"	583	263	0	846
+	AB-98	US Representative	2	R	"EVANS, Roger B."	218	58	0	276
+	AB-98	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	8	2	0	10
+	AB-98	State Representative	50	R	"THIELEN, Cynthia"	511	122	0	633
+	AB-99	Straight Party			DEMOCRATIC PARTY (D)	985	338	0	1323
+	AB-99	Straight Party			INDEPENDENT PARTY (I)	10	3	0	13
+	AB-99	Straight Party			LIBERTARIAN PARTY (L)	2	0	0	2
+	AB-99	Straight Party			NONPARTISAN BALLOT (N)	4	1	0	5
+	AB-99	Straight Party			REPUBLICAN PARTY (R)	237	71	0	308
+	AB-99	US Representative	2	I	"STENSHOL, Shaun"	7	2	0	9
+	AB-99	US Representative	2	D	"HIRONO, Mazie"	753	265	0	1018
+	AB-99	US Representative	2	R	"EVANS, Roger B."	118	32	0	150
+	AB-99	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	2	0	0	2
+	AB-99	State Representative	51	D	"ANDERSON, J. Ikaika"	326	135	0	461
+	AB-99	State Representative	51	D	"CHRISTENSEN, Shawn Aukai"	27	6	0	33
+	AB-99	State Representative	51	D	"LEE, Chris Kalani"	563	170	0	733
+	AB-99	State Representative	51	R	"KAWANANAKOA, Quentin Kuhio"	229	57	0	286
+	Overseas 100	Straight Party			DEMOCRATIC PARTY (D)	97	0	0	97
+	Overseas 100	Straight Party			INDEPENDENT PARTY (I)	1	0	0	1
+	Overseas 100	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
+	Overseas 100	Straight Party			NONPARTISAN BALLOT (N)	1	0	0	1
+	Overseas 100	Straight Party			REPUBLICAN PARTY (R)	19	0	0	19
+	Overseas 100	US Representative	1	D	"ABERCROMBIE, Neil"	96	0	0	96
+	Overseas 100	US Representative	1	R	"TATAII, Steve"	19	0	0	19
+	Overseas 100	US Representative	1	L	"AMSTERDAM, C. Kaui Jochanan"	1	0	0	1
+	Overseas 100	US Representative	1	L	"ZHAO, Li"	3	0	0	3
+	Overseas 101	Straight Party			DEMOCRATIC PARTY (D)	80	0	0	80
+	Overseas 101	Straight Party			INDEPENDENT PARTY (I)	2	0	0	2
+	Overseas 101	Straight Party			LIBERTARIAN PARTY (L)	4	0	0	4
+	Overseas 101	Straight Party			NONPARTISAN BALLOT (N)	0	0	0	0
+	Overseas 101	Straight Party			REPUBLICAN PARTY (R)	18	0	0	18
+	Overseas 101	US Representative	2	I	"STENSHOL, Shaun"	2	0	0	2
+	Overseas 101	US Representative	2	D	"HIRONO, Mazie"	80	0	0	80
+	Overseas 101	US Representative	2	R	"EVANS, Roger B."	18	0	0	18
+	Overseas 101	US Representative	2	L	"MALLAN, Lloyd J. (Jeff)"	4	0	0	4


### PR DESCRIPTION
[2008/20080920__hi__primary__precinct.csv](https://github.com/openelections/openelections-data-hi/blob/194e8c05a8e87b8ac80e5ddd6c7435c78736ce51/2008/20080920__hi__primary__precinct.csv) used tabs instead of commas as the column delimiters.  This replaces the tabs with commas and also fixes the line ending characters.